### PR TITLE
Double timeout and socket.destroy() not issuing close.

### DIFF
--- a/lib/nats.js
+++ b/lib/nats.js
@@ -713,14 +713,13 @@ Client.prototype.setupHandlers = function () {
     return
   }
 
-  if (this.connectionTimeoutHandler) {
-    clearTimeout(this.connectionTimeoutHandler)
-    delete this.connectionTimeoutHandler
-  }
-
-  if (this.options.timeout) {
+  // tls upgrade will re-bind the handlers here, so if we have a timer we are going to ignore it
+  if (this.options.timeout && !this.connectionTimeoutHandler) {
     this.connectionTimeoutHandler = setTimeout(() => {
-      stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))
+      if (this.stream) {
+        // this fires on the current stream
+        this.stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))
+      }
     }, this.options.timeout)
   }
 

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -713,6 +713,11 @@ Client.prototype.setupHandlers = function () {
     return
   }
 
+  if (this.connectionTimeoutHandler) {
+    clearTimeout(this.connectionTimeoutHandler)
+    delete this.connectionTimeoutHandler
+  }
+
   if (this.options.timeout) {
     this.connectionTimeoutHandler = setTimeout(() => {
       stream.destroy(new NatsError(CONN_TIMEOUT_MSG, CONN_TIMEOUT))

--- a/lib/nats.js
+++ b/lib/nats.js
@@ -702,6 +702,16 @@ Client.prototype.scheduleHeartbeat = function () {
 }
 
 /**
+ * @api private
+ */
+Client.prototype.clearConnectionTimeoutHandler = function () {
+  if (this.connectionTimeoutHandler) {
+    clearTimeout(this.connectionTimeoutHandler)
+    delete this.connectionTimeoutHandler
+  }
+}
+
+/**
  * Properly setup a stream event handlers.
  *
  * @api private
@@ -969,6 +979,7 @@ Client.prototype.cleanupTimers = function () {
 Client.prototype.closeStream = function () {
   if (this.stream !== null) {
     this.stream.destroy()
+    this.clearConnectionTimeoutHandler()
     this.stream = null
   }
   if (this.connected === true || this.closed === true) {
@@ -1221,13 +1232,14 @@ Client.prototype.processInbound = function () {
             // Send the connect message and subscriptions immediately
             this.sendConnect()
             // add the first callback to a ping
-            this.pongs.unshift(() => {
+            this.pongs.unshift((err) => {
+              if (err) {
+                // failed the connection
+                return
+              }
               // this gets called when the first pong is received by the connection
               // if we have a connection timeout timer, remove it
-              if (this.connectionTimeoutHandler) {
-                clearTimeout(this.connectionTimeoutHandler)
-                delete this.connectionTimeoutHandler
-              }
+              this.clearConnectionTimeoutHandler()
               // send any subscriptions, and strip pending
               this.sendSubscriptions()
               this.stripPendingSubs()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.4.8",
+  "version": "1.4.9-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "1.4.8",
+  "version": "1.4.9-0",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/test/tls.js
+++ b/test/tls.js
@@ -116,6 +116,26 @@ describe('TLS', () => {
     })
   })
 
+  it('should not timeout when it tls connects', done => {
+    const tlsOptions = {
+      ca: [fs.readFileSync('./test/certs/ca.pem')]
+    }
+    const nc = NATS.connect({
+      port: TLSPORT,
+      tls: tlsOptions,
+      timeout: 1000
+    })
+    nc.on('connect', client => {
+      setTimeout(() => {
+        nc.stream.destroy()
+      }, 1100)
+    })
+    nc.on('reconnect', () => {
+      nc.close()
+      done()
+    })
+  })
+
   it('should reject without proper cert if required by server', done => {
     const nc = NATS.connect({
       port: TLSVERIFYPORT,

--- a/test/tls.js
+++ b/test/tls.js
@@ -125,14 +125,26 @@ describe('TLS', () => {
       tls: tlsOptions,
       timeout: 1000
     })
+    let alive = false
     nc.on('connect', client => {
       setTimeout(() => {
-        nc.stream.destroy()
+        nc.flush((err) => {
+          if (err) {
+            done(err)
+            return
+          }
+          alive = true
+          nc.stream.destroy()
+        })
       }, 1100)
     })
     nc.on('reconnect', () => {
+      alive.should.be.true()
       nc.close()
       done()
+    })
+    nc.on('error', (err) => {
+      done(err)
     })
   })
 


### PR DESCRIPTION
- Checked for a possible timer already scheduled (via the first connection, prior to tls upgrade) and removed the timeout in that case.