### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ const sub = nc.subscribe("hello");
 nc.publish("hello", sc.encode("world"));
 nc.publish("hello", sc.encode("again"));
 
-// we want to insure that messages that are in flight
+// we want to ensure that messages that are in flight
 // get processed, so we are going to drain the
 // connection. Drain is the same as close, but makes
 // sure that all messages in flight get seen


### PR DESCRIPTION
i think this should be ensure. insure is usually used in financial contexts