### PR TITLE
Refactor object and key-value store watch methods

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,5 @@
 # TODO
 
 ## BUGS
+
+- ObjectStore should report the number of entries in it.

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -858,10 +858,12 @@ export class Bucket implements KV, KvRemove {
     let isUpdate = content === KvWatchInclude.UpdatesOnly || count === 0;
 
     qi._data = oc;
+    let i = 0;
     const iter = await oc.consume({
       callback: (m) => {
         if (!isUpdate) {
-          isUpdate = qi.received >= count;
+          i++;
+          isUpdate = i >= count;
         }
         const e = this.jmToWatchEntry(m, isUpdate);
         if (ignoreDeletes && e.operation === "DEL") {

--- a/migration.md
+++ b/migration.md
@@ -168,3 +168,13 @@ const service = await svc.add({
 
 // other manipulation as per service api...
 ```
+
+### Watch
+
+Object.watch() now returns an `ObjectWatchInfo` which is an `ObjectInfo` but adding the property
+`isUpdate` this property is now true when the watch is notifying of a new entry. Note that previously
+the iterator would yield `ObjectInfo | null`, the `null` signal has been removed. This means that
+when doing a watch on an empty ObjectStore you won't get an update notification until an actual value
+arrives.
+
+

--- a/obj/src/types.ts
+++ b/obj/src/types.ts
@@ -56,6 +56,10 @@ export type ObjectStoreMeta = {
   metadata?: Record<string, string>;
 };
 
+export interface ObjectWatchInfo extends ObjectInfo {
+  isUpdate: boolean;
+}
+
 export interface ObjectInfo extends ObjectStoreMeta {
   /**
    * The name of the bucket where the object is stored.
@@ -316,7 +320,7 @@ export interface ObjectStore {
         includeHistory?: boolean;
       }
     >,
-  ): Promise<QueuedIterator<ObjectInfo | null>>;
+  ): Promise<QueuedIterator<ObjectWatchInfo>>;
 
   /**
    * Seals the object store preventing any further modifications.


### PR DESCRIPTION
Update the `watch` methods in ObjectStore and KeyValue classes to use `ObjectWatchInfo` and `KvWatchEntry` types. Removed use of null signals, replaced with property `isUpdate` to indicate new entries. Added relevant tests to validate the changes.