### PR TITLE
fix(obj): Re-exported StorageType and Placement from objectstore module

### DIFF
--- a/obj/src/internal_mod.ts
+++ b/obj/src/internal_mod.ts
@@ -8,6 +8,9 @@ export type {
   ObjectStoreOptions,
   ObjectStorePutOpts,
   ObjectStoreStatus,
+  Placement,
 } from "./types.ts";
+
+export { StorageType } from "./types.ts";
 
 export { Objm } from "./objectstore.ts";

--- a/obj/src/mod.ts
+++ b/obj/src/mod.ts
@@ -8,6 +8,9 @@ export type {
   ObjectStoreOptions,
   ObjectStorePutOpts,
   ObjectStoreStatus,
+  Placement,
 } from "./internal_mod.ts";
+
+export { StorageType } from "./internal_mod.ts";
 
 export { Objm } from "./objectstore.ts";

--- a/obj/src/types.ts
+++ b/obj/src/types.ts
@@ -20,7 +20,11 @@ import type {
   StreamInfo,
   StreamInfoRequestOptions,
 } from "@nats-io/jetstream";
+
 import type { MsgHdrs, Nanos, QueuedIterator } from "@nats-io/nats-core";
+
+export type { Placement } from "@nats-io/jetstream";
+export { StorageType } from "@nats-io/jetstream";
 
 export type ObjectStoreLink = {
   /**


### PR DESCRIPTION
This commit enhances the `internal_mod.ts`, `mod.ts`, and `types.ts` files by exporting the `StorageType` and `Placement` types from the "@nats-io/jetstream" library. This change ensures that these types are available for use in applications that use objectstore.

Fix #52 