### PR TITLE
ported fix 727 from nats.deno

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -110,7 +110,7 @@ export interface SubjectTransformConfig {
 export interface StreamConsumerLimits {
   /**
    * The default `inactive_threshold` applied to consumers.
-   * This value is specified in nanoseconds. Pleause use the `nanos()`
+   * This value is specified in nanoseconds. Please use the `nanos()`
    * function to convert between millis and nanoseconds. Or `millis()`
    * to convert a nanosecond value to millis.
    */
@@ -982,11 +982,12 @@ export interface ConsumerUpdateConfig {
    */
   "max_batch"?: number;
   /**
-   * The maximum expires value that may be set when doing a pull on a Pull Consumer
+   * The maximum expires value that may be set when doing a pull on a Pull Consumer expressed in nanoseconds.
    */
   "max_expires"?: Nanos;
   /**
-   * Duration that instructs the server to clean up ephemeral consumers that are inactive for that long
+   * Duration that instructs the server to clean up ephemeral consumers that are inactive for the specified
+   * time in nanoseconds
    */
   "inactive_threshold"?: Nanos;
   /**

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -182,6 +182,8 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     return new ListerImpl<ConsumerInfo>(subj, filter, this);
   }
 
+  // Fixme: the API returns the number of nanoseconds, but really should return
+  //  millis,
   pause(
     stream: string,
     name: string,
@@ -196,6 +198,8 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     >;
   }
 
+  // Fixme: the API returns the number of nanoseconds, but really should return
+  //  millis,
   resume(
     stream: string,
     name: string,

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -347,7 +347,7 @@ export interface ConsumerAPI {
   delete(stream: string, consumer: string): Promise<boolean>;
 
   /**
-   * Lists all the consumers on the specfied streams
+   * Lists all the consumers on the specified streams
    * @param stream
    */
   list(stream: string): Lister<ConsumerInfo>;

--- a/services/src/service.ts
+++ b/services/src/service.ts
@@ -700,7 +700,7 @@ class NamedEndpointStatsImpl implements NamedEndpointStats {
     const qii = qi as QueuedIteratorImpl<unknown>;
     if (qii?.noIterator === false) {
       // grab stats in the iterator
-      this.processing_time = qii.time;
+      this.processing_time = nanos(qii.time);
       this.num_requests = qii.processed;
       this.average_processing_time =
         this.processing_time > 0 && this.num_requests > 0

--- a/services/src/types.ts
+++ b/services/src/types.ts
@@ -130,11 +130,11 @@ export type NamedEndpointStats = {
    */
   data?: unknown;
   /**
-   * Total processing_time for the service
+   * Total processing_time for the service in nanoseconds
    */
   processing_time: Nanos;
   /**
-   * Average processing_time is the total processing_time divided by the num_requests
+   * Average processing_time is the total processing_time divided by the num_requests in nanoseconds
    */
   average_processing_time: Nanos;
   /**


### PR DESCRIPTION
ported over fix from https://github.com/nats-io/nats.deno/pull/727/files

doc(jetstream,services): modified description of types that are in nanoseconds as jsdoc removes the type alias.

fix(services): `processing_time` was reported in millis instead of nanos


