### PR TITLE
removed deprecations and exported some missing symbols

### DIFF
--- a/jetstream/src/internal_mod.ts
+++ b/jetstream/src/internal_mod.ts
@@ -85,6 +85,7 @@ export type {
 export type { StreamNames } from "./jsbaseclient_api.ts";
 export type {
   AccountLimits,
+  ApiError,
   ApiPagedRequest,
   ClusterInfo,
   ConsumerConfig,

--- a/jetstream/src/mod.ts
+++ b/jetstream/src/mod.ts
@@ -39,6 +39,7 @@ export type {
   AbortOnMissingResource,
   AccountLimits,
   Advisory,
+  ApiError,
   ApiPagedRequest,
   Bind,
   BoundPushConsumerOptions,

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -78,7 +78,6 @@ import type {
   KvEntry,
   KvOptions,
   KvPutOptions,
-  KvRemove,
   KvStatus,
   KvWatchEntry,
   KvWatchOptions,
@@ -263,7 +262,7 @@ export class Kvm {
   }
 }
 
-export class Bucket implements KV, KvRemove {
+export class Bucket implements KV {
   js: JetStreamClient;
   jsm: JetStreamManager;
   stream!: string;
@@ -328,20 +327,11 @@ export class Bucket implements KV, KvRemove {
     this.stream = sc.name = opts.streamName ?? this.bucketName();
     sc.retention = RetentionPolicy.Limits;
     sc.max_msgs_per_subject = bo.history;
-    if (bo.maxBucketSize) {
-      bo.max_bytes = bo.maxBucketSize;
-    }
     if (bo.max_bytes) {
       sc.max_bytes = bo.max_bytes;
     }
     sc.max_msg_size = bo.maxValueSize;
     sc.storage = bo.storage;
-    const location = opts.placementCluster ?? "";
-    if (location) {
-      opts.placement = {} as Placement;
-      opts.placement.cluster = location;
-      opts.placement.tags = [];
-    }
     if (opts.placement) {
       sc.placement = opts.placement;
     }

--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -86,10 +86,7 @@ export interface KvLimits {
    * The maximum number of bytes on the KV
    */
   max_bytes: number;
-  /**
-   * @deprecated use max_bytes
-   */
-  maxBucketSize: number;
+
   /**
    * The maximum size of a value on the KV
    */
@@ -121,10 +118,6 @@ export interface KvLimits {
    * List of Stream names to replicate into this KV
    */
   sources?: StreamSource[];
-  /**
-   * @deprecated: use placement
-   */
-  placementCluster: string;
 
   /**
    * deprecated: use storage
@@ -148,12 +141,6 @@ export interface KvStatus extends KvLimits {
    * Number of entries in the KV
    */
   values: number;
-
-  /**
-   * @deprecated
-   * FIXME: remove this on 1.8
-   */
-  bucket_location: string;
 
   /**
    * The StreamInfo backing up the KV
@@ -201,13 +188,6 @@ export interface KvOptions extends KvLimits {
    * 2.10.x and better.
    */
   metadata?: Record<string, string>;
-}
-
-/**
- * @deprecated use purge(k)
- */
-export interface KvRemove {
-  remove(k: string): Promise<void>;
 }
 
 export enum KvWatchInclude {
@@ -280,11 +260,6 @@ export interface RoKV {
   watch(
     opts?: KvWatchOptions,
   ): Promise<QueuedIterator<KvWatchEntry>>;
-
-  /**
-   * @deprecated - this api is removed.
-   */
-  close(): Promise<void>;
 
   /**
    * Returns information about the Kv

--- a/obj/src/internal_mod.ts
+++ b/obj/src/internal_mod.ts
@@ -8,6 +8,7 @@ export type {
   ObjectStoreOptions,
   ObjectStorePutOpts,
   ObjectStoreStatus,
+  ObjectWatchInfo,
   Placement,
 } from "./types.ts";
 

--- a/obj/src/mod.ts
+++ b/obj/src/mod.ts
@@ -8,6 +8,7 @@ export type {
   ObjectStoreOptions,
   ObjectStorePutOpts,
   ObjectStoreStatus,
+  ObjectWatchInfo,
   Placement,
 } from "./internal_mod.ts";
 

--- a/obj/src/types.ts
+++ b/obj/src/types.ts
@@ -161,10 +161,7 @@ export type ObjectStoreStatus = {
    */
   compression: boolean;
 };
-/**
- * @deprecated {@link ObjectStoreStatus}
- */
-export type ObjectStoreInfo = ObjectStoreStatus;
+
 export type ObjectStoreOptions = {
   /**
    * A description for the object store


### PR DESCRIPTION
- fix(jetstream): exported ApiError
- change(kv): removed deprecated KV apis (`KvRemove` - `remove(k)=>Promise<void>`, `close()=>Promise<void>`) and - - options (`maxBucketSize`, `placementCluster`, `bucket_location`)
- fix(obj): exported ObjectWatchInfo type
- change(obj): removed deprecated `ObjectStoreInfo` - use `ObjectStoreStatus`