### PR TITLE
Connect timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ The following is the list of connection options and default values.
 | `reconnectTimeWait`    | `2000`                    | If disconnected, the client will wait the specified number of milliseconds between reconnect attempts
 | `reconnect`            | `true`                    | If false server will not attempt reconnecting
 | `servers`              |                           | Array of connection `url`s
+| `timeout`              | node default - no timeout | Number of milliseconds the client will wait for a connection to be established. If it fails it will emit a `connection_timeout` event with a NatsError that provides the hostport of the server where the connection was attempted.
 | `tls`                  | `false`                   | This property can be a boolean or an Object. If true the client requires a TLS connection. If false a non-tls connection is required.  The value can also be an object specifying TLS certificate data. The properties `ca`, `key`, `cert` should contain the certificate file data. `ca` should be provided for self-signed certificates. `key` and `cert` are required for client provided certificates. `rejectUnauthorized` if `true` validates server's credentials
 | `token`                |                           | Sets a authorization token for a connection
 | `tokenHandler`         |                           | A function returning a `token` used for authentication.

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ export const CLIENT_CERT_REQ: string;
 export const CONN_CLOSED: string;
 export const CONN_DRAINING: string;
 export const CONN_ERR: string;
+export const CONN_TIMEOUT: string;
 export const INVALID_ENCODING: string;
 export const NATS_PROTOCOL_ERR: string;
 export const NKEY_OR_JWT_REQ: string;
@@ -79,6 +80,7 @@ export interface ClientOpts {
 	reconnect?: boolean,
 	reconnectTimeWait?: number,
 	servers?: Array<string>,
+	timeout?: number,
 	tls?: boolean | tls.TlsOptions,
 	token?: string,
 	tokenHandler?: Function,

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -775,7 +775,8 @@ Client.prototype.setupHandlers = function () {
   })
 
   stream.on('data', (data) => {
-    if (this.options.timeout) {
+    if (toh) {
+      toh = undefined
       // connect added a timeout on data from the socket - remove it
       stream.setTimeout(0)
     }

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -707,22 +707,13 @@ Client.prototype.setupHandlers = function () {
     return
   }
 
-  let toh
   if (this.options.timeout) {
-    toh = setTimeout(() => {
+    this.connectionTimeoutHandler = setTimeout(() => {
       stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))
     }, this.options.timeout)
   }
 
   stream.on('connect', () => {
-    if (toh) {
-      // we got a connection
-      clearTimeout(toh)
-      // now we hope to get data on the socket before the timeout
-      stream.setTimeout(this.options.timeout, () => {
-        stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))
-      })
-    }
     this.cancelHeartbeat()
     this.connected = true
     this.scheduleHeartbeat()
@@ -775,11 +766,6 @@ Client.prototype.setupHandlers = function () {
   })
 
   stream.on('data', (data) => {
-    if (toh) {
-      toh = undefined
-      // connect added a timeout on data from the socket - remove it
-      stream.setTimeout(0)
-    }
     // If inbound exists, concat them together. We try to avoid this for split
     // messages, so this should only really happen for a split control line.
     // Long term answer is hand rolled parser and not regexp.
@@ -1228,17 +1214,25 @@ Client.prototype.processInbound = function () {
 
             // Send the connect message and subscriptions immediately
             this.sendConnect()
-            this.sendSubscriptions()
-
+            // add the first callback to a ping
             this.pongs.unshift(() => {
+              // this gets called when the first pong is received by the connection
+              // if we have a connection timeout timer, remove it
+              if (this.connectionTimeoutHandler) {
+                clearTimeout(this.connectionTimeoutHandler)
+                delete this.connectionTimeoutHandler
+              }
+              // send any subscriptions, and strip pending
+              this.sendSubscriptions()
+              this.stripPendingSubs()
+              // invoke the callback
               this.connectCB()
             })
+            // send that ping out now
             this.stream.write(PING_REQUEST)
-
+            this.flushPending()
             // Mark as received
             this.infoReceived = true
-            this.stripPendingSubs()
-            this.flushPending()
           }
         } else {
           // FIXME, check line length for something weird.

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -88,6 +88,7 @@ const CLIENT_CERT_REQ = 'CLIENT_CERT_REQ'
 const CONN_CLOSED = 'CONN_CLOSED'
 const CONN_DRAINING = 'CONN_DRAINING'
 const CONN_ERR = 'CONN_ERR'
+const CONN_TIMEOUT = 'CONN_TIMEOUT'
 const INVALID_ENCODING = 'INVALID_ENCODING'
 const NATS_PROTOCOL_ERR = 'NATS_PROTOCOL_ERR'
 const NKEY_OR_JWT_REQ = 'NKEY_OR_JWT_REQ'
@@ -118,6 +119,7 @@ const CLIENT_CERT_REQ_MSG = 'Server requires a client certificate.'
 const CONN_CLOSED_MSG = 'Connection closed'
 const CONN_DRAINING_MSG = 'Connection draining'
 const CONN_ERR_MSG_PREFIX = 'Could not connect to server: '
+const CONN_TIMEOUT_MSG = 'Connection timeout'
 const INVALID_ENCODING_MSG_PREFIX = 'Invalid Encoding:'
 const NKEY_OR_JWT_REQ_MSG = 'An Nkey or User JWT callback needs to be defined.'
 const NON_SECURE_CONN_REQ_MSG = 'Server does not support a secure connection.'
@@ -172,6 +174,7 @@ exports.CLIENT_CERT_REQ = CLIENT_CERT_REQ
 exports.CONN_CLOSED = CONN_CLOSED
 exports.CONN_DRAINING = CONN_DRAINING
 exports.CONN_ERR = CONN_ERR
+exports.CONN_TIMEOUT = CONN_TIMEOUT
 exports.INVALID_ENCODING = INVALID_ENCODING
 exports.NATS_PROTOCOL_ERR = NATS_PROTOCOL_ERR
 exports.NKEY_OR_JWT_REQ = NKEY_OR_JWT_REQ
@@ -226,8 +229,7 @@ exports.connect = function (url, opts) {
   // options object.
   if (opts !== undefined) {
     if (typeof opts !== 'object') {
-      this.emit('error', new NatsError(BAD_OPTIONS_MSG, BAD_OPTIONS))
-      return
+      throw new NatsError(BAD_OPTIONS_MSG, BAD_OPTIONS)
     }
     opts.url = sanitizeUrl(url)
   } else {
@@ -300,6 +302,7 @@ Client.prototype.parseOptions = function (opts) {
       options.url = DEFAULT_PRE + opts.port
     }
     // Pull out various options here
+    this.assignOption(opts, 'timeout')
     this.assignOption(opts, 'encoding')
     this.assignOption(opts, 'json')
     this.assignOption(opts, 'maxPingOut')
@@ -406,6 +409,10 @@ Client.prototype.parseOptions = function (opts) {
         options.tls = true
       }
     })
+  }
+
+  if (options.timeout && typeof options.timeout !== 'number') {
+    throw new NatsError('timeout should be a number', BAD_OPTIONS)
   }
 }
 
@@ -700,7 +707,22 @@ Client.prototype.setupHandlers = function () {
     return
   }
 
+  let toh
+  if (this.options.timeout) {
+    toh = setTimeout(() => {
+      stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))
+    }, this.options.timeout)
+  }
+
   stream.on('connect', () => {
+    if (toh) {
+      // we got a connection
+      clearTimeout(toh)
+      // now we hope to get data on the socket before the timeout
+      stream.setTimeout(this.options.timeout, () => {
+        stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))
+      })
+    }
     this.cancelHeartbeat()
     this.connected = true
     this.scheduleHeartbeat()
@@ -742,14 +764,21 @@ Client.prototype.setupHandlers = function () {
     }
 
     // Only bubble up error if we never had connected
-    // to the server and we only have one.
+    // to the server and we only have one, and close
     if (this.wasConnected === false && this.servers.length === 0) {
       this.emit('error', new NatsError(CONN_ERR_MSG_PREFIX + exception, CONN_ERR, exception))
+      this.close()
+      return
     }
+    // continue with reconnect
     this.closeStream()
   })
 
   stream.on('data', (data) => {
+    if (this.options.timeout) {
+      // connect added a timeout on data from the socket - remove it
+      stream.setTimeout(0)
+    }
     // If inbound exists, concat them together. We try to avoid this for split
     // messages, so this should only really happen for a split control line.
     // Long term answer is hand rolled parser and not regexp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.4.1-1",
+  "version": "1.4.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:unit": "mkdir -p reports/ && NODE_ENV=test multi='spec=- xunit=reports/mocha-xunit.xml' nyc mocha --timeout 10000 --slow 750",
     "test": "npm run depcheck && npm run depcheck:unused && npm run lint && npm run test:typescript && npm run test:unit",
     "test:typescript": "./node_modules/typescript/bin/tsc --strict --noEmit tstest/main.ts",
-    "coveralls": "npm run test && nyc report --reporter=text-lcov | coveralls",
+    "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "cover": "nyc report --reporter=html && open coverage/index.html",
     "lint": "standard './**/*.js'",
     "fmt": "standard --fix './**/*.js'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.4.1-1",
+  "version": "1.4.1-2",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -91,7 +91,6 @@ describe('Timeout and max received events for subscriptions', function () {
   }, 15000)
 
   it('connection timeout doesnt trigger', (done) => {
-    // this is not expecting to have enough time to connect
     const nc = NATS.connect({ port: PORT, timeout: 1000 })
     nc.on('error', (err) => {
       // shouldn't fail

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -20,6 +20,7 @@
 const NATS = require('../')
 const nsc = require('./support/nats_server_control')
 const should = require('should')
+const net = require('net')
 
 const PORT = 1428
 
@@ -34,6 +35,73 @@ describe('Timeout and max received events for subscriptions', function () {
   // Shutdown our server after we are done
   after(function (done) {
     nsc.stopServer(server, done)
+  })
+
+  // connect to a server that never sends data
+  it('conn timeout - socket timeout', (done) => {
+    const srv = net.createServer((c) => {})
+    srv.listen(0, () => {
+      const p = srv.address().port
+      const nc = NATS.connect({ port: p, timeout: 1000 })
+      nc.on('connect', () => {
+        done(new Error('should have failed'))
+      })
+      nc.on('error', (err) => {
+        err.should.be.instanceof(NATS.NatsError)
+        err.chainedError.should.be.instanceof(NATS.NatsError)
+        err.chainedError.should.have.property('code', NATS.CONN_TIMEOUT)
+        srv.close(done)
+      })
+    })
+  }, 15000)
+
+  it('connection timeout - fail to connect quickly enough', (done) => {
+    // this is not expecting to have enough time to connect
+    const nc = NATS.connect('nats://connect.ngs.global', { timeout: 1 })
+    nc.on('error', (err) => {
+      err.should.be.instanceof(NATS.NatsError)
+      err.chainedError.should.be.instanceof(NATS.NatsError)
+      err.chainedError.should.have.property('code', NATS.CONN_TIMEOUT)
+      done()
+    })
+
+    nc.on('connect', () => {
+      done(new Error('should have failed'))
+    })
+  })
+
+  // connect to a server that never sends data
+  it('conn timeout - reconnects work', (done) => {
+    const srv = net.createServer((c) => {})
+    srv.listen(0, () => {
+      const p = srv.address().port
+      const nc = NATS.connect('nats://localhost:' + p, {
+        timeout: 1000,
+        servers: ['nats://localhost:' + PORT]
+      })
+      nc.on('connect', () => {
+        nc.currentServer.url.host.should.be.equal('localhost:' + PORT)
+        nc.close()
+        srv.close(done)
+      })
+      nc.on('error', (err) => {
+        done(new Error('shouldnt have failed: ' + err))
+      })
+    })
+  }, 15000)
+
+  it('connection timeout doesnt trigger', (done) => {
+    // this is not expecting to have enough time to connect
+    const nc = NATS.connect({ port: PORT, timeout: 1000 })
+    nc.on('error', (err) => {
+      // shouldn't fail
+      done(err)
+    })
+    setTimeout(() => {
+      nc.connected.should.be.true()
+      nc.close()
+      done()
+    }, 1500)
   })
 
   it('should perform simple timeouts on subscriptions', function (done) {


### PR DESCRIPTION
FIX #309 - Added `timeout` connection option. The `timeout` option specifies the number of millis to wait for a connection to occur and for data to be sent by the server. The client must complete the dial and receive a `PONG` from the server within this amount of time, or it fails.

Fixed a small issue where if an options argument was provided but was not an object, the client would
try to emit an error, however, the emit mechanism was not yet set up, as the client was not yet created.

Also fixed an issue where if the client emitted an error (if it failed to connect to a server, the client would close the stream, but the client was not closed and thus preventing the node application from terminating.