### PR TITLE
fix honoring of `rejectUnauthorized`

### DIFF
--- a/src/node_transport.ts
+++ b/src/node_transport.ts
@@ -205,7 +205,11 @@ export class NodeTransport implements Transport {
 
   async startTLS(): Promise<TLSSocket> {
     let tlsError: Error;
-    let tlsOpts = { socket: this.socket, servername: this.tlsName };
+    let tlsOpts = {
+      socket: this.socket,
+      servername: this.tlsName,
+      rejectUnauthorized: true,
+    };
     if (typeof this.options.tls === "object") {
       try {
         const certOpts = await this.loadClientCerts() || {};
@@ -224,6 +228,10 @@ export class NodeTransport implements Transport {
         tlsError = err;
       });
       tlsSocket.on("secureConnect", () => {
+        // socket won't be authorized, if the user disabled it
+        if (tlsOpts.rejectUnauthorized === false) {
+          return;
+        }
         if (!tlsSocket.authorized) {
           throw tlsSocket.authorizationError;
         }

--- a/test/tls.js
+++ b/test/tls.js
@@ -91,6 +91,21 @@ test("tls - connects with proper ca", async (t) => {
   t.pass();
 });
 
+test("tls - connects with rejectUnauthorized is honored", async (t) => {
+  const ns = await NatsServer.start(tlsConfig);
+  const nc = await connect({
+    servers: `localhost:${ns.port}`,
+    tls: {
+      rejectUnauthorized: false,
+    },
+  });
+  await nc.flush();
+  t.false(nc.protocol.transport.socket.authorized);
+  await nc.close();
+  await ns.stop();
+  t.pass();
+});
+
 test("tls - client auth", async (t) => {
   const ns = await NatsServer.start(tlsConfig);
 


### PR DESCRIPTION
[fix] `rejectUnauthorized` was not getting honored due to a check to see if the connection was authorized (CA signature was verified). By passing this check if `rejectUnauthorized` is set to `false`.

FIX #421