### PR TITLE
nbc updates to 1.0.8

### DIFF
--- a/.github/workflows/natsjs.yml
+++ b/.github/workflows/natsjs.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           deno-version: 1.9.2
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.2.6" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.3.0" >> $GITHUB_ENV
       - name: Get nats-server
         run: |
           wget "https://github.com/nats-io/nats-server/releases/download/$NATS_VERSION/nats-server-$NATS_VERSION-linux-amd64.zip" -O tmp.zip

--- a/index.d.ts
+++ b/index.d.ts
@@ -337,11 +337,11 @@ export interface JetStreamClient {
 export interface ConsumerOpts {
     config: Partial<ConsumerConfig>;
     mack: boolean;
-    subQueue: string;
     stream: string;
     callbackFn?: JsMsgCallback;
     name?: string;
     max?: number;
+    queue?: string;
     debug?: boolean;
 }
 export declare function consumerOpts(opts?: Partial<ConsumerConfig>): ConsumerOptsBuilder;
@@ -362,6 +362,7 @@ export interface ConsumerOptsBuilder {
     maxAckPending(max: number): void;
     maxWaiting(max: number): void;
     maxMessages(max: number): void;
+    queue(n: string): void;
     callback(fn: JsMsgCallback): void;
 }
 export interface Lister<T> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats",
-  "version": "2.0.6",
+  "version": "2.0.8",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -41,7 +41,7 @@
     "build": "tsc",
     "cjs": "deno run --allow-all bin/cjs-fix-imports.ts -o nats-base-client/ ./.deps/nats.deno/nats-base-client/",
     "clean": "shx rm -Rf ./lib/* ./nats-base-client ./.deps",
-    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.0.6 https://github.com/nats-io/nats.deno.git",
+    "clone-nbc": "shx mkdir -p ./.deps && cd ./.deps && git clone --branch v1.0.8 https://github.com/nats-io/nats.deno.git",
     "fmt": "deno fmt ./src/ ./examples/ ./test/",
     "prepack": "npm run clone-nbc && npm run cjs && npm run build",
     "ava": "nyc ava --verbose -T 60000",


### PR DESCRIPTION
[UPDATED] nbc to 1.0.8 - see https://github.com/nats-io/nats.deno/releases/tag/v1.0.8
[UPDATED] nats-server for tests to current release