### PR TITLE
FIX #336

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -970,7 +970,7 @@ Client.prototype.closeStream = function () {
   if (this.connected === true || this.closed === true) {
     this.pongs = null
     this.pout = 0
-    this.pending = null
+    this.pending = []
     this.pSize = 0
     this.connected = false
   }


### PR DESCRIPTION
fix #336 - changed closeStream() to reset pending instead of setting to null. In cases where a timer fires between the closeStream() and a reconnect, the pending buffer will be null causing the client to crash.