### PR TITLE
[FEAT] added noop implementation for discard() api

### DIFF
--- a/src/node_transport.ts
+++ b/src/node_transport.ts
@@ -315,6 +315,10 @@ export class NodeTransport implements Transport {
     }
   }
 
+  discard() {
+    // ignored - this is not required, as there's no throttling
+  }
+
   disconnect(): void {
     this._closed(undefined, true).then().catch();
   }


### PR DESCRIPTION
Transport interface added a `discard()` method, to allow for websocket discards on transports that throttle, this is a noop on nodejs tcp