### PR TITLE
refactor(core): Consolidate Subscription type and remove Base interface

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -359,11 +359,6 @@ export interface ServersChanged {
   readonly deleted: string[];
 }
 
-/**
- * Type alias for NATS core subscriptions
- */
-export type Subscription = Sub<Msg>;
-
 export enum Match {
   // Exact option is case sensitive
   Exact = 0,
@@ -696,7 +691,7 @@ export function syncIterator<T>(src: AsyncIterable<T>): SyncIterator<T> {
 /**
  * Basic interface to a Subscription type
  */
-export interface Sub<T> extends AsyncIterable<T> {
+export interface Subscription extends AsyncIterable<Msg> {
   /** A promise that resolves when the subscription closes */
   closed: Promise<void>;
 
@@ -729,7 +724,7 @@ export interface Sub<T> extends AsyncIterable<T> {
   /**
    * @ignore
    */
-  callback(err: NatsError | null, msg: Msg): void;
+  callback: MsgCallback<Msg>;
 
   /**
    * Returns the subject that was used to create the subscription.
@@ -1087,15 +1082,6 @@ export const DEFAULT_PORT = 4222;
 export const DEFAULT_HOST = "127.0.0.1";
 
 export type ConnectFn = (opts: ConnectionOptions) => Promise<NatsConnection>;
-
-export interface Base {
-  subject: string;
-  callback: (error: NatsError | null, msg: Msg) => void;
-  received: number;
-  timeout?: number | null;
-  max?: number | undefined;
-  draining: boolean;
-}
 
 export interface URLParseFn {
   (u: string, encrypted?: boolean): string;

--- a/core/src/internal_mod.ts
+++ b/core/src/internal_mod.ts
@@ -108,7 +108,6 @@ export type {
   ServersChanged,
   Stats,
   Status,
-  Sub,
   SubOpts,
   Subscription,
   SubscriptionOptions,

--- a/core/src/mod.ts
+++ b/core/src/mod.ts
@@ -76,7 +76,6 @@ export type {
   ServersChanged,
   Stats,
   Status,
-  Sub,
   SubOpts,
   Subscription,
   SubscriptionOptions,

--- a/core/src/protocol.ts
+++ b/core/src/protocol.ts
@@ -32,7 +32,6 @@ import { Features, parseSemVer } from "./semver.ts";
 import { DebugEvents, ErrorCode, Events, NatsError } from "./core.ts";
 
 import type {
-  Base,
   ConnectionOptions,
   Dispatcher,
   Msg,
@@ -101,7 +100,7 @@ export class Connect {
 }
 
 export class SubscriptionImpl extends QueuedIteratorImpl<Msg>
-  implements Base, Subscription {
+  implements Subscription {
   sid!: number;
   queue?: string;
   draining: boolean;

--- a/services/src/service.ts
+++ b/services/src/service.ts
@@ -32,7 +32,7 @@ import type {
   PublishOptions,
   QueuedIterator,
   ReviverFn,
-  Sub,
+  Subscription,
 } from "@nats-io/nats-core/internal";
 
 import {
@@ -239,7 +239,7 @@ type ServiceSubscription<T = unknown> =
   & NamedEndpoint
   & {
     internal: boolean;
-    sub: Sub<T>;
+    sub: Subscription;
     qi?: QueuedIterator<T>;
     stats: NamedEndpointStatsImpl;
     metadata?: Record<string, string>;


### PR DESCRIPTION
Renamed internal `Sub` interface to `Subscription` removing the type alias `Subscription`. Removed the unnecessary `Base` and `Sub` interface, simplifying the codebase and reducing redundancy. The `Sub` interface was required for legacy JetStream subscriptions.