### PR TITLE
fix(jetstream): direct get api now uses the configured timeout in the context

### DIFF
--- a/jetstream/src/jsm.ts
+++ b/jetstream/src/jsm.ts
@@ -70,6 +70,7 @@ export class DirectStreamAPIImpl extends BaseApiClientImpl
     const r = await this.nc.request(
       subj,
       payload,
+      { timeout: this.timeout },
     );
 
     // response is not a JS.API response


### PR DESCRIPTION
This is a cherry pick from https://github.com/nats-io/nats.deno/pull/729

Fix #96

Thanks @SalvaChiLlo