### PR TITLE
FIX #326 - subscription ids start at 2

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -910,7 +910,7 @@ Client.prototype.createConnection = function () {
  * @api private
  */
 Client.prototype.initState = function () {
-  this.ssid = 1
+  this.ssid = 0
   this.subs = {}
   this.reconnects = 0
   this.connected = false

--- a/test/basics.js
+++ b/test/basics.js
@@ -1038,7 +1038,7 @@ describe('Basics', () => {
           } else if (/^PING/.test(line)) {
             c.write('PONG\r\n')
           } else if (/^SUB\s+/i.test(line)) {
-            c.write('MSG test 2 11\r\nHello World\r\n')
+            c.write('MSG test 1 11\r\nHello World\r\n')
           } else if (/^UNSUB\s+/i.test(line)) {
             unsubs++
             if (unsubs === 1) {
@@ -1081,6 +1081,16 @@ describe('Basics', () => {
         const opts = { max: 10 }
         nc.subscribe('test', opts, () => {})
       })
+    })
+  })
+
+  it('sub ids should start at 1', (done) => {
+    const nc = NATS.connect({ port: PORT, json: true, useOldRequestStyle: true })
+    nc.on('connect', () => {
+      const ssid = nc.subscribe(nc.createInbox(), () => {})
+      ssid.should.be.equal(1)
+      nc.close()
+      done()
     })
   })
 })


### PR DESCRIPTION
Fixed an issue where the subscriptions were initialized `1`, rather than zero, so when a subscription was added it started at `2`.