### PR TITLE
ci(*): fixed package actions, deno version

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -15,7 +15,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.x.x]
+        deno-version: [1.45.x]
         node-version: [ 22.x ]
     permissions:
       contents: read

--- a/.github/workflows/jetstream.yml
+++ b/.github/workflows/jetstream.yml
@@ -15,7 +15,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.x.x]
+        deno-version: [1.45.x]
 
     steps:
       - name: Git Checkout JetStream

--- a/.github/workflows/kv.yml
+++ b/.github/workflows/kv.yml
@@ -15,7 +15,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.x.x]
+        deno-version: [1.45.x]
 
     steps:
       - name: Git Checkout Kv

--- a/.github/workflows/npm_build.yml
+++ b/.github/workflows/npm_build.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        deno-version: [ 1.44.4 ]
+        deno-version: [ 1.45.x ]
         module: [ core, jetstream, kv, obj, services ]
         node-version: [22.x]
 

--- a/.github/workflows/obj.yml
+++ b/.github/workflows/obj.yml
@@ -15,7 +15,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.x.x]
+        deno-version: [1.45.x]
 
     steps:
       - name: Git Checkout Obj

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -15,7 +15,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.x.x]
+        deno-version: [1.45.x]
 
     steps:
       - name: Git Checkout Services

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        deno-version: [ 1.44.4 ]
+        deno-version: [ 1.45.x ]
         module: [ core, jetstream, kv, obj, services ]
 
     name: test ${{matrix.module}} with local dependencies

--- a/.github/workflows/transport-node-test.yml
+++ b/.github/workflows/transport-node-test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        deno-version: [ 1.44.4 ]
+        deno-version: [ 1.45.x ]
         node-version: [ 22.x ]
 
     name: test node transport with local dependencies

--- a/deno.json
+++ b/deno.json
@@ -59,7 +59,7 @@
       "@nats-io/services/internal": "./services/src/internal_mod.ts"
     }
   },
-  "workspaces": [
+  "workspace": [
     "./transport-deno",
     "./core",
     "./jetstream",

--- a/jetstream/import_map.json
+++ b/jetstream/import_map.json
@@ -3,7 +3,7 @@
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@1.2.0-4",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.1-2",
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-18",
-    "@nats-io/jetstream/internal": "./src/internal_mod.ts",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-18/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@std/io": "jsr:@std/io@0.224.0"
   }

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -47,7 +47,7 @@
     "setup_win": "choco install deno",
     "cover:html": "/nyc report --reporter=html && open coverage/index.html",
     "coveralls": "shx mkdir -p ./coverage && nyc report --reporter=text-lcov > ./coverage/lcov.info",
-    "check-package": "deno run --allow-all bin/check-bundle-version.ts",
+    "check-package": "cd .. && deno run --allow-all bin/check-bundle-version.ts --module transport-node",
     "version": "deno run -A bin/update-transport-version.ts && git add transport-node/src/node_transport.ts",
     "postversion": "git push && git push --tags",
     "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",


### PR DESCRIPTION
ci(*): check-package script fixes for node tests, import map fixes and clamped version of deno to 1.45.x, ci was pulling older.