### PR TITLE
FIX #280

### DIFF
--- a/examples/node-pub
+++ b/examples/node-pub
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
  * Copyright 2013-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +15,10 @@
  * limitations under the License.
  */
 
-#!/usr/bin/env node
-
 /* jslint node: true */
 'use strict';
 
-const nats = require('nats');
+const nats = require('../');
 const argv = require('minimist')(process.argv.slice(2));
 
 const url = argv.s || nats.DEFAULT_URI;
@@ -27,7 +27,7 @@ const subject = argv._[0];
 const msg = argv._[1] || '';
 
 if (!subject) {
-    console.log('Usage: node-pub  [-s server] [--creds file] <subject> [msg]');
+    console.log('Usage: node-pub  [-s server] [--creds=creds_file_path] <subject> [msg]');
     process.exit();
 }
 

--- a/examples/node-rep
+++ b/examples/node-rep
@@ -25,10 +25,10 @@ const url = argv.s || nats.DEFAULT_URI;
 const creds = argv.creds;
 const queue = argv.queue;
 const subject = argv._[0];
-
+const response = argv._[1] || '';
 
 if (!subject) {
-    console.log('Usage: node-sub [-s server] [--creds=creds_file_path] [--queue=qname] <subject>');
+    console.log('Usage: node-rep  [-s server] [--creds=creds_file_path] [--queue=qname] <subject> [response]');
     process.exit();
 }
 
@@ -40,22 +40,30 @@ nc.on('connect', function() {
     if(queue) {
         opts.queue = queue;
     }
-    nc.subscribe(subject, opts, function(msg) {
-        console.log('Received "' + msg + '"');
+
+    let count = 0;
+    nc.subscribe(subject, opts, function(msg, reply) {
+        if(reply) {
+            // give the response or echo back
+            const d = response || msg;
+            nc.publish(reply, d);
+            console.log('Sent [' + count++ + '] reply "' + d + '"');
+            return;
+        }
+        console.log('Dropping message "' + msg + '" - no reply subject set');
     });
     if(queue) {
-        console.log('Queue [' + queue + '] listening on [' + subject + ']');
+        console.log('Queue reply [' + queue + '] listening on [' + subject + ']');
     } else {
-        console.log('Listening on [' + subject + ']');
+        console.log('Reply listening on [' + subject + ']');
     }
+});
+
+nc.on('unsubscribe', function() {
+    process.exit();
 });
 
 nc.on('error', function(e) {
     console.log('Error [' + nc.currentServer + ']: ' + e);
-    process.exit();
-});
-
-nc.on('close', function() {
-    console.log('CLOSED');
     process.exit();
 });

--- a/examples/node-req
+++ b/examples/node-req
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /*
  * Copyright 2013-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,12 +15,10 @@
  * limitations under the License.
  */
 
-#!/usr/bin/env node
-
 /* jslint node: true */
 'use strict';
 
-const nats = require('nats');
+const nats = require('../');
 const argv = require('minimist')(process.argv.slice(2));
 
 const url = argv.s || nats.DEFAULT_URI;
@@ -28,14 +28,14 @@ const subject = argv._[0];
 const msg = argv._[1] || '';
 
 if (!subject) {
-    console.log('Usage: node-req  [-s server] [--creds file] [-n max_responses] <subject> [msg]');
+    console.log('Usage: node-req  [-s server] [--creds=creds_file_path] [-n max_responses] <subject> [msg]');
     process.exit();
 }
 
 // Connect to NATS server.
 const nc = nats.connect(url, nats.creds(creds));
 
-nc.request(subject, msg, {
+nc.request(subject, String(msg), {
     max: max
 }, function(response) {
     console.log('Received: ' + response);


### PR DESCRIPTION
- Fixed the usage to show correct use of long flags like --creds
- Changed `require('nats')` to use current library to make it easier to use the examples
- Added node-rep, to create a service that replies to requests (queue enabled)
- Added queue support to node-sub
- Moved copyright to below the shebang for easier use of the example