### PR TITLE
NATS#connect - prevent tls.connect from throwing uncaught exceptions (fixes #310)

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -100,6 +100,8 @@ const SUB_DRAINING = 'SUB_DRAINING'
 const SUB_DRAINING_MSG = 'Subscription draining'
 const CONN_ERR = 'CONN_ERR'
 const CONN_ERR_MSG_PREFIX = 'Could not connect to server: '
+const OPENSSL_ERR = 'OPENSSL_ERR'
+const OPENSSL_ERR_MSG_PREFIX = 'TLS credentials verification failed: '
 const INVALID_ENCODING = 'INVALID_ENCODING'
 const INVALID_ENCODING_MSG_PREFIX = 'Invalid Encoding:'
 const NATS_PROTOCOL_ERR = 'NATS_PROTOCOL_ERR'
@@ -1169,9 +1171,15 @@ Client.prototype.processInbound = function () {
               if (this.stream) {
                 this.stream.removeAllListeners()
               }
-              this.stream = tls.connect(tlsOpts, () => {
-                this.flushPending()
-              })
+              try {
+                // Refer to issue #310
+                this.stream = tls.connect(tlsOpts, () => {
+                  this.flushPending()
+                })
+              } catch (error) {
+                this.emit('error', new NatsError(OPENSSL_ERR_MSG_PREFIX + error, OPENSSL_ERR, error))
+                return
+              }
               this.setupHandlers()
             }
 

--- a/test/tls.js
+++ b/test/tls.js
@@ -148,6 +148,7 @@ describe('TLS', function () {
     const testTable = [
       {
         errorCode: 'ERR_OSSL_X509_KEY_VALUES_MISMATCH',
+        regex: /key values mismatch/i,
         tls: {
           key: fs.readFileSync('./test/certs/client-key.pem'),
           cert: fs.readFileSync('./test/certs/ca.pem'),
@@ -156,6 +157,7 @@ describe('TLS', function () {
       },
       {
         errorCode: 'ERR_OSSL_PEM_NO_START_LINE',
+        regex: /no start line/i,
         tls: {
           key: fs.readFileSync('./test/certs/client-cert.pem'),
           cert: fs.readFileSync('./test/certs/client-key.pem'),
@@ -164,7 +166,7 @@ describe('TLS', function () {
       }
     ]
 
-    testTable.forEach(({ errorCode, tls }) => {
+    testTable.forEach(({ errorCode, regex, tls }) => {
       it(`should handle ${errorCode}`, function (done) {
         const nc = NATS.connect({
           port: TLSPORT,
@@ -176,7 +178,7 @@ describe('TLS', function () {
         nc.once('error', function (error) {
           should.exist(error)
           should(error.code).equal('OPENSSL_ERR')
-          should(error.chainedError.code).equal(errorCode)
+          should.exist(regex.exec(error.chainedError.message))
           nc.close()
           done()
         })


### PR DESCRIPTION
## Introduction
As described in #310, `tls.connect` throws an uncaught exception if OpenSSL's pre-flight verification fails. This pull request fixes that.

## Description of the Fix
A simple `try-catch` wrapper around `tls.connect` in `lib/nats.js` seems to do the trick just fine. For additional semantic interoperability, a new error code definition (and its accompanying message prefix) was added; namely:
* `OPENSSL_ERR` - set to `OPENSSL_ERR`
* `OPENSSL_ERR_MSG_PREFIX` - set to `TLS credentials verification failed: `

## Breaking Changes
None.

## Compatibility Issues
None.

## Testbeds
* `Darwin` - `18.7.0` 
* [Travis](https://travis-ci.com/labsvisual/nats.js/builds/145139786)