### PR TITLE
FIX #323 - Remove Noop code collecting pending PUB and Pings

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -89,6 +89,7 @@ const CONN_CLOSED = 'CONN_CLOSED'
 const CONN_DRAINING = 'CONN_DRAINING'
 const CONN_ERR = 'CONN_ERR'
 const CONN_TIMEOUT = 'CONN_TIMEOUT'
+const DISCONNECT_ERR = 'DISCONNECT'
 const INVALID_ENCODING = 'INVALID_ENCODING'
 const NATS_PROTOCOL_ERR = 'NATS_PROTOCOL_ERR'
 const NKEY_OR_JWT_REQ = 'NKEY_OR_JWT_REQ'
@@ -120,6 +121,7 @@ const CONN_CLOSED_MSG = 'Connection closed'
 const CONN_DRAINING_MSG = 'Connection draining'
 const CONN_ERR_MSG_PREFIX = 'Could not connect to server: '
 const CONN_TIMEOUT_MSG = 'Connection timeout'
+const DISCONNECT_MSG = 'Client disconnected, flush was reset'
 const INVALID_ENCODING_MSG_PREFIX = 'Invalid Encoding:'
 const NKEY_OR_JWT_REQ_MSG = 'An Nkey or User JWT callback needs to be defined.'
 const NON_SECURE_CONN_REQ_MSG = 'Server does not support a secure connection.'
@@ -724,11 +726,33 @@ Client.prototype.setupHandlers = function () {
   })
 
   stream.on('close', () => {
+    const done = (this.closed === true || this.options.reconnect === false || this.servers.length === 0)
+    // if connected, it resets everything as partial buffers may have been sent
+    // this will also reset the heartbeats, but not other timers on requests or subscriptions
+    const pongs = this.pongs
     this.closeStream()
     if (stream.bytesRead > 0) {
+      // if the client will reconnect, re-setup pongs/pending to sending commands
+      if (!done) {
+        this.pongs = []
+        this.pending = []
+        this.pSize = 0
+      }
+      // now we tell them that we bailed
+      if (pongs) {
+        pongs.forEach((cb) => {
+          if (typeof cb === 'function') {
+            try {
+              cb(new NatsError(DISCONNECT_MSG, DISCONNECT_ERR))
+            } catch (_) {
+              // don't fail
+            }
+          }
+        })
+      }
       this.emit('disconnect')
     }
-    if (this.closed === true || this.options.reconnect === false || this.servers.length === 0) {
+    if (done) {
       this.cleanupTimers()
       this.emit('close')
     } else {
@@ -848,41 +872,9 @@ Client.prototype.sendConnect = function () {
  * @api private
  */
 Client.prototype.createConnection = function () {
-  // Commands may have been queued during reconnect. Discard everything except:
-  // 1) ping requests with a pong callback
-  // 2) publish requests
-  //
-  // Rationale: CONNECT and SUBs are written directly upon connecting, any PONG
-  // response is no longer relevant, and any UNSUB will be accounted for when we
-  // sync our SUBs. Without this, users of the client may miss state transitions
-  // via callbacks, would have to track the client's internal connection state,
-  // and may have to double buffer messages (which we are already doing) if they
-  // wanted to ensure their messages reach the server.
-  const pong = []
-  const pend = []
-  let pSize = 0
-  if (this.pending !== null) {
-    let pongIndex = 0
-    this.pending.forEach((cmd) => {
-      const cmdLen = Buffer.isBuffer(cmd) ? cmd.length : Buffer.byteLength(cmd)
-      if (cmd === PING_REQUEST && this.pongs !== null && pongIndex < this.pongs.length) {
-        // filter out any useless ping requests (no pong callback, nop flush)
-        const p = this.pongs[pongIndex++]
-        if (p !== undefined) {
-          pend.push(cmd)
-          pSize += cmdLen
-          pong.push(p)
-        }
-      } else if (cmd.length > 3 && cmd[0] === 'P' && cmd[1] === 'U' && cmd[2] === 'B') {
-        pend.push(cmd)
-        pSize += cmdLen
-      }
-    })
-  }
-  this.pongs = pong
-  this.pending = pend
-  this.pSize = pSize
-
+  this.pongs = this.pongs || []
+  this.pending = this.pending || []
+  this.pSize = this.pSize || 0
   this.pstate = AWAITING_CONTROL
 
   // Clear info processing.
@@ -983,6 +975,8 @@ Client.prototype.closeStream = function () {
     this.connected = false
   }
   this.inbound = null
+  // if we are not connected, let's not queue up heartbeats
+  this.cancelHeartbeat()
 }
 
 /**
@@ -1059,7 +1053,7 @@ Client.prototype.sendCommand = function (cmd) {
   // Buffer to cut down on system calls, increase throughput.
   // When receive gets faster, should make this Buffer based..
 
-  if (this.closed || this.pending === null) {
+  if (this.closed) {
     return
   }
 

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -23,6 +23,7 @@ const afterEach = require('mocha').afterEach
 const beforeEach = require('mocha').beforeEach
 const describe = require('mocha').describe
 const it = require('mocha').it
+const net = require('net')
 
 describe('Reconnect functionality', () => {
   const PORT = 1426
@@ -391,6 +392,88 @@ describe('Reconnect functionality', () => {
       const s = server
       server = null
       nsc.stopServer(s)
+    })
+  })
+
+  it('should preserve buffer between reconnect attempts', (done) => {
+    let socket = null
+    let msgs = 0
+    const srv = net.createServer((c) => {
+      socket = c
+      c.write('INFO ' + JSON.stringify({
+        server_id: 'TEST',
+        version: '0.0.0',
+        host: '127.0.0.1',
+        port: srv.address.port,
+        auth_required: false
+      }) + '\r\n')
+      c.on('data', (d) => {
+        const r = d.toString()
+        const lines = r.split('\r\n')
+        lines.forEach((line) => {
+          if (line === '\r\n') {
+            return
+          }
+          if (/^CONNECT\s+/.test(line)) {
+          } else if (/^PING/.test(line)) {
+            c.write('PONG\r\n')
+          } else if (/^SUB\s+/i.test(line)) {
+          } else if (/^PUB\s+/i.test(line)) {
+            msgs++
+          } else if (/^UNSUB\s+/i.test(line)) {
+          } else if (/^MSG\s+/i.test(line)) {
+          } else if (/^INFO\s+/i.test(line)) {
+          }
+        })
+      })
+      c.on('error', () => {
+        // we are messing with the server so this will raise connection reset
+      })
+    })
+    let called = false
+    let flushErr = false
+    srv.listen(0, () => {
+      const p = srv.address().port
+      const nc = NATS.connect('nats://localhost:' + p, {
+        reconnect: true,
+        reconnectTimeWait: 250
+      })
+      nc.on('connect', () => {
+        nc.pongs.push((err) => {
+          if (err) {
+            flushErr = true
+          }
+        })
+        process.nextTick(() => {
+          // this is going to fake an outstanding ping
+          socket.destroy()
+        })
+      })
+      nc.on('disconnect', () => {
+        flushErr.should.be.true()
+        nc.pending.length.should.be.equal(0)
+        nc.pongs.length.should.be.equal(0)
+        nc.publish('foo')
+        nc.flush(() => {
+          called = true
+        })
+      })
+      nc.on('reconnecting', () => {
+        should.exist(nc.pending)
+        should.exist(nc.pongs)
+        nc.pongs.length.should.be.equal(1)
+      })
+      nc.on('reconnect', () => {
+        nc.flush()
+        setTimeout(() => {
+          msgs.should.be.equal(1)
+          called.should.be.true()
+          nc.close()
+          srv.close(() => {
+            done()
+          }, 500)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Removed noop code that collected pending PUB and PINGs. The code was a noop, because on any disconnect, `closeStream()` would already reset the pending buffer and the pongs. So nothing was recovered. 

As before until there's a connect, any contents in the pending is preserved and sent should it connect.
This change is no different than the current behavior, except that the previous code eluded to something that never happened.

This behavior lines up with go and other clients.