### PR TITLE
FIX reconnect callbacks if published after disconnect

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -978,9 +978,7 @@ Client.prototype.closeStream = function () {
     this.stream = null
   }
   if (this.connected === true || this.closed === true) {
-    this.pongs = null
     this.pout = 0
-    this.pending = null
     this.pSize = 0
     this.connected = false
   }


### PR DESCRIPTION
Messages and callbacks will be lost in case when client try to publish after `disconnect` and before `connect` event.
I suggest, that reason is `closeStream` function, it aggressive cleaning resources. As I can see `pongs` and `pending` variables processed in `createConnection` function.