### PR TITLE
FIX #292

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -260,7 +260,7 @@ module.exports = {
         "prefer-numeric-literals": "error",
         "prefer-promise-reject-errors": "error",
         "prefer-reflect": "off",
-        "prefer-rest-params": "error",
+        "prefer-rest-params": "off",
         "prefer-spread": "error",
         "prefer-template": "off",
         "quote-props": "off",

--- a/index.d.ts
+++ b/index.d.ts
@@ -23,8 +23,10 @@ export const version: string;
  * Error codes
  */
 export const BAD_AUTHENTICATION: string;
+export const BAD_CALLBACK: string;
 export const BAD_JSON: string;
 export const BAD_MSG: string;
+export const BAD_OPTIONS: string;
 export const BAD_REPLY: string;
 export const BAD_SUBJECT: string;
 export const CLIENT_CERT_REQ: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,6 @@ export interface ClientOpts {
 	token?: string,
 	pingInterval?: number,
 	maxPingOut?: number,
-	useOldRequestStyle?: boolean,
 	noEcho?: boolean
 }
 
@@ -163,7 +162,7 @@ declare class Client extends events.EventEmitter {
 	 * This should be treated as a subscription. You can optionally indicate how many
 	 * messages you only want to receive using opt_options = {max:N}. Otherwise you
 	 * will need to unsubscribe to stop the message stream.
-	 * The Subscriber Id is returned.
+	 * The Subscriber Id is returned or 0 if the request failed.
 	 */
 	request(subject: string, callback: Function): number;
 	request(subject: string, msg: any, callback: Function): number;
@@ -175,7 +174,7 @@ declare class Client extends events.EventEmitter {
 	 * after the first response is received or the timeout is reached.
 	 * The callback can be called with either a message payload or a NatsError to indicate
 	 * a timeout has been reached.
-	 * The Subscriber Id is returned.
+	 * The Subscriber Id is returned or 0 if the request failed.
 	 */
 	requestOne(subject: string, timeout: number, callback: Function): number;
 	requestOne(subject: string, msg: any, timeout: number, callback: Function): number;

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -173,6 +173,9 @@ exports.CLIENT_CERT_REQ = CLIENT_CERT_REQ;
 exports.NATS_PROTOCOL_ERR = NATS_PROTOCOL_ERR;
 exports.REQ_TIMEOUT = REQ_TIMEOUT;
 exports.SUB_DRAINING = SUB_DRAINING;
+exports.BAD_CALLBACK = BAD_CALLBACK;
+exports.PERMISSIONS_ERR = PERMISSIONS_ERR;
+exports.STALE_CONNECTION_ERR = STALE_CONNECTION_ERR;
 
 
 /**
@@ -213,8 +216,7 @@ exports.connect = function(url, opts) {
     // options object.
     if (opts !== undefined) {
         if ('object' !== typeof opts) {
-            this.emit('error', new NatsError(BAD_OPTIONS_MSG, BAD_OPTIONS));
-            return;
+            throw new NatsError(BAD_OPTIONS_MSG, BAD_OPTIONS);
         }
         opts.url = sanitizeUrl(url);
     } else {
@@ -1553,20 +1555,13 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
     }
 
     if (typeof msg === 'function') {
-        if (opt_callback) {
-            opt_callback(new NatsError(BAD_MSG_MSG, BAD_MSG));
-            return;
-        } else {
-            throw(new NatsError(BAD_MSG_MSG, BAD_MSG));
-        }
+        this.cbOrEmit(new NatsError(BAD_MSG_MSG, BAD_MSG), opt_callback);
+        return;
     }
+
     if (typeof opt_reply === 'function') {
-        if (opt_callback) {
-            opt_callback(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
-            return;
-        } else {
-            throw(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
-        }
+        this.cbOrEmit(new NatsError(BAD_REPLY_MSG, BAD_REPLY), opt_callback);
+        return;
     }
 
     if (!this.options.json) {

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -32,7 +32,7 @@ const net = require('net'),
 /**
  * Constants
  */
-const VERSION = '1.3.0',
+const VERSION = '2.0.0',
 
     DEFAULT_PORT = 4222,
     DEFAULT_PRE = 'nats://localhost:',
@@ -88,6 +88,8 @@ const VERSION = '1.3.0',
     BAD_MSG_MSG = 'Message can\'t be a function',
     BAD_REPLY = 'BAD_REPLY',
     BAD_REPLY_MSG = 'Reply can\'t be a function',
+    BAD_CALLBACK = 'BAD_CALLBACK',
+    BAD_CALLBACK_MSG = 'Callback needs to be a function',
     BAD_SUBJECT = 'BAD_SUBJECT',
     BAD_SUBJECT_MSG = 'Subject must be supplied',
     CLIENT_CERT_REQ = 'CLIENT_CERT_REQ',
@@ -270,7 +272,6 @@ Client.prototype.parseOptions = function(opts) {
         waitOnFirstConnect: false,
         pingInterval: DEFAULT_PING_INTERVAL,
         maxPingOut: DEFAULT_MAX_PING_OUT,
-        useOldRequestStyle: false,
         noEcho: false
     };
 
@@ -314,7 +315,6 @@ Client.prototype.parseOptions = function(opts) {
         this.assignOption(opts, 'preserveBuffers');
         this.assignOption(opts, 'pingInterval');
         this.assignOption(opts, 'maxPingOut');
-        this.assignOption(opts, 'useOldRequestStyle');
         this.assignOption(opts, 'sigCB', 'sig');
         this.assignOption(opts, 'sigcb', 'sig');
         this.assignOption(opts, 'sigCallback', 'sig');
@@ -681,7 +681,7 @@ Client.prototype.setupHandlers = function() {
         this.scheduleHeartbeat();
     });
 
-    stream.on('close', (hadError) => {
+    stream.on('close', () => {
         this.closeStream();
         if(stream.bytesRead > 0) {
             this.emit('disconnect');
@@ -1441,6 +1441,10 @@ Client.prototype.flush = function(opt_callback) {
  * @param opt_callback
  */
 Client.prototype.drain = function(opt_callback) {
+    if (opt_callback && typeof opt_callback !== 'function') {
+        this.cbOrEmit(new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK));
+        return;
+    }
     if(this.handledClosedOrDraining(opt_callback)) {
         return;
     }
@@ -1462,7 +1466,7 @@ Client.prototype.drain = function(opt_callback) {
                 this.noMorePublishing = true;
                 this.flush(() => {
                     this.close();
-                    if (typeof opt_callback === 'function') {
+                    if (opt_callback) {
                         opt_callback();
                     }
                 });
@@ -1474,7 +1478,7 @@ Client.prototype.drain = function(opt_callback) {
     if(subs.length === 0) {
         this.noMorePublishing = true;
         this.close();
-        if (typeof opt_callback === 'function') {
+        if (opt_callback) {
             opt_callback();
         }
     }
@@ -1489,20 +1493,30 @@ Client.prototype.drain = function(opt_callback) {
  */
 Client.prototype.handledClosedOrDraining = function(opt_callback) {
     if (this.closed) {
-        if (typeof opt_callback === 'function') {
-            opt_callback(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
-        } else {
-            throw (new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
-        }
+        this.cbOrEmit(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED), opt_callback);
         return true;
     }
     if (this.draining) {
-        if (typeof opt_callback === 'function') {
-            opt_callback(new NatsError(CONN_DRAINING_MSG, CONN_DRAINING));
-        } else {
-            throw (new NatsError(CONN_DRAINING_MSG, CONN_DRAINING));
-        }
+        this.cbOrEmit(new NatsError(CONN_DRAINING_MSG, CONN_DRAINING), opt_callback);
         return true;
+    }
+    return false;
+};
+
+/**
+ * Invokes the provided callback if a function, or emits error.
+ * In the case where the client is closed, and no callback is provided,
+ * it throws an error, as any error event handler has been cleared.
+ * @param err
+ * @param opt_callback
+ */
+Client.prototype.cbOrEmit = function(err, opt_callback) {
+    if(opt_callback && typeof opt_callback === 'function') {
+        opt_callback(err);
+    } else if(!this.closed) {
+        this.emit('error', err);
+    } else {
+        throw(err);
     }
 };
 
@@ -1516,19 +1530,43 @@ Client.prototype.handledClosedOrDraining = function(opt_callback) {
  * @api public
  */
 Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
-    // They only supplied a callback function.
-    if (typeof subject === 'function') {
-        opt_callback = subject;
-        subject = undefined;
+    // normalize arguments
+    const args = callbackShifter(4, Array.prototype.slice.call(arguments));
+    subject = args[0];
+    msg = args[1];
+    opt_reply = args[2];
+    opt_callback = args[3];
+
+    if (opt_callback && typeof opt_callback !== 'function') {
+        this.cbOrEmit(new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK), opt_callback);
+        return;
     }
 
     if (this.noMorePublishing) {
-        if (typeof opt_callback === 'function') {
-            opt_callback(new NatsError(CONN_DRAINING_MSG, CONN_DRAINING));
-        } else {
-            this.emit('error', new NatsError(CONN_DRAINING_MSG, CONN_DRAINING));
-        }
+        this.cbOrEmit(new NatsError(CONN_DRAINING_MSG, CONN_DRAINING), opt_callback);
         return;
+    }
+
+    if(this.closed) {
+        this.cbOrEmit(new NatsError(CONN_CLOSED_MSG, CONN_CLOSED), opt_callback);
+        return;
+    }
+
+    if (typeof msg === 'function') {
+        if (opt_callback) {
+            opt_callback(new NatsError(BAD_MSG_MSG, BAD_MSG));
+            return;
+        } else {
+            throw(new NatsError(BAD_MSG_MSG, BAD_MSG));
+        }
+    }
+    if (typeof opt_reply === 'function') {
+        if (opt_callback) {
+            opt_callback(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
+            return;
+        } else {
+            throw(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
+        }
     }
 
     if (!this.options.json) {
@@ -1539,28 +1577,8 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
     }
 
     if (!subject) {
-        if (opt_callback) {
-            opt_callback(new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT));
-        } else {
-            throw (new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT));
-        }
-    }
-    if (typeof msg === 'function') {
-        if (opt_callback || opt_reply) {
-            opt_callback(new NatsError(BAD_MSG_MSG, BAD_MSG));
-            return;
-        }
-        opt_callback = msg;
-        msg = EMPTY;
-        opt_reply = undefined;
-    }
-    if (typeof opt_reply === 'function') {
-        if (opt_callback) {
-            opt_callback(new NatsError(BAD_REPLY_MSG, BAD_REPLY));
-            return;
-        }
-        opt_callback = opt_reply;
-        opt_reply = undefined;
+        this.cbOrEmit(new NatsError(BAD_SUBJECT_MSG, BAD_SUBJECT), opt_callback);
+        return;
     }
 
     // Hold PUB SUB [REPLY]
@@ -1578,7 +1596,8 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
             try {
                 str = JSON.stringify(msg);
             } catch (e) {
-                throw (new NatsError(BAD_JSON_MSG, BAD_JSON));
+                this.cbOrEmit(new NatsError(BAD_JSON_MSG, BAD_JSON), opt_callback);
+                return;
             }
         }
         this.sendCommand(psub + Buffer.byteLength(str) + CR_LF + str + CR_LF);
@@ -1590,32 +1609,37 @@ Client.prototype.publish = function(subject, msg, opt_reply, opt_callback) {
         this.sendCommand(b);
     }
 
-    if (opt_callback !== undefined) {
+    if (opt_callback) {
         this.flush(opt_callback);
-    } else if (this.closed) {
-        throw (new NatsError(CONN_CLOSED_MSG, CONN_CLOSED));
     }
 };
 
 /**
  * Subscribe to a given subject, with optional options and callback. opts can be
- * ommitted, even with a callback. The Subscriber Id is returned.
+ * omitted, even with a callback. The Subscriber Id is returned.
  *
  * @param {String} subject
  * @param {Object} [opts]
- * @param {Function} callback - callback arguments are data, reply subject (may be undefined), and subscription id
+ * @param {Function} callback
  * @return {Number}
  * @api public
  */
 Client.prototype.subscribe = function(subject, opts, callback) {
+    // normalize arguments
+    const args = callbackShifter(3, Array.prototype.slice.call(arguments));
+    subject = args[0];
+    opts = args[1];
+    callback = args[2];
     let qgroup, max;
-    if (typeof opts === 'function') {
-        callback = opts;
-        opts = undefined;
-    } else if (opts && typeof opts === 'object') {
-        // FIXME, check exists, error otherwise..
+
+    if (opts && typeof opts === 'object') {
         qgroup = opts.queue;
         max = opts.max;
+    }
+
+    if (!callback || (callback && typeof callback !== 'function')) {
+        this.cbOrEmit(new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK), callback);
+        return 0;
     }
 
     if(this.handledClosedOrDraining(callback)) {
@@ -1701,23 +1725,28 @@ Client.prototype.unsubscribe = function(sid, opt_max) {
  * @param opt_callback
  */
 Client.prototype.drainSubscription = function(sid, opt_callback) {
+    const args = callbackShifter(2, Array.prototype.slice.call(arguments));
+    sid = args[0];
+    opt_callback = args[1];
+
+    if(opt_callback && typeof opt_callback !== 'function') {
+        this.cbOrEmit(new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK));
+        return;
+    }
+
     if(this.handledClosedOrDraining(opt_callback)) {
         return;
     }
 
     const sub = this.subs[sid];
     if (sub === undefined) {
-        if (typeof opt_callback === 'function') {
+        if (opt_callback) {
             opt_callback();
         }
         return;
     }
     if(sub.draining) {
-        if (typeof opt_callback === 'function') {
-            opt_callback(new NatsError(SUB_DRAINING_MSG, SUB_DRAINING));
-        } else {
-            throw (new NatsError(SUB_DRAINING_MSG, SUB_DRAINING));
-        }
+        this.cbOrEmit(new NatsError(SUB_DRAINING_MSG, SUB_DRAINING), opt_callback);
         return;
     }
     sub.draining = true;
@@ -1730,7 +1759,7 @@ Client.prototype.drainSubscription = function(sid, opt_callback) {
         }
         delete this.subs[sid];
         this.emit('unsubscribe', sid, sub.subject);
-        if (typeof opt_callback === 'function') {
+        if (opt_callback) {
             opt_callback();
         }
     });
@@ -1750,6 +1779,16 @@ Client.prototype.drainSubscription = function(sid, opt_callback) {
  * @api public
  */
 Client.prototype.timeout = function(sid, timeout, expected, callback) {
+    const args = callbackShifter(4, Array.prototype.slice.call(arguments));
+    sid = args[0];
+    timeout = args[1];
+    expected = args[2];
+    callback = args[3];
+
+    if (!callback || typeof callback !== 'function') {
+        this.cbOrEmit(new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK));
+        return;
+    }
     if (!sid) {
         return;
     }
@@ -1776,7 +1815,6 @@ Client.prototype.timeout = function(sid, timeout, expected, callback) {
     }
 };
 
-
 /**
  * Publish a message with an implicit inbox listener as the reply. Message is optional.
  * This should be treated as a subscription. You can optionally indicate how many
@@ -1799,17 +1837,15 @@ Client.prototype.timeout = function(sid, timeout, expected, callback) {
  * @api public
  */
 Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
-    if (this.options.useOldRequestStyle) {
-        return this.oldRequest(subject, opt_msg, opt_options, callback);
-    }
-    if (typeof opt_msg === 'function') {
-        callback = opt_msg;
-        opt_msg = EMPTY;
-        opt_options = null;
-    }
-    if (typeof opt_options === 'function') {
-        callback = opt_options;
-        opt_options = null;
+    const args = callbackShifter(4, Array.prototype.slice.call(arguments));
+    subject = args[0];
+    opt_msg = args[1];
+    opt_options = args[2];
+    callback = args[3];
+
+    if(!callback || typeof callback !== 'function') {
+        this.cbOrEmit(new NatsError(BAD_CALLBACK_MSG, BAD_CALLBACK));
+        return 0;
     }
 
     if(this.handledClosedOrDraining(callback)) {
@@ -1822,7 +1858,7 @@ Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
 
     if (opt_options.timeout) {
         conf.timeout = setTimeout(() => {
-            if (conf.callback) {
+            if (callback) {
                 conf.callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + conf.id, REQ_TIMEOUT));
             }
             this.cancelMuxRequest(conf.token);
@@ -1830,35 +1866,6 @@ Client.prototype.request = function(subject, opt_msg, opt_options, callback) {
     }
 
     return conf.id;
-};
-
-
-/**
- * @deprecated
- * @api private
- */
-Client.prototype.oldRequest = function(subject, opt_msg, opt_options, callback) {
-    if (typeof opt_msg === 'function') {
-        callback = opt_msg;
-        opt_msg = EMPTY;
-        opt_options = null;
-    }
-    if (typeof opt_options === 'function') {
-        callback = opt_options;
-        opt_options = null;
-    }
-
-    if (this.draining) {
-        callback(new NatsError(CONN_DRAINING_MSG, CONN_DRAINING));
-        return;
-    }
-
-    const inbox = this.createInbox();
-    const s = this.subscribe(inbox, opt_options, function(msg, reply) {
-        callback(msg, reply);
-    });
-    this.publish(subject, opt_msg, inbox);
-    return s;
 };
 
 /**
@@ -1881,21 +1888,20 @@ Client.prototype.oldRequest = function(subject, opt_msg, opt_options, callback) 
  * @api public
  */
 Client.prototype.requestOne = function(subject, opt_msg, opt_options, timeout, callback) {
-    if (this.options.useOldRequestStyle) {
-        return this.oldRequestOne(subject, opt_msg, opt_options, timeout, callback);
-    }
+    const args = callbackShifter(5, Array.prototype.slice.call(arguments));
+    subject = args[0];
+    opt_msg = args[1];
+    opt_options = args[2];
+    timeout = args[3];
+    callback = args[4];
 
-    if (typeof opt_msg === 'number') {
-        callback = opt_options;
-        timeout = opt_msg;
-        opt_options = null;
-        opt_msg = EMPTY;
-    }
-
-    if (typeof opt_options === 'number') {
-        callback = timeout;
+    if (timeout === undefined && typeof opt_options === "number") {
         timeout = opt_options;
-        opt_options = null;
+        opt_options = undefined;
+    }
+    if (timeout === undefined && opt_options === undefined && typeof opt_msg === "number") {
+        timeout = opt_msg;
+        opt_msg = EMPTY;
     }
 
     opt_options = opt_options || {};
@@ -2019,34 +2025,6 @@ Client.prototype.cancelMuxRequest = function(token) {
 };
 
 /**
- * @deprecated
- * @api private
- */
-Client.prototype.oldRequestOne = function(subject, opt_msg, opt_options, timeout, callback) {
-    if (typeof opt_msg === 'number') {
-        callback = opt_options;
-        timeout = opt_msg;
-        opt_options = null;
-        opt_msg = EMPTY;
-    }
-
-    if (typeof opt_options === 'number') {
-        callback = timeout;
-        timeout = opt_options;
-        opt_options = null;
-    }
-
-    opt_options = opt_options || {};
-    opt_options.max = 1;
-
-    const sid = this.request(subject, opt_msg, opt_options, callback);
-    this.timeout(sid, timeout, 1, function() {
-        callback(new NatsError(REQ_TIMEOUT_MSG_PREFIX + sid, REQ_TIMEOUT));
-    });
-    return sid;
-};
-
-/**
  * Report number of outstanding subscriptions on this connection.
  *
  * @return {Number}
@@ -2096,3 +2074,38 @@ Client.prototype.scheduleReconnect = function() {
         this.reconnect();
     }, wait);
 };
+
+
+// finds the last index that satisfies the testFun in array a
+function lastIndexOf(a, testFun) {
+    const idx = a.length-1;
+    for(let i=idx; i > -1; i--) {
+        if (testFun(a[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+// returns an array that shifts the last function in the
+// array to the last element of the array
+function callbackShifter(maxArgs, args) {
+    // last argument is expected to be a function
+    const a = new Array(maxArgs);
+    const idx = lastIndexOf(args, (v) => typeof v === 'function');
+
+    // found a function, at the last index
+    if (idx !== -1 && idx === args.length - 1) {
+        a[maxArgs - 1] = args[idx];
+        for (let i = 0; i < idx; i++) {
+            a[i] = args[i];
+        }
+    } else {
+        for (let i=0; i < args.length; i++) {
+            a[i] = args[i];
+        }
+    }
+    return a;
+}
+// exported only for tests
+exports.callbackShifter = callbackShifter;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/basics.js
+++ b/test/basics.js
@@ -607,6 +607,21 @@ describe('Basics', function() {
         });
     });
 
+    it('drains callback must be a function', function(done) {
+        const nc = NATS.connect(PORT);
+        nc.on('error', (err) => {
+            nc.close();
+            if(err.code === NATS.BAD_CALLBACK) {
+                done();
+                return;
+            }
+            done(err);
+        });
+        nc.on('connect', function() {
+            nc.drain("a string");
+        });
+    });
+
     it('connection drains when no subs', function(done) {
         const nc = NATS.connect(PORT);
         nc.on('error', function(err) {
@@ -860,4 +875,106 @@ describe('Basics', function() {
         });
     });
 
+    it('drain sub callback must be function', function(done) {
+        const nc1 = NATS.connect(PORT);
+        nc1.on('connect', () => {
+            nc1.on('error', (err) => {
+                nc1.close();
+                if(err.code === NATS.BAD_CALLBACK) {
+                    done();
+                    return;
+                }
+                done(err);
+            });
+            const sid = nc1.subscribe(NATS.createInbox(), () => {});
+            nc1.drainSubscription(sid, "not a function");
+
+        });
+    });
+
+    it('drain sub callback on unknown sub is called', function(done) {
+        const nc1 = NATS.connect(PORT);
+        nc1.on('connect', () => {
+            nc1.drainSubscription(1000, () => {
+                nc1.close();
+                done();
+            });
+        });
+    });
+
+    it('publish callback must be a function', (done) => {
+        const nc = NATS.connect(PORT);
+        nc.on('error', (err) => {
+            nc.close();
+            if(err.code === NATS.BAD_CALLBACK) {
+                done();
+                return;
+            }
+            done(err);
+        });
+
+        nc.publish("foo", undefined, undefined, "not a function");
+    });
+
+    it('publish reply cannot be a function', (done) => {
+        const nc = NATS.connect(PORT);
+        nc.publish("foo", undefined, () => {}, (err) => {
+            nc.close();
+            if(err.code === NATS.BAD_REPLY) {
+                done();
+                return;
+            }
+            done(err);
+        });
+    });
+
+    it('subscribe cb must be function', (done) => {
+        const nc = NATS.connect(PORT);
+        nc.on('error', (err) => {
+            nc.close();
+            if(err.code === NATS.BAD_CALLBACK) {
+                done();
+                return;
+            }
+            done(err);
+        });
+        nc.subscribe("foo");
+    });
+
+    it('subscribe cb must be function or sid is zero', (done) => {
+        const nc = NATS.connect(PORT);
+        nc.on('error', (err) => {
+            // need a handler
+        });
+        const sid = nc.subscribe("foo");
+        sid.should.be.equal(0);
+        nc.close();
+        done();
+    });
+
+    it('timeout callback must be function', (done) => {
+        const nc = NATS.connect(PORT);
+        nc.on('error', (err) => {
+            nc.close();
+            if(err.code === NATS.BAD_CALLBACK) {
+                done();
+                return;
+            }
+            done(err);
+        });
+        nc.timeout(1000, 1000000, 1, "not a function");
+    });
+
+    it('request callback must be function', (done) => {
+        const nc = NATS.connect(PORT);
+        nc.on('error', (err) => {
+            nc.close();
+            if(err.code === NATS.BAD_CALLBACK) {
+                done();
+                return;
+            }
+            done(err);
+        });
+        nc.request("foo", undefined, undefined, "not a function");
+    });
 });

--- a/test/connect.js
+++ b/test/connect.js
@@ -168,4 +168,10 @@ describe('Basic Connectivity', function() {
         });
     });
 
+    it('opts must be an object', (done) => {
+       should.throws(() => {
+           NATS.connect(uri, "a string");
+       });
+       done();
+    });
 });

--- a/test/dsub.js
+++ b/test/dsub.js
@@ -50,7 +50,7 @@ describe('Double SUBS', function() {
         });
 
         const nc = NATS.connect(PORT);
-        nc.subscribe('foo');
+        nc.subscribe('foo', () => {});
         nc.on('connect', function(nc) {
             setTimeout(function() {
                 nc.close();

--- a/test/json.js
+++ b/test/json.js
@@ -61,7 +61,7 @@ describe('JSON payloads', () => {
         };
     }
 
-    function testReqRep(input, expected, useOldRequestStyle) {
+    function testReqRep(input, expected) {
         if (expected === undefined) {
             expected = input;
         }
@@ -70,7 +70,6 @@ describe('JSON payloads', () => {
             const nc = NATS.connect({
                 json: true,
                 port: PORT,
-                useOldRequestStyle: useOldRequestStyle === true
             });
 
             nc.subscribe('reqrep', {
@@ -135,15 +134,9 @@ describe('JSON payloads', () => {
     for (const name of Object.getOwnPropertyNames(testInputs)) {
         it(`should pub/sub with ${name}`, testPubSub(testInputs[name]));
         it(`should req/rep with ${name}`, testReqRep(testInputs[name]));
-        it(`should req/rep with ${name} oldrr`, testReqRep(
-            testInputs[name], undefined, true
-        ));
     }
 
     // undefined must be serialized as null
     it('should pub/sub with undefined', testPubSub(undefined, null));
     it('should req/rep with undefined', testReqRep(undefined, null));
-    it('should req/rep with undefined oldrr', testReqRep(
-        undefined, null, true
-    ));
 });

--- a/test/properties.js
+++ b/test/properties.js
@@ -72,8 +72,6 @@ describe('Connection Properties', function() {
         nc.options.should.have.property('reconnect');
         nc.options.should.have.property('maxReconnectAttempts');
         nc.options.should.have.property('reconnectTimeWait');
-        nc.options.should.have.property('useOldRequestStyle');
-        nc.options.useOldRequestStyle.should.equal(false);
         nc.options.noEcho.should.be.false();
     });
 
@@ -95,7 +93,6 @@ describe('Connection Properties', function() {
             'reconnect': false,
             'maxReconnectAttempts': 22,
             'reconnectTimeWait': 11,
-            'useOldRequestStyle': true,
         };
 
         nc = NATS.connect(options);
@@ -107,7 +104,6 @@ describe('Connection Properties', function() {
         nc.options.reconnect.should.equal(false);
         nc.options.maxReconnectAttempts.should.equal(22);
         nc.options.reconnectTimeWait.should.equal(11);
-        nc.options.useOldRequestStyle.should.equal(true);
         nc.close();
     });
 });

--- a/test/shift.js
+++ b/test/shift.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2013-2019 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const NATS = require('../'),
+    should = require('should');
+
+describe('shifter', function() {
+    it('should handle empty', () => {
+        const a = new Array(0);
+        const b = NATS.callbackShifter(0, a);
+        b.should.have.length(0);
+    });
+
+    it('should handle just fun', () => {
+        const a  = [function () {}];
+        const b = NATS.callbackShifter(10, a);
+        b.should.have.length(10);
+        for(let i=0; i < 8; i++) {
+            (b[i] === undefined).should.be.true();
+        }
+        const v = typeof b[9];
+        v.should.be.equal('function');
+    });
+
+    it('should handle all', () => {
+        const a = ['a', '1', function () {}];
+        const b = NATS.callbackShifter(3, a);
+        should.deepEqual(a, b);
+    });
+
+    it('should handle holes', () => {
+        const a = ['a', '1', undefined, function () {}];
+        const b = NATS.callbackShifter(4, a);
+        should.deepEqual(a, b);
+    });
+});

--- a/test/subevents.js
+++ b/test/subevents.js
@@ -47,7 +47,7 @@ describe('Subscription Events', function() {
             nc.close();
             done();
         });
-        nc.subscribe(subj);
+        nc.subscribe(subj, () => {});
     });
 
     it('should generate subscribe events with opts', function(done) {
@@ -66,7 +66,7 @@ describe('Subscription Events', function() {
         });
         nc.subscribe(subj, {
             queue: queuegroup
-        });
+        }, () => {});
     });
 
     it('should generate unsubscribe events', function(done) {
@@ -79,7 +79,7 @@ describe('Subscription Events', function() {
             nc.close();
             done();
         });
-        var sid = nc.subscribe(subj);
+        var sid = nc.subscribe(subj, () => {});
         nc.unsubscribe(sid);
     });
 
@@ -95,7 +95,7 @@ describe('Subscription Events', function() {
         });
         nc.subscribe(subj, {
             max: 1
-        });
+        }, () => {});
         nc.publish(subj);
     });
 
@@ -105,10 +105,10 @@ describe('Subscription Events', function() {
         let eventsReceived = 0;
         const want = 5;
 
-        nc.on('unsubscribe', function(sid, subject) {
+        nc.on('unsubscribe', function() {
             eventsReceived++;
         });
-        const sid = nc.subscribe(subj);
+        const sid = nc.subscribe(subj, () => {});
         nc.unsubscribe(sid, want);
         for (let i = 0; i < want; i++) {
             nc.publish(subj);
@@ -129,7 +129,7 @@ describe('Subscription Events', function() {
         });
         nc.request(subj, null, {
             max: 1
-        });
+        }, () => {});
 
         nc.on('unsubscribe', function(sid, subject) {
             should.exist(sid);

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -41,7 +41,7 @@ describe('Timeout and max received events for subscriptions', function() {
         const nc = NATS.connect(PORT);
         nc.on('connect', function() {
             const startTime = new Date();
-            const sid = nc.subscribe('foo');
+            const sid = nc.subscribe('foo', () => {});
             nc.timeout(sid, 50, 1, function() {
                 const elapsed = new Date() - startTime;
                 should.exists(elapsed);
@@ -55,7 +55,7 @@ describe('Timeout and max received events for subscriptions', function() {
     it('should not timeout if exepected has been received', function(done) {
         const nc = NATS.connect(PORT);
         nc.on('connect', function() {
-            const sid = nc.subscribe('foo');
+            const sid = nc.subscribe('foo', () => {});
             nc.timeout(sid, 50, 1, function() {
                 done(new Error('Timeout improperly called'));
             });
@@ -71,7 +71,7 @@ describe('Timeout and max received events for subscriptions', function() {
         const nc = NATS.connect(PORT);
         nc.on('connect', function() {
             let count = 0;
-            const sid = nc.subscribe('bar', function (m) {
+            const sid = nc.subscribe('bar', function () {
                 count++;
                 if (count === 1) {
                     nc.unsubscribe(sid);
@@ -94,7 +94,7 @@ describe('Timeout and max received events for subscriptions', function() {
         const nc = NATS.connect(PORT);
         nc.on('connect', function() {
             let count = 0;
-            const sid = nc.subscribe('bar', function (m) {
+            const sid = nc.subscribe('bar', function () {
                 count++;
             });
             nc.timeout(sid, 250, 2, function() {
@@ -159,7 +159,7 @@ describe('Timeout and max received events for subscriptions', function() {
             const sid = nc.request('foo', null, {
                 max: 2,
                 timeout: 1000
-            }, function (err) {
+            }, function () {
                 calledOnRequestHandler = true;
             });
 


### PR DESCRIPTION
FIX #292 
Unlike nats.ts, nats.js has many optional arguments, and unfortunately the required arguments don't preceed optional ones, so argument shuffling is performed.

- This release will raise errors in dodgy code that was accepted by previous releases. For example a subscription or request that doesn't provide a callback will now fail, as a callback is required to process messages. Only optional callbacks can be omitted.

- In cases where a call has a callback, if a validation type error is raised, the error will be delivered through the callback provided. If the callback is not provided in optional cases, the error will be raised via the standard event emitter mechanism.

- This PR does away with deprecated functions.