### PR TITLE
Adjust ArrayBuffer use on DenoBuffer() to use buffer/ArrayBufferLike

### DIFF
--- a/core/src/denobuffer.ts
+++ b/core/src/denobuffer.ts
@@ -76,7 +76,7 @@ export class DenoBuffer implements Reader, Writer {
   _buf: Uint8Array; // contents are the bytes _buf[off : len(_buf)]
   _off: number; // read at _buf[off], write at _buf[_buf.byteLength]
 
-  constructor(ab?: ArrayBuffer) {
+  constructor(ab?: ArrayBufferLike) {
     this._off = 0;
     if (ab == null) {
       this._buf = new Uint8Array(0);

--- a/core/src/parser.ts
+++ b/core/src/parser.ts
@@ -517,14 +517,14 @@ export class Parser {
       (this.state === State.MSG_ARG || this.state === State.MINUS_ERR_ARG ||
         this.state === State.INFO_ARG) && !this.argBuf
     ) {
-      this.argBuf = new DenoBuffer(buf.subarray(this.as, i - this.drop));
+      this.argBuf = new DenoBuffer(buf.subarray(this.as, i - this.drop).buffer);
     }
 
     if (this.state === State.MSG_PAYLOAD && !this.msgBuf) {
       if (!this.argBuf) {
         this.cloneMsgArg();
       }
-      this.msgBuf = new DenoBuffer(buf.subarray(this.as));
+      this.msgBuf = new DenoBuffer(buf.subarray(this.as).buffer);
     }
   }
 
@@ -536,7 +536,7 @@ export class Parser {
     if (this.ma.reply) {
       buf.set(this.ma.reply, s);
     }
-    this.argBuf = new DenoBuffer(buf);
+    this.argBuf = new DenoBuffer(buf.buffer);
     this.ma.subject = buf.subarray(0, s);
     if (this.ma.reply) {
       this.ma.reply = buf.subarray(s);


### PR DESCRIPTION
This PR adjusts DenoBuffer to accept an ArrayBufferLike (instead of an ArrayBuffer ) and adjusts DenoBuffer constructor calls to use the buffer of the view rather than the view itself.

In es2023 and lower, you can get away with a view as a buffer because of duck typing, even though technically you are supposed to use the buffer of the view and not the view itself. Starting with es2024 (and when using Moddable today) these uses will cause a TypeScript compile error.

Signed-off-by: Christopher W. Midgley <chris@koose.com>