### PR TITLE
clean up argument handling in publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,10 @@ Our support policy for Nodejs versions follows [Nodejs release support]( https:/
 We will support and build node-nats on even-numbered Nodejs versions that are current or in LTS.
 
 
+## Running The Tests
+
+To run the tests, you need to have a `nats-server` execubtable in your path. Refer to the [server installation guide](https://nats-io.github.io/docs/nats_server/installation.html#installing-via-a-package-manager) in the NATS.io documentation. With that in place, you can run `npm test` to run all tests.
+
 ## License
 
 Unless otherwise noted, the NATS source files are distributed under the Apache Version 2.0 license found in the LICENSE file.

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ export const BAD_AUTHENTICATION: string;
 export const BAD_JSON: string;
 export const BAD_MSG: string;
 export const BAD_REPLY: string;
+export const BAD_CALLBACK: string;
 export const BAD_SUBJECT: string;
 export const CLIENT_CERT_REQ: string;
 export const CONN_CLOSED: string;

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -88,6 +88,8 @@ const VERSION = '1.3.0',
     BAD_MSG_MSG = 'Message can\'t be a function',
     BAD_REPLY = 'BAD_REPLY',
     BAD_REPLY_MSG = 'Reply can\'t be a function',
+    BAD_CALLBACK = 'BAD_CALLBACK',
+    BAD_CALLBACK_MSG = 'Callback needs to be a function',
     BAD_SUBJECT = 'BAD_SUBJECT',
     BAD_SUBJECT_MSG = 'Subject must be supplied',
     CLIENT_CERT_REQ = 'CLIENT_CERT_REQ',
@@ -1512,10 +1514,19 @@ Client.prototype.handledClosedOrDraining = function(opt_callback) {
  * @api public
  */
 Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
-    // They only supplied a callback function.
-    if (typeof subject === 'function') {
+    // normalize arguments
+    if (arguments.length === 3 && typeof opt_reply === 'function') {
+        opt_callback = opt_reply;
+        opt_reply = undefined;
+    } else if (arguments.length === 2 && typeof msg === 'function') {
+        opt_callback = msg;
+        msg = undefined;
+        opt_reply = undefined;
+    } else if (arguments.length === 1 && typeof subject === 'function') {
         opt_callback = subject;
         subject = undefined;
+        msg = undefined;
+        opt_reply = undefined;
     }
 
     if (this.noMorePublishing) {
@@ -1534,29 +1545,33 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
         msg = msg === undefined ? null : msg;
     }
 
+    if (opt_callback && typeof opt_callback !== 'function') {
+        throw (new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK));
+    }
+
     if (!subject) {
         if (opt_callback) {
             opt_callback(new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT));
+            return;
         } else {
             throw (new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT));
         }
     }
     if (typeof msg === 'function') {
-        if (opt_callback || opt_reply) {
+        if (opt_callback) {
             opt_callback(new NatsError(BAD_MSG_MSG, BAD_MSG));
             return;
+        } else {
+            throw(new NatsError(BAD_MSG_MSG, BAD_MSG));
         }
-        opt_callback = msg;
-        msg = EMPTY;
-        opt_reply = undefined;
     }
     if (typeof opt_reply === 'function') {
         if (opt_callback) {
             opt_callback(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
             return;
+        } else {
+            throw(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
         }
-        opt_callback = opt_reply;
-        opt_reply = undefined;
     }
 
     // Hold PUB SUB [REPLY]


### PR DESCRIPTION
This removes a few minor bugs from how the arguments in `publish` are handled:

1. `opt_callback` was called twice when `publish` was called without a subject but with a message and a reply (that is, `nc.publish(null, 'message', 'opt_reply', function(err) { ... })`) -- once with the `BAD_SUBJECT` error, once without (there was a missing return after the first call to the callback).
2. `opt_callback` was ignored and a type error was thrown synchronously when `publish` was called without a subject and without a reply (that is, `nc.publish(null, 'message', function(err) { ... })`)
3. A type error was thrown synchronously when passing four arguments but the fourth argument was not a function (because the code implicitly assumed that it is a valid callback).

In addition, I also cleaned up the tests around error handling a bit. Some of them were passing only accidentally (expecting a NatsError but only testing if any error is thrown, thereby masking the aforementioned TypeErrors). Also, two tests were testing multiple things at once -- I have split those tests so that each individual test takes care of one particular case.

I have run `npm test` successfully after my changes, all tests are passing.