### PR TITLE
Check if inbound is null before checking length

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -1309,7 +1309,7 @@ Client.prototype.processInbound = function () {
     }
 
     // This is applicable for a regex match to eat the bytes we used from a control line.
-    if (m && !this.closed) {
+    if (this.inbound && m && !this.closed) {
       // Chop inbound
       const psize = m[0].length
       if (psize >= this.inbound.length) {


### PR DESCRIPTION
In tests for a private project that uses nats, we were occasionally seeing failures with the message:

```js
.../node_modules/nats/lib/nats.js:1315
      if (psize >= this.inbound.length) {
                                ^

TypeError: Cannot read property 'length' of null
    at Client.processInbound (.../node_modules/nats/lib/nats.js:1315:33)
    at Socket.<anonymous> (.../node_modules/nats/lib/nats.js:805:10)
    at Socket.emit (events.js:210:5)
    at addChunk (_stream_readable.js:308:12)
    at readableAddChunk (_stream_readable.js:289:11)
    at Socket.Readable.push (_stream_readable.js:223:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:182:23)
```

This seems to be timing-dependant, but is easily avoidable by checking that `this.inbound` exists before attempting to check its length.