### PR TITLE
[FIX] identify ipv6 encoding an ipv4 as ipv6

### DIFF
--- a/core/src/servers.ts
+++ b/core/src/servers.ts
@@ -24,11 +24,14 @@ import type {
 import { DEFAULT_HOST, DEFAULT_PORT } from "./core.ts";
 
 export function isIPV4OrHostname(hp: string): boolean {
-  if (hp.indexOf(".") !== -1) {
-    return true;
-  }
+  // in the wild seeing IPv4s as IPv6s
+  // ::ffff:35.234.43.228 which incorrectly get mapped to IPv4 unless
+  // we add this test first
   if (hp.indexOf("[") !== -1 || hp.indexOf("::") !== -1) {
     return false;
+  }
+  if (hp.indexOf(".") !== -1) {
+    return true;
   }
   // if we have a plain hostname or host:port
   if (hp.split(":").length <= 2) {

--- a/core/tests/servers_test.ts
+++ b/core/tests/servers_test.ts
@@ -132,4 +132,5 @@ Deno.test("servers - port 80", () => {
 Deno.test("servers - hostname only", () => {
   assertEquals(isIPV4OrHostname("hostname"), true);
   assertEquals(isIPV4OrHostname("hostname:40"), true);
+  assertEquals(isIPV4OrHostname("::ffff:35.234.43.228"), false);
 });

--- a/deno.json
+++ b/deno.json
@@ -6,7 +6,7 @@
     "test_helpers": "./test_helpers/mod.ts"
   },
   "tasks": {
-    "clean": "rm -Rf ./coverage",
+    "clean": "rm -Rf ./coverage core/lib jetstream/lib services/lib kv/lib obj/lib transport-node/lib transport-ws/lib",
     "test": "deno task clean && deno task lint && deno task test-all",
     "test-all": "deno task test-core && deno task test-jetstream && deno task test-kv && deno task test-obj && deno task test-services && deno task test-unsafe",
     "test-unsafe": "deno test -A --parallel --reload --quiet --unsafely-ignore-certificate-errors --coverage=coverage core/unsafe_tests",
@@ -32,10 +32,10 @@
   },
   "fmt": {
     "include": ["transport-deno/", "bin/", "core/", "debug/", "jetstream/", "kv/", "obj/", "services/", "*.md", "transport-node/"],
-    "exclude": ["*/lib", "*/build", "docs/"]
+    "exclude": ["core/lib", "jetstream/lib", "kv/lib","obj/lib", "services/lib", "transport-node/lib", "transport-ws/lib", "*/build", "docs/"]
   },
   "lint": {
-    "exclude": ["*/lib", "*/build", "docs/"]
+    "exclude": ["core/lib", "jetstream/lib", "kv/lib","obj/lib", "services/lib", "transport-node/lib", "transport-ws/lib", "*/build", "docs/"]
   },
   "scopes": {
     "*": {


### PR DESCRIPTION
Detecting ipv6 was tried after testing for ipv4, and in cases that there was an ipv4 represented as ipv6, it would return a false positive. 

#Fix for https://github.com/nats-io/nats.js/issues/635