### PR TITLE
Flexible conn

### DIFF
--- a/core/src/ws_transport.ts
+++ b/core/src/ws_transport.ts
@@ -138,7 +138,7 @@ export class WsTransport implements Transport {
     this.socket.onclose = (evt: CloseEvent) => {
       this.socketClosed = true;
       let reason: Error | undefined;
-      if (!evt.wasClean) {
+      if (!evt.wasClean && evt.reason !== "") {
         reason = new Error(evt.reason);
       }
       this._closed(reason);

--- a/core/tests/authenticator_test.ts
+++ b/core/tests/authenticator_test.ts
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import { _setup, cleanup } from "test_helpers";
-import { connect } from "./connect.ts";
+import { cleanup, setup } from "test_helpers";
 
 import {
   credsAuthenticator,
@@ -74,7 +73,7 @@ async function testAuthenticatorFn(
     return fn(nonce);
   };
   conf = Object.assign({}, conf, { debug });
-  const { ns, nc } = await _setup(connect, conf, {
+  const { ns, nc } = await setup(conf, {
     authenticator,
   });
 

--- a/core/tests/autounsub_test.ts
+++ b/core/tests/autounsub_test.ts
@@ -16,12 +16,11 @@ import { assertEquals, assertRejects } from "jsr:@std/assert";
 
 import { createInbox, Empty, errors } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl, Subscription } from "../src/internal_mod.ts";
-import { _setup, cleanup, Lock } from "test_helpers";
-import { connect } from "./connect.ts";
+import { cleanup, Lock, setup } from "test_helpers";
 import { TimeoutError } from "../src/errors.ts";
 
 Deno.test("autounsub - max option", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 10 });
   for (let i = 0; i < 20; i++) {
@@ -33,7 +32,7 @@ Deno.test("autounsub - max option", async () => {
 });
 
 Deno.test("autounsub - unsubscribe", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 10 });
   sub.unsubscribe(11);
@@ -46,7 +45,7 @@ Deno.test("autounsub - unsubscribe", async () => {
 });
 
 Deno.test("autounsub - can unsub from auto-unsubscribed", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1 });
   for (let i = 0; i < 20; i++) {
@@ -59,7 +58,7 @@ Deno.test("autounsub - can unsub from auto-unsubscribed", async () => {
 });
 
 Deno.test("autounsub - can break to unsub", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 20 });
   const iter = (async () => {
@@ -77,7 +76,7 @@ Deno.test("autounsub - can break to unsub", async () => {
 });
 
 Deno.test("autounsub - can change auto-unsub to a higher value", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1 });
   sub.unsubscribe(10);
@@ -90,7 +89,7 @@ Deno.test("autounsub - can change auto-unsub to a higher value", async () => {
 });
 
 Deno.test("autounsub - request receives expected count with multiple helpers", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
 
   const fn = async (sub: Subscription) => {
@@ -117,7 +116,7 @@ Deno.test("autounsub - request receives expected count with multiple helpers", a
 });
 
 Deno.test("autounsub - manual request receives expected count with multiple helpers", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const lock = Lock(5);
 
@@ -141,7 +140,7 @@ Deno.test("autounsub - manual request receives expected count with multiple help
 });
 
 Deno.test("autounsub - check subscription leaks", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subj = createInbox();
   const sub = nc.subscribe(subj);
@@ -151,7 +150,7 @@ Deno.test("autounsub - check subscription leaks", async () => {
 });
 
 Deno.test("autounsub - check request leaks", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subj = createInbox();
 
@@ -187,7 +186,7 @@ Deno.test("autounsub - check request leaks", async () => {
 });
 
 Deno.test("autounsub - check cancelled request leaks", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subj = createInbox();
 
@@ -214,7 +213,7 @@ Deno.test("autounsub - check cancelled request leaks", async () => {
 });
 
 Deno.test("autounsub - timeout cancelled request leaks", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subj = createInbox();
 

--- a/core/tests/basics_test.ts
+++ b/core/tests/basics_test.ts
@@ -44,7 +44,7 @@ import type {
   PublishOptions,
   SubscriptionImpl,
 } from "../src/internal_mod.ts";
-import { _setup, cleanup, Lock, NatsServer } from "test_helpers";
+import { cleanup, Lock, NatsServer, setup } from "test_helpers";
 import { connect } from "./connect.ts";
 import { errors } from "../src/errors.ts";
 
@@ -87,14 +87,14 @@ Deno.test("basics - fail connect", async () => {
 });
 
 Deno.test("basics - publish", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   nc.publish(createInbox());
   await nc.flush();
   await cleanup(ns, nc);
 });
 
 Deno.test("basics - no publish without subject", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   assertThrows(
     () => {
       nc.publish("");
@@ -106,7 +106,7 @@ Deno.test("basics - no publish without subject", async () => {
 });
 
 Deno.test("basics - pubsub", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const iter = (async () => {
@@ -122,7 +122,7 @@ Deno.test("basics - pubsub", async () => {
 });
 
 Deno.test("basics - subscribe and unsubscribe", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1000, queue: "aaa" });
@@ -157,7 +157,7 @@ Deno.test("basics - subscribe and unsubscribe", async () => {
 });
 
 Deno.test("basics - subscriptions iterate", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const lock = Lock();
   const subj = createInbox();
   const sub = nc.subscribe(subj);
@@ -173,7 +173,7 @@ Deno.test("basics - subscriptions iterate", async () => {
 });
 
 Deno.test("basics - subscriptions pass exact subject to cb", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   const subj = `${s}.foo.bar.baz`;
   const sub = nc.subscribe(`${s}.*.*.*`);
@@ -190,7 +190,7 @@ Deno.test("basics - subscriptions pass exact subject to cb", async () => {
 });
 
 Deno.test("basics - subscribe returns Subscription", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj) as SubscriptionImpl;
   assertEquals(sub.sid, 1);
@@ -198,7 +198,7 @@ Deno.test("basics - subscribe returns Subscription", async () => {
 });
 
 Deno.test("basics - wildcard subscriptions", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const single = 3;
   const partial = 2;
@@ -226,7 +226,7 @@ Deno.test("basics - wildcard subscriptions", async () => {
 });
 
 Deno.test("basics - correct data in message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const mp = deferred<Msg>();
   const sub = nc.subscribe(subj);
@@ -246,7 +246,7 @@ Deno.test("basics - correct data in message", async () => {
 });
 
 Deno.test("basics - correct reply in message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   const r = createInbox();
 
@@ -264,7 +264,7 @@ Deno.test("basics - correct reply in message", async () => {
 });
 
 Deno.test("basics - respond returns false if no reply subject set", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   const dr = deferred<boolean>();
   const sub = nc.subscribe(s);
@@ -281,7 +281,7 @@ Deno.test("basics - respond returns false if no reply subject set", async () => 
 });
 
 Deno.test("basics - closed cannot subscribe", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await nc.close();
   let failed = false;
   try {
@@ -295,7 +295,7 @@ Deno.test("basics - closed cannot subscribe", async () => {
 });
 
 Deno.test("basics - close cannot request", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await nc.close();
   let failed = false;
   try {
@@ -309,7 +309,7 @@ Deno.test("basics - close cannot request", async () => {
 });
 
 Deno.test("basics - flush returns promise", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const p = nc.flush();
   if (!p) {
     fail("should have returned a promise");
@@ -319,7 +319,7 @@ Deno.test("basics - flush returns promise", async () => {
 });
 
 Deno.test("basics - unsubscribe after close", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe(createInbox());
   await nc.close();
   sub.unsubscribe();
@@ -327,7 +327,7 @@ Deno.test("basics - unsubscribe after close", async () => {
 });
 
 Deno.test("basics - unsubscribe stops messages", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   // in this case we use a callback otherwise messages are buffered.
   const sub = nc.subscribe(subj, {
@@ -346,7 +346,7 @@ Deno.test("basics - unsubscribe stops messages", async () => {
 });
 
 Deno.test("basics - request", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   const sub = nc.subscribe(s);
   (async () => {
@@ -360,7 +360,7 @@ Deno.test("basics - request", async () => {
 });
 
 Deno.test("basics - request no responders", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await assertRejects(
     () => {
       return nc.request("q", Empty, { timeout: 100 });
@@ -373,7 +373,7 @@ Deno.test("basics - request no responders", async () => {
 });
 
 Deno.test("basics - request no responders noMux", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await assertRejects(
     () => {
       return nc.request("q", Empty, { timeout: 100, noMux: true });
@@ -385,7 +385,7 @@ Deno.test("basics - request no responders noMux", async () => {
 });
 
 Deno.test("basics - request timeout", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   nc.subscribe(s, { callback: () => {} });
   await assertRejects(() => {
@@ -396,7 +396,7 @@ Deno.test("basics - request timeout", async () => {
 });
 
 Deno.test("basics - request timeout noMux", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   nc.subscribe(s, { callback: () => {} });
   await assertRejects(() => {
@@ -407,7 +407,7 @@ Deno.test("basics - request timeout noMux", async () => {
 });
 
 Deno.test("basics - request cancel rejects", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const s = createInbox();
 
@@ -428,7 +428,7 @@ Deno.test("basics - request cancel rejects", async () => {
 });
 
 Deno.test("basics - old style requests", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   nc.subscribe("q", {
     callback: (_err, msg) => {
       msg.respond("hello");
@@ -447,7 +447,7 @@ Deno.test("basics - old style requests", async () => {
 });
 
 Deno.test("basics - reply can only be used with noMux", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   nc.subscribe("q", {
     callback: (_err, msg) => {
       msg.respond("hello");
@@ -466,7 +466,7 @@ Deno.test("basics - reply can only be used with noMux", async () => {
 });
 
 Deno.test("basics - request with headers", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   const sub = nc.subscribe(s);
   (async () => {
@@ -486,7 +486,7 @@ Deno.test("basics - request with headers", async () => {
 });
 
 Deno.test("basics - request with headers and custom subject", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const s = createInbox();
   const sub = nc.subscribe(s);
   (async () => {
@@ -508,7 +508,7 @@ Deno.test("basics - request with headers and custom subject", async () => {
 });
 
 Deno.test("basics - request requires a subject", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await assertRejects(
     () => {
       //@ts-ignore: testing
@@ -521,7 +521,7 @@ Deno.test("basics - request requires a subject", async () => {
 });
 
 Deno.test("basics - closed returns error", async () => {
-  const { ns, nc } = await _setup(connect, {}, { reconnect: false });
+  const { ns, nc } = await setup({}, { reconnect: false });
   setTimeout(() => {
     (nc as NatsConnectionImpl).protocol.sendCommand("Y\r\n");
   }, 100);
@@ -531,7 +531,7 @@ Deno.test("basics - closed returns error", async () => {
 });
 
 Deno.test("basics - subscription with timeout", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe(createInbox(), { max: 1, timeout: 250 });
   await assertRejects(
     async () => {
@@ -546,7 +546,7 @@ Deno.test("basics - subscription with timeout", async () => {
 });
 
 Deno.test("basics - subscription expecting 2 doesn't fire timeout", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 2, timeout: 500 });
   (async () => {
@@ -566,7 +566,7 @@ Deno.test("basics - subscription expecting 2 doesn't fire timeout", async () => 
 });
 
 Deno.test("basics - subscription timeout auto cancels", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   let c = 0;
   const sub = nc.subscribe(subj, { max: 2, timeout: 300 });
@@ -586,7 +586,7 @@ Deno.test("basics - subscription timeout auto cancels", async () => {
 });
 
 Deno.test("basics - no mux requests create normal subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   nc.request(createInbox(), Empty, { timeout: 1000, noMux: true }).then();
   assertEquals(nci.protocol.subscriptions.size(), 1);
@@ -600,7 +600,7 @@ Deno.test("basics - no mux requests create normal subs", async () => {
 });
 
 Deno.test("basics - no mux requests timeout", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   nc.subscribe(subj, { callback: () => {} });
   await assertRejects(
@@ -614,7 +614,7 @@ Deno.test("basics - no mux requests timeout", async () => {
 });
 
 Deno.test("basics - no mux requests", async () => {
-  const { ns, nc } = await _setup(connect, { max_payload: 2048 });
+  const { ns, nc } = await setup({ max_payload: 2048 });
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const data = Uint8Array.from([1234]);
@@ -630,7 +630,7 @@ Deno.test("basics - no mux requests", async () => {
 });
 
 Deno.test("basics - no mux request timeout doesn't leak subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   nc.subscribe("q", { callback: () => {} });
   const nci = nc as NatsConnectionImpl;
@@ -648,7 +648,7 @@ Deno.test("basics - no mux request timeout doesn't leak subs", async () => {
 });
 
 Deno.test("basics - no mux request no responders doesn't leak subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const nci = nc as NatsConnectionImpl;
   assertEquals(nci.protocol.subscriptions.size(), 0);
@@ -661,7 +661,7 @@ Deno.test("basics - no mux request no responders doesn't leak subs", async () =>
 });
 
 Deno.test("basics - no mux request no perms doesn't leak subs", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "s",
@@ -703,7 +703,7 @@ Deno.test("basics - no mux request no perms doesn't leak subs", async () => {
 });
 
 Deno.test("basics - max_payload errors", async () => {
-  const { ns, nc } = await _setup(connect, { max_payload: 2048 });
+  const { ns, nc } = await setup({ max_payload: 2048 });
   const nci = nc as NatsConnectionImpl;
   assert(nci.protocol.info);
   const big = new Uint8Array(nci.protocol.info.max_payload + 1);
@@ -756,7 +756,7 @@ Deno.test("basics - max_payload errors", async () => {
 });
 
 Deno.test("basics - close cancels requests", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   nc.subscribe("q", { callback: () => {} });
 
   const done = assertRejects(
@@ -774,7 +774,7 @@ Deno.test("basics - close cancels requests", async () => {
 });
 
 Deno.test("basics - empty message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const mp = deferred<Msg>();
   const sub = nc.subscribe(subj);
@@ -793,7 +793,7 @@ Deno.test("basics - empty message", async () => {
 });
 
 Deno.test("basics - msg buffers dont overwrite", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const N = 100;
   const sub = nc.subscribe(">");
@@ -858,7 +858,7 @@ Deno.test("basics - get client ip", async () => {
 });
 
 Deno.test("basics - subs pending count", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
 
   const sub = nc.subscribe(subj, { max: 10 });
@@ -904,7 +904,7 @@ Deno.test("basics - create inbox", () => {
 });
 
 Deno.test("basics - custom prefix", async () => {
-  const { ns, nc } = await _setup(connect, {}, { inboxPrefix: "_x" });
+  const { ns, nc } = await setup({}, { inboxPrefix: "_x" });
   const subj = createInbox();
   nc.subscribe(subj, {
     max: 1,
@@ -919,7 +919,7 @@ Deno.test("basics - custom prefix", async () => {
 });
 
 Deno.test("basics - custom prefix noMux", async () => {
-  const { ns, nc } = await _setup(connect, {}, { inboxPrefix: "_y" });
+  const { ns, nc } = await setup({}, { inboxPrefix: "_y" });
   const subj = createInbox();
   nc.subscribe(subj, {
     max: 1,
@@ -934,14 +934,14 @@ Deno.test("basics - custom prefix noMux", async () => {
 });
 
 Deno.test("basics - debug", async () => {
-  const { ns, nc } = await _setup(connect, {}, { debug: true });
+  const { ns, nc } = await setup({}, { debug: true });
   await nc.flush();
   await cleanup(ns, nc);
   assertEquals(nc.isClosed(), true);
 });
 
 Deno.test("basics - subscription with timeout cancels on message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1, timeout: 500 }) as SubscriptionImpl;
   assert(sub.timer !== undefined);
@@ -956,7 +956,7 @@ Deno.test("basics - subscription with timeout cancels on message", async () => {
 });
 
 Deno.test("basics - subscription cb with timeout cancels on message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const done = Lock();
   const sub = nc.subscribe(subj, {
@@ -996,7 +996,7 @@ Deno.test("basics - port and server are mutually exclusive", async () => {
 });
 
 Deno.test("basics - rtt", async () => {
-  const { ns, nc } = await _setup(connect, {}, {
+  const { ns, nc } = await setup({}, {
     maxReconnectAttempts: 1,
     reconnectTimeWait: 750,
   });
@@ -1021,7 +1021,7 @@ Deno.test("basics - rtt", async () => {
 });
 
 Deno.test("basics - request many count", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -1052,7 +1052,7 @@ Deno.test("basics - request many count", async () => {
 });
 
 Deno.test("basics - request many jitter", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -1083,7 +1083,7 @@ Deno.test("basics - request many jitter", async () => {
 });
 
 Deno.test("basics - request many sentinel", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -1115,7 +1115,7 @@ Deno.test("basics - request many sentinel", async () => {
 });
 
 Deno.test("basics - request many sentinel - partial response", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -1146,7 +1146,7 @@ Deno.test("basics - request many sentinel - partial response", async () => {
 });
 
 Deno.test("basics - request many wait for timer - no respone", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -1175,7 +1175,7 @@ Deno.test("basics - request many wait for timer - no respone", async () => {
 });
 
 Deno.test("basics - request many waits for timer late response", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -1205,7 +1205,7 @@ Deno.test("basics - request many waits for timer late response", async () => {
 });
 
 Deno.test("basics - server version", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   assertEquals(nci.protocol.features.require("3.0.0"), false);
   assertEquals(nci.protocol.features.require("2.8.2"), true);
@@ -1220,7 +1220,7 @@ Deno.test("basics - server version", async () => {
 });
 
 Deno.test("basics - info", async () => {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup();
   assertExists(nc.info);
   await cleanup(ns, nc);
 });
@@ -1332,7 +1332,7 @@ Deno.test("basics - ipv4 mapped to ipv6", async () => {
 });
 
 Deno.test("basics - data types empty", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = nuid.next();
   nc.subscribe(subj, {
     callback: (_err, msg) => {
@@ -1363,7 +1363,7 @@ Deno.test("basics - data types empty", async () => {
 });
 
 Deno.test("basics - data types string", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = nuid.next();
   nc.subscribe(subj, {
     callback: (_err, msg) => {
@@ -1397,7 +1397,7 @@ Deno.test("basics - data types string", async () => {
 });
 
 Deno.test("basics - json reviver", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = nuid.next();
 
   nc.subscribe(subj, {
@@ -1426,7 +1426,7 @@ Deno.test("basics - json reviver", async () => {
 });
 
 Deno.test("basics - sync subscription", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = nuid.next();
 
   const sub = nc.subscribe(subj);
@@ -1444,7 +1444,7 @@ Deno.test("basics - sync subscription", async () => {
 });
 
 Deno.test("basics - publish message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe("q");
 
   const nis = new MM(nc);
@@ -1466,7 +1466,7 @@ Deno.test("basics - publish message", async () => {
 });
 
 Deno.test("basics - respond message", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe("q");
 
   const nis = new MM(nc);
@@ -1499,7 +1499,7 @@ Deno.test("basics - resolve false", async () => {
 });
 
 Deno.test("basics - stats", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const cid = nc.info?.client_id || -1;
   if (cid === -1) {

--- a/core/tests/binary_test.ts
+++ b/core/tests/binary_test.ts
@@ -16,12 +16,11 @@
 import { assertEquals } from "jsr:@std/assert";
 import { createInbox, deferred } from "../src/internal_mod.ts";
 import type { Msg } from "../src/internal_mod.ts";
-import { _setup, cleanup } from "test_helpers";
-import { connect } from "./connect.ts";
+import { cleanup, setup } from "test_helpers";
 
 function macro(input: Uint8Array) {
   return async () => {
-    const { ns, nc } = await _setup(connect);
+    const { ns, nc } = await setup();
     const subj = createInbox();
     const dm = deferred<Msg>();
     const sub = nc.subscribe(subj, { max: 1 });

--- a/core/tests/drain_test.ts
+++ b/core/tests/drain_test.ts
@@ -20,18 +20,18 @@ import {
 } from "jsr:@std/assert";
 import { createInbox } from "../src/internal_mod.ts";
 import { Lock } from "test_helpers";
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 import { connect } from "./connect.ts";
 import { errors } from "../src/errors.ts";
 
 Deno.test("drain - connection drains when no subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await nc.drain();
   await cleanup(ns);
 });
 
 Deno.test("drain - connection drain", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nc2 = await connect({ port: ns.port });
 
   const max = 1000;
@@ -74,7 +74,7 @@ Deno.test("drain - connection drain", async () => {
 });
 
 Deno.test("drain - subscription drain", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const lock = Lock();
   const subj = createInbox();
   let c1 = 0;
@@ -114,7 +114,7 @@ Deno.test("drain - subscription drain", async () => {
 });
 
 Deno.test("drain - publish after drain fails", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   nc.subscribe(subj);
   await nc.drain();
@@ -132,7 +132,7 @@ Deno.test("drain - publish after drain fails", async () => {
 });
 
 Deno.test("drain - reject reqrep during connection drain", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const done = nc.drain();
   await assertRejects(() => {
     return nc.request("foo");
@@ -142,7 +142,7 @@ Deno.test("drain - reject reqrep during connection drain", async () => {
 });
 
 Deno.test("drain - reject drain on closed", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await nc.close();
   await assertRejects(() => {
     return nc.drain();
@@ -151,7 +151,7 @@ Deno.test("drain - reject drain on closed", async () => {
 });
 
 Deno.test("drain - reject drain on draining", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const done = nc.drain();
   await assertRejects(() => {
     return nc.drain();
@@ -161,7 +161,7 @@ Deno.test("drain - reject drain on draining", async () => {
 });
 
 Deno.test("drain - reject subscribe on draining", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const done = nc.drain();
   assertThrows(() => {
     return nc.subscribe("foo");
@@ -172,7 +172,7 @@ Deno.test("drain - reject subscribe on draining", async () => {
 });
 
 Deno.test("drain - reject subscription drain on closed sub callback", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe("foo", { callback: () => {} });
   sub.unsubscribe();
   await assertRejects(
@@ -187,7 +187,7 @@ Deno.test("drain - reject subscription drain on closed sub callback", async () =
 });
 
 Deno.test("drain - reject subscription drain on closed sub iter", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe("foo");
   const d = (async () => {
     for await (const _ of sub) {
@@ -209,7 +209,7 @@ Deno.test("drain - reject subscription drain on closed sub iter", async () => {
 });
 
 Deno.test("drain - connection is closed after drain", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   nc.subscribe("foo");
   await nc.drain();
   assert(nc.isClosed());
@@ -217,7 +217,7 @@ Deno.test("drain - connection is closed after drain", async () => {
 });
 
 Deno.test("drain - reject subscription drain on closed", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const sub = nc.subscribe("foo");
   await nc.close();
   await assertRejects(() => {
@@ -227,7 +227,7 @@ Deno.test("drain - reject subscription drain on closed", async () => {
 });
 
 Deno.test("drain - multiple sub drain returns same promise", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const p1 = sub.drain();
@@ -240,7 +240,7 @@ Deno.test("drain - multiple sub drain returns same promise", async () => {
 });
 
 Deno.test("drain - publisher drain", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nc1 = await connect({ port: ns.port });
 
   const subj = createInbox();

--- a/core/tests/events_test.ts
+++ b/core/tests/events_test.ts
@@ -20,10 +20,10 @@ import type {
   NatsConnectionImpl,
   ServersChanged,
 } from "../src/internal_mod.ts";
-import { _setup } from "test_helpers";
+import { setup } from "test_helpers";
 
 Deno.test("events - close on close", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   nc.close().then();
   const status = await nc.closed();
   await ns.stop();
@@ -32,7 +32,7 @@ Deno.test("events - close on close", async () => {
 
 Deno.test("events - disconnect and close", async () => {
   const lock = Lock(2);
-  const { ns, nc } = await _setup(connect, {}, { reconnect: false });
+  const { ns, nc } = await setup({}, { reconnect: false });
   (async () => {
     for await (const s of nc.status()) {
       switch (s.type) {
@@ -52,7 +52,7 @@ Deno.test("events - disconnect and close", async () => {
   assertEquals(v, undefined);
 });
 
-Deno.test("events - disconnect, reconnect", async () => {
+Deno.test("events - disreconnect", async () => {
   const cluster = await NatsServer.cluster();
   const nc = await connect(
     {

--- a/core/tests/headers_test.ts
+++ b/core/tests/headers_test.ts
@@ -31,7 +31,7 @@ import type {
 import { NatsServer } from "../../test_helpers/launcher.ts";
 import { assert, assertEquals, assertThrows } from "jsr:@std/assert";
 import { TestDispatcher } from "./parser_test.ts";
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 import { errors } from "../src/errors.ts";
 
 Deno.test("headers - illegal key", () => {
@@ -346,7 +346,7 @@ Deno.test("headers - code/description", () => {
 });
 
 Deno.test("headers - codec", async () => {
-  const { ns, nc } = await _setup(connect, {}, {});
+  const { ns, nc } = await setup({}, {});
 
   nc.subscribe("foo", {
     callback: (_err, msg) => {
@@ -363,7 +363,7 @@ Deno.test("headers - codec", async () => {
 });
 
 Deno.test("headers - malformed headers", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   type t = {

--- a/core/tests/iterators_test.ts
+++ b/core/tests/iterators_test.ts
@@ -23,11 +23,11 @@ import {
   syncIterator,
 } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/internal_mod.ts";
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 import { errors } from "../src/errors.ts";
 
 Deno.test("iterators - unsubscribe breaks and closes", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const done = (async () => {
@@ -45,7 +45,7 @@ Deno.test("iterators - unsubscribe breaks and closes", async () => {
 });
 
 Deno.test("iterators - autounsub breaks and closes", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 2 });
   const lock = Lock(2);
@@ -95,7 +95,7 @@ Deno.test("iterators - permission error breaks and closes", async () => {
 });
 
 Deno.test("iterators - unsubscribing closes", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const lock = Lock();
@@ -112,7 +112,7 @@ Deno.test("iterators - unsubscribing closes", async () => {
 });
 
 Deno.test("iterators - connection close closes", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const lock = Lock();
@@ -130,7 +130,7 @@ Deno.test("iterators - connection close closes", async () => {
 });
 
 Deno.test("iterators - cb subs fail iterator", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const sub = nc.subscribe(subj, { callback: () => {} });
 
@@ -150,7 +150,7 @@ Deno.test("iterators - cb subs fail iterator", async () => {
 });
 
 Deno.test("iterators - cb message counts", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const lock = Lock(3);
   const sub = nc.subscribe(subj, {
@@ -194,7 +194,7 @@ Deno.test("iterators - push on done is noop", async () => {
 });
 
 Deno.test("iterators - break cleans up", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subj = createInbox();
   const sub = nc.subscribe(subj);
@@ -213,7 +213,7 @@ Deno.test("iterators - break cleans up", async () => {
 });
 
 Deno.test("iterators - sync iterator", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = nuid.next();
   const sub = nc.subscribe(subj);
   const sync = syncIterator(sub);

--- a/core/tests/json_test.ts
+++ b/core/tests/json_test.ts
@@ -12,16 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { connect } from "./connect.ts";
 import { assertEquals } from "jsr:@std/assert";
 import { createInbox } from "../src/internal_mod.ts";
 import type { Msg } from "../src/internal_mod.ts";
 import { Lock } from "test_helpers";
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 
 function macro(input: unknown) {
   return async () => {
-    const { ns, nc } = await _setup(connect);
+    const { ns, nc } = await setup();
     const lock = Lock();
     const subj = createInbox();
     nc.subscribe(subj, {

--- a/core/tests/mrequest_test.ts
+++ b/core/tests/mrequest_test.ts
@@ -12,8 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { _setup, cleanup } from "test_helpers";
-import { connect } from "./connect.ts";
+import { cleanup, setup } from "test_helpers";
 import type { NatsConnectionImpl } from "../src/internal_mod.ts";
 import {
   createInbox,
@@ -27,7 +26,7 @@ import { assert, assertEquals, assertRejects, fail } from "jsr:@std/assert";
 import { errors } from "../src/errors.ts";
 
 async function requestManyCount(noMux = false): Promise<void> {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
 
   let payload = "";
@@ -71,7 +70,7 @@ Deno.test("mreq - request many count noMux", async () => {
 });
 
 async function requestManyJitter(noMux = false): Promise<void> {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -113,7 +112,7 @@ async function requestManySentinel(
   noMux = false,
   partial = false,
 ): Promise<void> {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -164,7 +163,7 @@ Deno.test("mreq - nomux request many sentinel partial noMux", async () => {
 });
 
 async function requestManyTimerNoResponse(noMux = false): Promise<void> {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -202,7 +201,7 @@ Deno.test("mreq - request many wait for timer noMux - no response", async () => 
 });
 
 async function requestTimerLateResponse(noMux = false): Promise<void> {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -241,7 +240,7 @@ Deno.test("mreq - request many waits for timer late response noMux", async () =>
 });
 
 async function requestManyStopsOnError(noMux = false): Promise<void> {
-  const { ns, nc } = await _setup(connect, {});
+  const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
 
   const subj = createInbox();
@@ -272,7 +271,7 @@ Deno.test("mreq - request many stops on error noMux", async () => {
 });
 
 Deno.test("mreq - pub permission error", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "a",
@@ -313,7 +312,7 @@ Deno.test("mreq - pub permission error", async () => {
 });
 
 Deno.test("mreq - sub permission error", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "a",
@@ -363,7 +362,7 @@ Deno.test("mreq - sub permission error", async () => {
 });
 
 Deno.test("mreq - lost sub permission", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "a",
@@ -425,7 +424,7 @@ Deno.test("mreq - lost sub permission", async () => {
 });
 
 Deno.test("mreq - timeout doesn't leak subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   nc.subscribe("q", { callback: () => {} });
   const nci = nc as NatsConnectionImpl;
@@ -446,7 +445,7 @@ Deno.test("mreq - timeout doesn't leak subs", async () => {
 });
 
 Deno.test("mreq - no responder doesn't leak subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const nci = nc as NatsConnectionImpl;
   assertEquals(nci.protocol.subscriptions.size(), 0);
@@ -472,7 +471,7 @@ Deno.test("mreq - no responder doesn't leak subs", async () => {
 });
 
 Deno.test("mreq - no mux request no perms doesn't leak subs", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "s",

--- a/core/tests/queues_test.ts
+++ b/core/tests/queues_test.ts
@@ -16,11 +16,10 @@
 import { createInbox } from "../src/core.ts";
 import type { Subscription } from "../src/core.ts";
 import { assertEquals } from "jsr:@std/assert";
-import { connect } from "./connect.ts";
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 
 Deno.test("queues - deliver to single queue", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const subs = [];
   for (let i = 0; i < 5; i++) {
@@ -36,7 +35,7 @@ Deno.test("queues - deliver to single queue", async () => {
 });
 
 Deno.test("queues - deliver to multiple queues", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
 
   const fn = (queue: string) => {
@@ -65,7 +64,7 @@ Deno.test("queues - deliver to multiple queues", async () => {
 });
 
 Deno.test("queues - queues and subs independent", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const subs = [];
   let queueCount = 0;

--- a/core/tests/reconnect_test.ts
+++ b/core/tests/reconnect_test.ts
@@ -26,7 +26,7 @@ import {
 } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/nats.ts";
 
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 import { deadline } from "jsr:@std/async";
 import { ConnectionError } from "../src/errors.ts";
 
@@ -272,13 +272,13 @@ Deno.test("reconnect - wait on first connect", async () => {
 
   // stop the server
   await srv.stop();
-  // no reconnect, will quit the client
+  // no re will quit the client
   const err = await nc.closed();
   assertInstanceOf(err, ConnectionError, "connection refused");
 });
 
 Deno.test("reconnect - close stops reconnects", async () => {
-  const { ns, nc } = await _setup(connect, {}, {
+  const { ns, nc } = await setup({}, {
     maxReconnectAttempts: -1,
     reconnectTimeWait: 500,
   });
@@ -307,7 +307,7 @@ Deno.test("reconnect - close stops reconnects", async () => {
     });
   // await some more, because the close could have a timer pending that
   // didn't complete flapping the test on resource leak
-  await delay(750);
+  await delay(1000);
 });
 
 Deno.test("reconnect - stale connections don't close", async () => {
@@ -406,7 +406,7 @@ Deno.test("reconnect - stale connections don't close", async () => {
 });
 
 Deno.test("reconnect - protocol errors don't close client", async () => {
-  const { ns, nc } = await _setup(connect, {}, {
+  const { ns, nc } = await setup({}, {
     maxReconnectAttempts: -1,
     reconnectTimeWait: 500,
   });

--- a/core/tests/resub_test.ts
+++ b/core/tests/resub_test.ts
@@ -13,8 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "./connect.ts";
-import { _setup, cleanup } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 import { createInbox } from "../src/internal_mod.ts";
 import type {
   Msg,
@@ -25,7 +24,7 @@ import { assert, assertEquals, assertExists, fail } from "jsr:@std/assert";
 import type { NatsServer } from "../../test_helpers/launcher.ts";
 
 Deno.test("resub - iter", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subja = createInbox();
 
@@ -54,7 +53,7 @@ Deno.test("resub - iter", async () => {
 });
 
 Deno.test("resub - callback", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
   const subja = createInbox();
   const buf: Msg[] = [];
@@ -111,7 +110,7 @@ async function assertEqualSubs(
 }
 
 Deno.test("resub - removes server interest", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   nc.subscribe("a", {
     callback() {

--- a/deno.json
+++ b/deno.json
@@ -39,7 +39,7 @@
     "enable-npm-workspace": "mv _package.json package.json"
   },
   "fmt": {
-    "include": ["transport-deno/", "bin/", "core/", "debug/", "jetstream/", "kv/", "obj/", "services/", "*.md", "transport-node/"],
+    "include": ["transport-deno/", "bin/", "core/", "debug/", "jetstream/", "kv/", "obj/", "services/", "*.md", "transport-node/", "test_helpers/"],
     "exclude": ["core/lib", "jetstream/lib", "kv/lib","obj/lib", "services/lib", "transport-node/lib", "transport-ws/lib", "*/build", "docs/"]
   },
   "lint": {

--- a/jetstream/tests/consume_test.ts
+++ b/jetstream/tests/consume_test.ts
@@ -14,11 +14,11 @@
  */
 
 import {
-  _setup,
   cleanup,
   connect,
   jetstreamServerConf,
   NatsServer,
+  setup,
 } from "test_helpers";
 import { setupStreamAndConsumer } from "../examples/util.ts";
 import {
@@ -48,7 +48,7 @@ import {
 import type { ConsumerStatus } from "../src/mod.ts";
 
 Deno.test("consumers - consume", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const count = 1000;
   const { stream, consumer } = await setupStreamAndConsumer(nc, count);
@@ -76,7 +76,7 @@ Deno.test("consumers - consume", async () => {
 });
 
 Deno.test("consumers - consume callback rejects iter", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream, consumer } = await setupStreamAndConsumer(nc, 0);
   const js = jetstream(nc);
   const c = await js.consumers.get(stream, consumer);
@@ -156,7 +156,7 @@ Deno.test("consume - heartbeats", async () => {
 });
 
 Deno.test("consume - deleted consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(stream, {
@@ -206,7 +206,7 @@ Deno.test("consume - deleted consumer", async () => {
 });
 
 Deno.test("consume - sub leaks", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -235,7 +235,7 @@ Deno.test("consume - sub leaks", async () => {
 });
 
 Deno.test("consume - drain", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -262,7 +262,7 @@ Deno.test("consume - drain", async () => {
 });
 
 Deno.test("consume - sync", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "messages", subjects: ["hello"] });
 
@@ -289,7 +289,7 @@ Deno.test("consume - sync", async () => {
 });
 
 Deno.test("consume - stream not found request abort", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -322,7 +322,7 @@ Deno.test("consume - stream not found request abort", async () => {
 });
 
 Deno.test("consume - consumer deleted request abort", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -358,7 +358,7 @@ Deno.test("consume - consumer deleted request abort", async () => {
 });
 
 Deno.test("consume - consumer not found request abort", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -392,7 +392,7 @@ Deno.test("consume - consumer not found request abort", async () => {
 });
 
 Deno.test("consume - consumer bind", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -29,11 +29,10 @@ import {
 } from "../src/mod.ts";
 import type { ConsumerMessages, JsMsg } from "../src/mod.ts";
 import {
-  _setup,
   cleanup,
-  connect,
   jetstreamServerConf,
   notCompatible,
+  setup,
 } from "test_helpers";
 import { deadline, deferred, delay } from "@nats-io/nats-core";
 import type {
@@ -46,7 +45,7 @@ import { flakyTest } from "../../test_helpers/mod.ts";
 import { ConsumerNotFoundError } from "../src/jserrors.ts";
 
 Deno.test("ordered consumers - get", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   await assertRejects(
@@ -72,7 +71,7 @@ Deno.test("ordered consumers - get", async () => {
 });
 
 Deno.test("ordered consumers - fetch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -100,7 +99,7 @@ Deno.test("ordered consumers - fetch", async () => {
 });
 
 Deno.test("ordered consumers - consume reset", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -144,7 +143,7 @@ Deno.test("ordered consumers - consume reset", async () => {
 });
 
 Deno.test("ordered consumers - consume", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -167,7 +166,7 @@ Deno.test("ordered consumers - consume", async () => {
 });
 
 Deno.test("ordered consumers - filters consume", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -197,7 +196,7 @@ Deno.test("ordered consumers - filters consume", async () => {
 });
 
 Deno.test("ordered consumers - filters fetch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -223,7 +222,7 @@ Deno.test("ordered consumers - filters fetch", async () => {
 });
 
 Deno.test("ordered consumers - fetch reject consumer type change or concurrency", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -258,7 +257,7 @@ Deno.test("ordered consumers - fetch reject consumer type change or concurrency"
 });
 
 Deno.test("ordered consumers - consume reject consumer type change or concurrency", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -293,7 +292,7 @@ Deno.test("ordered consumers - consume reject consumer type change or concurrenc
 });
 
 Deno.test("ordered consumers - last per subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -328,7 +327,7 @@ Deno.test("ordered consumers - last per subject", async () => {
 });
 
 Deno.test("ordered consumers - start sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -365,7 +364,7 @@ Deno.test("ordered consumers - start sequence", async () => {
 });
 
 Deno.test("ordered consumers - last", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -403,7 +402,7 @@ Deno.test("ordered consumers - last", async () => {
 });
 
 Deno.test("ordered consumers - new", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -443,7 +442,7 @@ Deno.test("ordered consumers - new", async () => {
 });
 
 Deno.test("ordered consumers - start time", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -488,7 +487,7 @@ Deno.test("ordered consumers - start time", async () => {
 });
 
 Deno.test("ordered consumers - start time reset", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -525,7 +524,7 @@ Deno.test("ordered consumers - start time reset", async () => {
 });
 
 Deno.test("ordered consumers - next", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test"] });
   const js = jetstream(nc);
@@ -550,7 +549,7 @@ Deno.test("ordered consumers - next", async () => {
 });
 
 Deno.test("ordered consumers - sub leaks next()", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   //@ts-ignore: test
@@ -564,7 +563,7 @@ Deno.test("ordered consumers - sub leaks next()", async () => {
 });
 
 Deno.test("ordered consumers - sub leaks fetch()", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   //@ts-ignore: test
@@ -584,7 +583,7 @@ Deno.test("ordered consumers - sub leaks fetch()", async () => {
 });
 
 Deno.test("ordered consumers - sub leaks consume()", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   //@ts-ignore: test
@@ -608,7 +607,7 @@ Deno.test("ordered consumers - sub leaks consume()", async () => {
 });
 
 Deno.test("ordered consumers - consume drain", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -629,7 +628,7 @@ Deno.test("ordered consumers - consume drain", async () => {
 });
 
 Deno.test("ordered consumers - headers only", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -644,7 +643,7 @@ Deno.test("ordered consumers - headers only", async () => {
 });
 
 Deno.test("ordered consumers - max deliver", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -659,7 +658,7 @@ Deno.test("ordered consumers - max deliver", async () => {
 });
 
 Deno.test("ordered consumers - mem", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -674,7 +673,7 @@ Deno.test("ordered consumers - mem", async () => {
 });
 
 Deno.test("ordered consumers - inboxPrefix is respected", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf(), {
+  const { ns, nc } = await setup(jetstreamServerConf(), {
     inboxPrefix: "x",
   });
   const jsm = await jetstreamManager(nc);
@@ -696,7 +695,7 @@ Deno.test("ordered consumers - inboxPrefix is respected", async () => {
 });
 
 Deno.test("ordered consumers - fetch deleted consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
 
@@ -725,7 +724,7 @@ Deno.test("ordered consumers - fetch deleted consumer", async () => {
 });
 
 Deno.test("ordered consumers - next deleted consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["hello"] });
@@ -751,7 +750,7 @@ Deno.test("ordered consumers - next deleted consumer", async () => {
 Deno.test(
   "ordered consumers - next stream not found",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
 
     const jsm = await jetstreamManager(nc);
     await jsm.streams.add({ name: "A", subjects: ["hello"] });
@@ -775,7 +774,7 @@ Deno.test(
 Deno.test(
   "ordered consumers - fetch stream not found",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
     const jsm = await jetstreamManager(nc);
     const si = await jsm.streams.add({ name: "A", subjects: ["a"] });
 
@@ -805,7 +804,7 @@ Deno.test(
 );
 
 Deno.test("ordered consumers - consume stream not found request abort", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -833,7 +832,7 @@ Deno.test("ordered consumers - consume stream not found request abort", async ()
 });
 
 Deno.test("ordered consumers - consume consumer deleted request abort", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -863,7 +862,7 @@ Deno.test("ordered consumers - consume consumer deleted request abort", async ()
 });
 
 Deno.test("ordered consumers - bind is rejected", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -899,7 +898,7 @@ Deno.test("ordered consumers - bind is rejected", async () => {
 });
 
 Deno.test("ordered consumers - name prefix", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -929,7 +928,7 @@ Deno.test("ordered consumers - name prefix", async () => {
 });
 
 Deno.test("ordered consumers - fetch reset", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -980,7 +979,7 @@ Deno.test("ordered consumers - fetch reset", async () => {
 });
 
 Deno.test("ordered consumers - consume reset", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -1028,7 +1027,7 @@ Deno.test("ordered consumers - consume reset", async () => {
 });
 
 Deno.test("ordered consumers - next reset", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -1055,7 +1054,7 @@ Deno.test("ordered consumers - next reset", async () => {
 });
 
 Deno.test("ordered consumers - no reset on next", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -1078,7 +1077,7 @@ Deno.test("ordered consumers - no reset on next", async () => {
 });
 
 Deno.test("ordered consumers - initial creation fails, consumer fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -1108,7 +1107,7 @@ Deno.test("ordered consumers - initial creation fails, consumer fails", async ()
 Deno.test(
   "ordered consumers - stale reference recovers",
   async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
     const jsm = await jetstreamManager(nc);
 
     await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -1147,7 +1146,7 @@ Deno.test(
 Deno.test(
   "ordered consumers - consume stale reference recovers",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
     const jsm = await jetstreamManager(nc);
     await jsm.streams.add({ name: "A", subjects: ["a"] });
     const js = jetstream(nc);

--- a/jetstream/tests/consumers_push_test.ts
+++ b/jetstream/tests/consumers_push_test.ts
@@ -4,20 +4,14 @@ import {
   jetstream,
   jetstreamManager,
 } from "../src/mod.ts";
-import {
-  _setup,
-  cleanup,
-  connect,
-  jetstreamServerConf,
-  Lock,
-} from "test_helpers";
+import { cleanup, jetstreamServerConf, Lock, setup } from "test_helpers";
 import { nanos } from "@nats-io/nats-core";
 import { assert, assertEquals, assertExists } from "jsr:@std/assert";
 import type { PushConsumerMessagesImpl } from "../src/pushconsumer.ts";
 import { delay } from "@nats-io/nats-core/internal";
 
 Deno.test("push consumers - basics", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["A.*"] });
@@ -62,7 +56,7 @@ Deno.test("push consumers - basics", async () => {
 });
 
 Deno.test("push consumers - basics cb", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["A.*"] });
@@ -109,8 +103,7 @@ Deno.test("push consumers - basics cb", async () => {
 });
 
 Deno.test("push consumers - queue", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_file_store: 1024 * 1024 * 1024,
@@ -180,8 +173,7 @@ Deno.test("push consumers - queue", async () => {
 });
 
 Deno.test("push consumers - connection status iterator closes", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf(),
   );
   const js = jetstream(nc);

--- a/jetstream/tests/consumers_test.ts
+++ b/jetstream/tests/consumers_test.ts
@@ -36,11 +36,11 @@ import type {
 import { connect, NatsServer } from "test_helpers";
 import { deferred, nanos } from "@nats-io/nats-core";
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
-import { _setup, cleanup, jetstreamServerConf } from "test_helpers";
+import { cleanup, jetstreamServerConf, setup } from "test_helpers";
 import type { PullConsumerMessagesImpl } from "../src/consumer.ts";
 
 Deno.test("consumers - min supported server", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(stream, {
@@ -70,7 +70,7 @@ Deno.test("consumers - min supported server", async () => {
 });
 
 Deno.test("consumers - get", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
   await assertRejects(
     async () => {
@@ -99,7 +99,7 @@ Deno.test("consumers - get", async () => {
 });
 
 Deno.test("consumers - delete", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const { stream } = await initStream(nc);
@@ -122,7 +122,7 @@ Deno.test("consumers - delete", async () => {
 });
 
 Deno.test("consumers - info", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const js = jetstream(nc);
 
@@ -160,7 +160,7 @@ Deno.test("consumers - info", async () => {
 });
 
 Deno.test("consumers - push consumer on get", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const { stream } = await initStream(nc);
@@ -235,7 +235,7 @@ Deno.test("consumers - fetch heartbeats", async () => {
 });
 
 Deno.test("consumers - bad options", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(stream, {
@@ -265,7 +265,7 @@ Deno.test("consumers - bad options", async () => {
 });
 
 Deno.test("consumers - should be able to consume and pull", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(stream, {
@@ -303,7 +303,7 @@ Deno.test("consumers - should be able to consume and pull", async () => {
 });
 
 Deno.test("consumers - discard notifications", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(stream, {
@@ -331,7 +331,7 @@ Deno.test("consumers - discard notifications", async () => {
 });
 
 Deno.test("consumers - threshold_messages", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream, subj } = await initStream(nc);
 
   const proms = [];
@@ -384,7 +384,7 @@ Deno.test("consumers - threshold_messages", async () => {
 });
 
 Deno.test("consumers - threshold_messages bytes", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream, subj } = await initStream(nc);
 
   const proms = [];
@@ -453,7 +453,7 @@ Deno.test("consumers - threshold_messages bytes", async () => {
 });
 
 Deno.test("consumers - sub leaks fetch()", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -478,7 +478,7 @@ Deno.test("consumers - sub leaks fetch()", async () => {
 });
 
 Deno.test("consumers - inboxPrefix is respected", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf(), {
+  const { ns, nc } = await setup(jetstreamServerConf(), {
     inboxPrefix: "x",
   });
   const jsm = await jetstreamManager(nc);
@@ -508,7 +508,7 @@ Deno.test("consumers - inboxPrefix is respected", async () => {
 });
 
 Deno.test("consumers - processed", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf(), {
+  const { ns, nc } = await setup(jetstreamServerConf(), {
     inboxPrefix: "x",
   });
   const jsm = await jetstreamManager(nc);

--- a/jetstream/tests/fetch_test.ts
+++ b/jetstream/tests/fetch_test.ts
@@ -13,13 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  _setup,
-  cleanup,
-  connect,
-  flakyTest,
-  jetstreamServerConf,
-} from "test_helpers";
+import { cleanup, flakyTest, jetstreamServerConf, setup } from "test_helpers";
 import { initStream } from "./jstest_util.ts";
 import { assertEquals, assertExists, assertRejects } from "jsr:@std/assert";
 import { delay, Empty, nanos, syncIterator } from "@nats-io/nats-core";
@@ -33,7 +27,7 @@ import {
 import type { PullConsumerMessagesImpl } from "../src/consumer.ts";
 
 Deno.test("fetch - no messages", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
@@ -58,7 +52,7 @@ Deno.test("fetch - no messages", async () => {
 });
 
 Deno.test("fetch - less messages", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
@@ -83,7 +77,7 @@ Deno.test("fetch - less messages", async () => {
 });
 
 Deno.test("fetch - exactly messages", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
@@ -116,7 +110,7 @@ Deno.test("fetch - exactly messages", async () => {
 Deno.test(
   "fetch - consumer not found",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
     const jsm = await jetstreamManager(nc);
     await jsm.streams.add({ name: "A", subjects: ["hello"] });
 
@@ -152,7 +146,7 @@ Deno.test(
 );
 
 Deno.test("fetch - deleted consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
 
@@ -187,7 +181,7 @@ Deno.test("fetch - deleted consumer", async () => {
 });
 
 Deno.test("fetch - stream not found", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["hello"] });
@@ -220,7 +214,7 @@ Deno.test("fetch - stream not found", async () => {
 });
 
 Deno.test("fetch - listener leaks", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "messages", subjects: ["hello"] });
 
@@ -260,7 +254,7 @@ Deno.test("fetch - listener leaks", async () => {
 });
 
 Deno.test("fetch - sync", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "messages", subjects: ["hello"] });
 
@@ -286,7 +280,7 @@ Deno.test("fetch - sync", async () => {
 });
 
 Deno.test("fetch - consumer bind", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -324,7 +318,7 @@ Deno.test("fetch - consumer bind", async () => {
 });
 
 Deno.test("fetch - exceeding max_messages will stop", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
   await jsm.consumers.add("A", {

--- a/jetstream/tests/jetstream409_test.ts
+++ b/jetstream/tests/jetstream409_test.ts
@@ -24,10 +24,10 @@ import {
 
 import { assert, assertRejects, fail } from "jsr:@std/assert";
 import { initStream } from "./jstest_util.ts";
-import { _setup, cleanup, connect, jetstreamServerConf } from "test_helpers";
+import { cleanup, jetstreamServerConf, setup } from "test_helpers";
 
 Deno.test("409 - max expires", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -84,7 +84,7 @@ Deno.test("409 - max expires", async () => {
 });
 
 Deno.test("409 - max message size", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -136,7 +136,7 @@ Deno.test("409 - max message size", async () => {
 });
 
 Deno.test("409 - max batch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -186,7 +186,7 @@ Deno.test("409 - max batch", async () => {
 });
 
 Deno.test("409 - max waiting", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);

--- a/jetstream/tests/jetstream_pullconsumer_test.ts
+++ b/jetstream/tests/jetstream_pullconsumer_test.ts
@@ -14,11 +14,11 @@
  */
 
 import {
-  _setup,
   cleanup,
   connect,
   jetstreamExportServerConf,
   jetstreamServerConf,
+  setup,
 } from "test_helpers";
 import { initStream } from "./jstest_util.ts";
 import type { ConsumerConfig } from "../src/jsapi_types.ts";
@@ -28,7 +28,7 @@ import { Empty, nanos, nuid } from "@nats-io/nats-core";
 import { jetstream, jetstreamManager } from "../src/mod.ts";
 
 Deno.test("jetstream - pull consumer options", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   const v = await jsm.consumers.add(stream, {
@@ -45,7 +45,7 @@ Deno.test("jetstream - pull consumer options", async () => {
 });
 
 Deno.test("jetstream - cross account pull", async () => {
-  const { ns, nc: admin } = await _setup(connect, jetstreamExportServerConf(), {
+  const { ns, nc: admin } = await setup(jetstreamExportServerConf(), {
     user: "js",
     pass: "js",
   });
@@ -87,7 +87,7 @@ Deno.test("jetstream - cross account pull", async () => {
 });
 
 Deno.test("jetstream - last of", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const n = nuid.next();
   await jsm.streams.add({

--- a/jetstream/tests/jetstream_pushconsumer_test.ts
+++ b/jetstream/tests/jetstream_pushconsumer_test.ts
@@ -14,13 +14,13 @@
  */
 
 import {
-  _setup,
   assertBetween,
   cleanup,
   connect,
   jetstreamExportServerConf,
   jetstreamServerConf,
   notCompatible,
+  setup,
 } from "test_helpers";
 import { initStream } from "./jstest_util.ts";
 import {
@@ -53,7 +53,7 @@ import type {
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 
 Deno.test("jetstream - durable", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
   await js.publish(subj);
@@ -91,7 +91,7 @@ Deno.test("jetstream - durable", async () => {
 });
 
 Deno.test("jetstream - queue error checks", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.3.5")) {
     return;
   }
@@ -129,7 +129,7 @@ Deno.test("jetstream - queue error checks", async () => {
 });
 
 Deno.test("jetstream - max ack pending", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -173,7 +173,7 @@ Deno.test("jetstream - max ack pending", async () => {
 });
 
 Deno.test("jetstream - deliver new", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { subj, stream } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -205,7 +205,7 @@ Deno.test("jetstream - deliver new", async () => {
 });
 
 Deno.test("jetstream - deliver last", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { subj, stream } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -236,7 +236,7 @@ Deno.test("jetstream - deliver last", async () => {
 });
 
 Deno.test("jetstream - deliver seq", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { subj, stream } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -267,7 +267,7 @@ Deno.test("jetstream - deliver seq", async () => {
 });
 
 Deno.test("jetstream - deliver start time", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { subj, stream } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -299,7 +299,7 @@ Deno.test("jetstream - deliver start time", async () => {
 });
 
 Deno.test("jetstream - deliver last per subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc)) {
     return;
   }
@@ -347,7 +347,7 @@ Deno.test("jetstream - deliver last per subject", async () => {
 });
 
 Deno.test("jetstream - cross account subscribe", async () => {
-  const { ns, nc: admin } = await _setup(connect, jetstreamExportServerConf(), {
+  const { ns, nc: admin } = await setup(jetstreamExportServerConf(), {
     user: "js",
     pass: "js",
   });
@@ -404,7 +404,7 @@ Deno.test("jetstream - cross account subscribe", async () => {
 });
 
 Deno.test("jetstream - ack lease extends with working", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const sn = nuid.next();
   const jsm = await jetstreamManager(nc);
@@ -451,7 +451,7 @@ Deno.test("jetstream - ack lease extends with working", async () => {
 });
 
 Deno.test("jetstream - idle heartbeats", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
@@ -490,8 +490,7 @@ Deno.test("jetstream - idle heartbeats", async () => {
 });
 
 Deno.test("jetstream - flow control", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_file_store: -1,
@@ -537,7 +536,7 @@ Deno.test("jetstream - flow control", async () => {
 });
 
 Deno.test("jetstream - durable resumes", async () => {
-  let { ns, nc } = await _setup(connect, jetstreamServerConf({}), {
+  let { ns, nc } = await setup(jetstreamServerConf({}), {
     maxReconnectAttempts: -1,
     reconnectTimeWait: 100,
   });
@@ -588,7 +587,7 @@ Deno.test("jetstream - durable resumes", async () => {
 });
 
 Deno.test("jetstream - nak delay", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.7.1")) {
     return;
   }
@@ -626,8 +625,7 @@ Deno.test("jetstream - nak delay", async () => {
 });
 
 Deno.test("jetstream - bind", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_file_store: -1,
@@ -716,7 +714,7 @@ Deno.test("jetstream - bind", async () => {
 });
 
 Deno.test("jetstream - bind example", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
   const jsm = await jetstreamManager(nc);
   const subj = `A.*`;
@@ -771,7 +769,7 @@ Deno.test("jetstream - bind example", async () => {
 });
 
 Deno.test("jetstream - push consumer is bound", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -822,7 +820,7 @@ Deno.test("jetstream - push consumer is bound", async () => {
 });
 
 Deno.test("jetstream - idleheartbeats notifications don't cancel", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const c = await js.consumers.getBoundPushConsumer({
@@ -846,7 +844,7 @@ Deno.test("jetstream - idleheartbeats notifications don't cancel", async () => {
 });
 
 Deno.test("jetstream - push on stopped server doesn't close client", async () => {
-  let { ns, nc } = await _setup(connect, jetstreamServerConf(), {
+  let { ns, nc } = await setup(jetstreamServerConf(), {
     maxReconnectAttempts: -1,
   });
   const reconnected = deferred<void>();
@@ -902,7 +900,7 @@ Deno.test("jetstream - push on stopped server doesn't close client", async () =>
 });
 
 Deno.test("jetstream - push sync", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const name = nuid.next();
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({
@@ -930,8 +928,7 @@ Deno.test("jetstream - push sync", async () => {
 });
 
 Deno.test("jetstream - ordered push consumer honors inbox prefix", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf(
       {
         authorization: {

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -45,11 +45,11 @@ import {
 import type { JetStreamClientImpl } from "../src/jsclient.ts";
 import { defaultJsOptions } from "../src/jsbaseclient_api.ts";
 import {
-  _setup,
   cleanup,
   flakyTest,
   jetstreamServerConf,
   notCompatible,
+  setup,
 } from "test_helpers";
 import { PubHeaders } from "../src/jsapi_types.ts";
 import { JetStreamApiError } from "../src/jserrors.ts";
@@ -70,7 +70,7 @@ Deno.test("jetstream - default override prefix", () => {
 });
 
 Deno.test("jetstream - options rejects empty prefix", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   assertThrows(() => {
     jetstream(nc, { apiPrefix: "" });
   });
@@ -78,14 +78,14 @@ Deno.test("jetstream - options rejects empty prefix", async () => {
 });
 
 Deno.test("jetstream - options removes trailing dot", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc, { apiPrefix: "hello." }) as JetStreamClientImpl;
   assertEquals(js.opts.apiPrefix, "hello");
   await cleanup(ns, nc);
 });
 
 Deno.test("jetstream - find stream throws when not found", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc) as JetStreamClientImpl;
   await assertRejects(
     async () => {
@@ -100,7 +100,7 @@ Deno.test("jetstream - find stream throws when not found", async () => {
 });
 
 Deno.test("jetstream - publish basic", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -118,7 +118,7 @@ Deno.test("jetstream - publish basic", async () => {
 });
 
 Deno.test("jetstream - ackAck", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(stream, {
@@ -138,7 +138,7 @@ Deno.test("jetstream - ackAck", async () => {
 });
 
 Deno.test("jetstream - publish id", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -155,7 +155,7 @@ Deno.test("jetstream - publish id", async () => {
 });
 
 Deno.test("jetstream - publish require stream", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -177,7 +177,7 @@ Deno.test("jetstream - publish require stream", async () => {
 });
 
 Deno.test("jetstream - publish require last message id", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -207,7 +207,7 @@ Deno.test("jetstream - publish require last message id", async () => {
 });
 
 Deno.test("jetstream - get message last by subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
@@ -228,7 +228,7 @@ Deno.test("jetstream - get message last by subject", async () => {
 });
 
 Deno.test("jetstream - publish first sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -245,7 +245,7 @@ Deno.test("jetstream - publish first sequence", async () => {
 });
 
 Deno.test("jetstream - publish require last sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const js = jetstream(nc);
@@ -275,7 +275,7 @@ Deno.test("jetstream - publish require last sequence", async () => {
 });
 
 Deno.test("jetstream - publish require last sequence by subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add({ name: stream, subjects: [`${stream}.*`] });
@@ -299,7 +299,7 @@ Deno.test("jetstream - publish require last sequence by subject", async () => {
 });
 
 Deno.test("jetstream - ephemeral options", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   const v = await jsm.consumers.add(stream, {
@@ -311,7 +311,7 @@ Deno.test("jetstream - ephemeral options", async () => {
 });
 
 Deno.test("jetstream - publish headers", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
   const h = headers();
@@ -329,7 +329,7 @@ Deno.test("jetstream - publish headers", async () => {
 });
 
 Deno.test("jetstream - JSON", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
   const values = [null, true, "", ["hello"], { hello: "world" }];
@@ -359,8 +359,7 @@ Deno.test("jetstream - JSON", async () => {
 });
 
 Deno.test("jetstream - domain", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         domain: "afton",
@@ -391,7 +390,7 @@ Deno.test("jetstream - account domain", async () => {
     },
   });
 
-  const { ns, nc } = await _setup(connect, conf, { user: "a", pass: "a" });
+  const { ns, nc } = await setup(conf, { user: "a", pass: "a" });
 
   const jsm = await jetstreamManager(nc, { domain: "A" });
   const ai = await jsm.getAccountInfo();
@@ -402,8 +401,7 @@ Deno.test("jetstream - account domain", async () => {
 });
 
 Deno.test("jetstream - puback domain", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         domain: "A",
@@ -423,7 +421,7 @@ Deno.test("jetstream - puback domain", async () => {
 });
 
 Deno.test("jetstream - source", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const stream = nuid.next();
   const subj = `${stream}.*`;
@@ -472,7 +470,7 @@ Deno.test("jetstream - source", async () => {
 });
 
 Deno.test("jetstream - seal", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.2")) {
     return;
   }
@@ -506,7 +504,7 @@ Deno.test("jetstream - seal", async () => {
 });
 
 Deno.test("jetstream - deny delete", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.2")) {
     return;
   }
@@ -539,7 +537,7 @@ Deno.test("jetstream - deny delete", async () => {
 });
 
 Deno.test("jetstream - deny purge", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.2")) {
     return;
   }
@@ -572,7 +570,7 @@ Deno.test("jetstream - deny purge", async () => {
 });
 
 Deno.test("jetstream - rollup all", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -605,7 +603,7 @@ Deno.test("jetstream - rollup all", async () => {
 });
 
 Deno.test("jetstream - rollup subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -660,7 +658,7 @@ Deno.test("jetstream - rollup subject", async () => {
 });
 
 Deno.test("jetstream - no rollup", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -698,7 +696,7 @@ Deno.test("jetstream - no rollup", async () => {
 });
 
 Deno.test("jetstream - backoff", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.7.2")) {
     return;
   }
@@ -738,7 +736,7 @@ Deno.test("jetstream - backoff", async () => {
 });
 
 Deno.test("jetstream - detailed errors", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
 
   const ne = await assertRejects(() => {
@@ -795,7 +793,7 @@ Deno.test(
 );
 
 Deno.test("jetstream - duplicate message pub", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { subj } = await initStream(nc);
   const js = jetstream(nc);
 
@@ -809,7 +807,7 @@ Deno.test("jetstream - duplicate message pub", async () => {
 });
 
 Deno.test("jetstream - republish", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
   }
@@ -844,7 +842,7 @@ Deno.test("jetstream - republish", async () => {
 });
 
 Deno.test("jetstream - num_replicas consumer option", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   const name = nuid.next();
@@ -886,7 +884,7 @@ Deno.test("jetstream - num_replicas consumer option", async () => {
 });
 
 Deno.test("jetstream - filter_subject consumer update", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
   }
@@ -907,7 +905,7 @@ Deno.test("jetstream - filter_subject consumer update", async () => {
 });
 
 Deno.test("jetstream - jsmsg decode", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const name = nuid.next();
   const jsm = await jetstreamManager(nc);
   const js = jetstream(nc);
@@ -932,7 +930,7 @@ Deno.test("jetstream - jsmsg decode", async () => {
 });
 
 Deno.test("jetstream - input transform", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -965,7 +963,7 @@ Deno.test("jetstream - input transform", async () => {
 });
 
 Deno.test("jetstream - source transforms", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1020,7 +1018,7 @@ Deno.test("jetstream - source transforms", async () => {
 });
 
 Deno.test("jetstream - term reason", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.11.0")) {
     return;
   }

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -55,7 +55,6 @@ import {
 } from "../src/mod.ts";
 import { initStream } from "./jstest_util.ts";
 import {
-  _setup,
   cleanup,
   connect,
   flakyTest,
@@ -63,6 +62,7 @@ import {
   jetstreamServerConf,
   NatsServer,
   notCompatible,
+  setup,
 } from "test_helpers";
 import { validateName } from "../src/jsutil.ts";
 import {
@@ -82,7 +82,7 @@ const ConsumerNameRequired = "durable name required";
 
 Deno.test("jsm - jetstream not enabled", async () => {
   // start a regular server - no js conf
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await assertRejects(
     () => {
       return jetstreamManager(nc);
@@ -93,7 +93,7 @@ Deno.test("jsm - jetstream not enabled", async () => {
 });
 
 Deno.test("jsm - account info", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const ai = await jsm.getAccountInfo();
   assert(ai.limits.max_memory === -1 || ai.limits.max_memory > 0);
@@ -113,7 +113,7 @@ Deno.test("jsm - account not enabled", async () => {
       },
     },
   };
-  const { ns, nc } = await _setup(connect, jetstreamServerConf(conf));
+  const { ns, nc } = await setup(jetstreamServerConf(conf));
   await assertRejects(
     () => {
       return jetstreamManager(nc);
@@ -130,7 +130,7 @@ Deno.test("jsm - account not enabled", async () => {
 });
 
 Deno.test("jsm - empty stream config fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -144,7 +144,7 @@ Deno.test("jsm - empty stream config fails", async () => {
 });
 
 Deno.test("jsm - empty stream config update fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const name = nuid.next();
   let ci = await jsm.streams.add({ name: name, subjects: [`${name}.>`] });
@@ -165,7 +165,7 @@ Deno.test("jsm - empty stream config update fails", async () => {
 });
 
 Deno.test("jsm - update stream name is internally added", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const name = nuid.next();
   const ci = await jsm.streams.add({
@@ -180,7 +180,7 @@ Deno.test("jsm - update stream name is internally added", async () => {
 });
 
 Deno.test("jsm - delete empty stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -194,7 +194,7 @@ Deno.test("jsm - delete empty stream name fails", async () => {
 });
 
 Deno.test("jsm - info empty stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -208,7 +208,7 @@ Deno.test("jsm - info empty stream name fails", async () => {
 });
 
 Deno.test("jsm - info msg not found stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const name = nuid.next();
   await assertRejects(
@@ -221,7 +221,7 @@ Deno.test("jsm - info msg not found stream name fails", async () => {
 });
 
 Deno.test("jsm - delete msg empty stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -235,7 +235,7 @@ Deno.test("jsm - delete msg empty stream name fails", async () => {
 });
 
 Deno.test("jsm - delete msg not found stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const name = nuid.next();
   await assertRejects(
@@ -248,7 +248,7 @@ Deno.test("jsm - delete msg not found stream name fails", async () => {
 });
 
 Deno.test("jsm - no stream lister is empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const streams = await jsm.streams.list().next();
   assertEquals(streams.length, 0);
@@ -256,7 +256,7 @@ Deno.test("jsm - no stream lister is empty", async () => {
 });
 
 Deno.test("jsm - stream names is empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const names = await jsm.streams.names().next();
   assertEquals(names.length, 0);
@@ -264,7 +264,7 @@ Deno.test("jsm - stream names is empty", async () => {
 });
 
 Deno.test("jsm - lister after empty, empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const lister = jsm.streams.list();
   let streams = await lister.next();
@@ -275,7 +275,7 @@ Deno.test("jsm - lister after empty, empty", async () => {
 });
 
 Deno.test("jsm - add stream", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const name = nuid.next();
   let si = await jsm.streams.add({ name });
@@ -306,7 +306,7 @@ Deno.test("jsm - add stream", async () => {
 });
 
 Deno.test("jsm - purge not found stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const name = nuid.next();
   await assertRejects(
@@ -319,7 +319,7 @@ Deno.test("jsm - purge not found stream name fails", async () => {
 });
 
 Deno.test("jsm - purge empty stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -333,7 +333,7 @@ Deno.test("jsm - purge empty stream name fails", async () => {
 });
 
 Deno.test("jsm - stream purge", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
 
@@ -350,7 +350,7 @@ Deno.test("jsm - stream purge", async () => {
 });
 
 Deno.test("jsm - purge by sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add(
@@ -379,7 +379,7 @@ Deno.test("jsm - purge by sequence", async () => {
 });
 
 Deno.test("jsm - purge by filtered sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add(
@@ -409,7 +409,7 @@ Deno.test("jsm - purge by filtered sequence", async () => {
 });
 
 Deno.test("jsm - purge by subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add(
@@ -439,7 +439,7 @@ Deno.test("jsm - purge by subject", async () => {
 });
 
 Deno.test("jsm - purge by subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add(
@@ -469,7 +469,7 @@ Deno.test("jsm - purge by subject", async () => {
 });
 
 Deno.test("jsm - purge keep", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add(
@@ -500,7 +500,7 @@ Deno.test("jsm - purge keep", async () => {
 });
 
 Deno.test("jsm - purge filtered keep", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add(
@@ -535,7 +535,7 @@ Deno.test("jsm - purge filtered keep", async () => {
 });
 
 Deno.test("jsm - purge seq and keep fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     () => {
@@ -548,7 +548,7 @@ Deno.test("jsm - purge seq and keep fails", async () => {
 });
 
 Deno.test("jsm - stream delete", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
 
@@ -564,7 +564,7 @@ Deno.test("jsm - stream delete", async () => {
 });
 
 Deno.test("jsm - stream delete message", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
 
@@ -585,7 +585,7 @@ Deno.test("jsm - stream delete message", async () => {
 });
 
 Deno.test("jsm - stream delete info", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const { stream, subj } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
@@ -604,7 +604,7 @@ Deno.test("jsm - stream delete info", async () => {
 });
 
 Deno.test("jsm - consumer info on empty stream name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -618,7 +618,7 @@ Deno.test("jsm - consumer info on empty stream name fails", async () => {
 });
 
 Deno.test("jsm - consumer info on empty consumer name fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -632,7 +632,7 @@ Deno.test("jsm - consumer info on empty consumer name fails", async () => {
 });
 
 Deno.test("jsm - consumer info on not found stream fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     async () => {
@@ -644,7 +644,7 @@ Deno.test("jsm - consumer info on not found stream fails", async () => {
 });
 
 Deno.test("jsm - consumer info on not found consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await assertRejects(
@@ -657,7 +657,7 @@ Deno.test("jsm - consumer info on not found consumer", async () => {
 });
 
 Deno.test("jsm - consumer info", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(
@@ -672,7 +672,7 @@ Deno.test("jsm - consumer info", async () => {
 });
 
 Deno.test("jsm - no consumer lister with empty stream fails", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   assertThrows(
     () => {
@@ -685,7 +685,7 @@ Deno.test("jsm - no consumer lister with empty stream fails", async () => {
 });
 
 Deno.test("jsm - no consumer lister with no consumers empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   const consumers = await jsm.consumers.list(stream).next();
@@ -694,7 +694,7 @@ Deno.test("jsm - no consumer lister with no consumers empty", async () => {
 });
 
 Deno.test("jsm - lister", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
   await jsm.consumers.add(
@@ -713,7 +713,7 @@ Deno.test("jsm - lister", async () => {
 });
 
 Deno.test("jsm - update stream", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream } = await initStream(nc);
   const jsm = await jetstreamManager(nc);
 
@@ -727,7 +727,7 @@ Deno.test("jsm - update stream", async () => {
 });
 
 Deno.test("jsm - get message", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
 
   const h = headers();
@@ -763,7 +763,7 @@ Deno.test("jsm - get message", async () => {
 });
 
 Deno.test("jsm - get message payload", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const { stream, subj } = await initStream(nc);
   const js = jetstream(nc);
   await js.publish(subj, Empty, { msgID: "empty" });
@@ -785,7 +785,7 @@ Deno.test("jsm - get message payload", async () => {
 });
 
 Deno.test("jsm - advisories", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   const iter = jsm.advisories();
   const streamAction = deferred();
@@ -866,7 +866,7 @@ Deno.test("jsm - minValidation", () => {
 });
 
 Deno.test("jsm - cross account streams", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamExportServerConf(), {
+  const { ns, nc } = await setup(jetstreamExportServerConf(), {
     user: "a",
     pass: "s3cret",
   });
@@ -946,7 +946,7 @@ Deno.test("jsm - cross account streams", async () => {
 Deno.test(
   "jsm - cross account consumers",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamExportServerConf(), {
+    const { ns, nc } = await setup(jetstreamExportServerConf(), {
       user: "a",
       pass: "s3cret",
     });
@@ -1010,7 +1010,7 @@ Deno.test(
 );
 
 Deno.test("jsm - jetstream error info", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
   await assertRejects(
     () => {
@@ -1029,7 +1029,7 @@ Deno.test("jsm - jetstream error info", async () => {
 });
 
 Deno.test("jsm - update consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.4")) {
     return;
   }
@@ -1064,7 +1064,7 @@ Deno.test("jsm - update consumer", async () => {
 });
 
 Deno.test("jsm - stream info subjects", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.7.2")) {
     return;
   }
@@ -1155,7 +1155,7 @@ Deno.test("jsm - account limits", async () => {
 });
 
 Deno.test("jsm - stream update preserves other value", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const jsm = await jetstreamManager(nc);
 
   await jsm.streams.add({
@@ -1173,7 +1173,7 @@ Deno.test("jsm - stream update preserves other value", async () => {
 });
 
 Deno.test("jsm - direct getMessage", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1217,7 +1217,7 @@ Deno.test("jsm - direct getMessage", async () => {
 });
 
 Deno.test("jsm - consumer name", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1353,7 +1353,7 @@ async function testConsumerNameAPI(nc: NatsConnection) {
 }
 
 Deno.test("jsm - consumer name apis are not used on old servers", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.7.0")) {
     return;
   }
@@ -1367,7 +1367,7 @@ Deno.test("jsm - consumer name apis are not used on old servers", async () => {
 });
 
 Deno.test("jsm - consumer name apis are not used when disabled", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
   }
@@ -1380,7 +1380,7 @@ Deno.test("jsm - consumer name apis are not used when disabled", async () => {
 });
 
 Deno.test("jsm - mirror_direct options", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1411,7 +1411,7 @@ Deno.test("jsm - mirror_direct options", async () => {
 });
 
 Deno.test("jsm - consumers with name and durable_name", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1444,7 +1444,7 @@ Deno.test("jsm - consumers with name and durable_name", async () => {
 });
 
 Deno.test("jsm - consumer name is validated", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1494,7 +1494,7 @@ Deno.test("jsm - consumer name is validated", async () => {
 });
 
 Deno.test("jsm - discard_new_per_subject option", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.2")) {
     return;
@@ -1540,8 +1540,7 @@ Deno.test("jsm - discard_new_per_subject option", async () => {
 });
 
 Deno.test("jsm - paginated subjects", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_memory_store: -1,
@@ -1577,8 +1576,7 @@ Deno.test("jsm - paginated subjects", async () => {
 });
 
 Deno.test("jsm - paged stream list", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_memory_store: -1,
@@ -1615,8 +1613,7 @@ Deno.test("jsm - paged stream list", async () => {
 });
 
 Deno.test("jsm - paged consumer infos", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_memory_store: -1,
@@ -1657,8 +1654,7 @@ Deno.test("jsm - paged consumer infos", async () => {
 });
 
 Deno.test("jsm - list filter", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_memory_store: -1,
@@ -1703,7 +1699,7 @@ Deno.test("jsm - list filter", async () => {
 });
 
 Deno.test("jsm - stream names list filtering subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const jsm = await jetstreamManager(nc);
 
@@ -1782,7 +1778,7 @@ Deno.test("jsm - remap domain", () => {
 });
 
 Deno.test("jsm - filter_subjects", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1805,7 +1801,7 @@ Deno.test("jsm - filter_subjects", async () => {
 });
 
 Deno.test("jsm - filter_subjects rejects filter_subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1832,7 +1828,7 @@ Deno.test("jsm - filter_subjects rejects filter_subject", async () => {
 });
 
 Deno.test("jsm - update filter_subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1856,7 +1852,7 @@ Deno.test("jsm - update filter_subject", async () => {
 });
 
 Deno.test("jsm - update filter_subjects", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1880,7 +1876,7 @@ Deno.test("jsm - update filter_subjects", async () => {
 });
 
 Deno.test("jsm - update from filter_subject to filter_subjects", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1936,7 +1932,7 @@ Deno.test("jsm - update from filter_subject to filter_subjects", async () => {
 });
 
 Deno.test("jsm - direct msg decode", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const name = nuid.next();
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   const js = jetstream(nc);
@@ -1960,7 +1956,7 @@ Deno.test("jsm - direct msg decode", async () => {
 });
 
 Deno.test("jsm - stored msg decode", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const name = nuid.next();
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   const js = jetstream(nc);
@@ -1982,7 +1978,7 @@ Deno.test("jsm - stored msg decode", async () => {
 });
 
 Deno.test("jsm - stream/consumer metadata", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -2085,7 +2081,7 @@ Deno.test("jsm - stream/consumer metadata", async () => {
 });
 
 Deno.test("jsm - consumer api action", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -2125,7 +2121,7 @@ Deno.test("jsm - consumer api action", async () => {
 });
 
 Deno.test("jsm - validate stream name in operations", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   const names = ["", ".", "*", ">", "\r", "\n", "\t", " "];
@@ -2198,7 +2194,7 @@ Deno.test("jsm - validate stream name in operations", async () => {
 });
 
 Deno.test("jsm - validate consumer name", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   const stream = nuid.next();
   await jsm.streams.add({ name: stream, subjects: [stream] });
@@ -2246,7 +2242,7 @@ Deno.test("jsm - validate consumer name", async () => {
 });
 
 Deno.test("jsm - validate consumer name in operations", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
 
   const names = ["", ".", "*", ">", "\r", "\n", "\t", " "];
@@ -2295,7 +2291,7 @@ Deno.test("jsm - validate consumer name in operations", async () => {
 });
 
 Deno.test("jsm - source transforms", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -2350,7 +2346,7 @@ Deno.test("jsm - source transforms", async () => {
 });
 
 Deno.test("jsm - source transforms rejected on old servers", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const nci = nc as NatsConnectionImpl;
   nci.features.update("2.8.0");
   nci.info!.version = "2.8.0";
@@ -2425,7 +2421,7 @@ Deno.test("jsm - source transforms rejected on old servers", async () => {
 });
 
 Deno.test("jsm - stream compression not supported", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const nci = nc as NatsConnectionImpl;
   nci.features.update("2.9.0");
   nci.info!.version = "2.9.0";
@@ -2449,7 +2445,7 @@ Deno.test("jsm - stream compression not supported", async () => {
 });
 
 Deno.test("jsm - stream compression", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -2470,7 +2466,7 @@ Deno.test("jsm - stream compression", async () => {
 });
 
 Deno.test("jsm - stream consumer limits", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -2505,7 +2501,7 @@ Deno.test("jsm - stream consumer limits", async () => {
 });
 
 Deno.test("jsm - stream consumer limits override", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -2546,7 +2542,7 @@ Deno.test("jsm - stream consumer limits override", async () => {
 });
 
 Deno.test("jsm - stream consumer limits rejected on old servers", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const nci = nc as NatsConnectionImpl;
   nci.features.update("2.9.0");
   nci.info!.version = "2.9.0";
@@ -2571,7 +2567,7 @@ Deno.test("jsm - stream consumer limits rejected on old servers", async () => {
 });
 
 Deno.test("jsm - api check not ok", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   let count = 0;
   nc.subscribe("$JS.API.INFO", {
     callback: () => {
@@ -2591,7 +2587,7 @@ Deno.test("jsm - api check not ok", async () => {
 });
 
 Deno.test("jsm - api check ok", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   let count = 0;
 
   nc.subscribe("$JS.API.INFO", {
@@ -2610,7 +2606,7 @@ Deno.test("jsm - api check ok", async () => {
 });
 
 Deno.test("jsm - consumer create paused", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.11.0")) {
     return;
   }
@@ -2633,7 +2629,7 @@ Deno.test("jsm - consumer create paused", async () => {
 });
 
 Deno.test("jsm - pause/unpause", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.11.0")) {
     return;
   }
@@ -2664,7 +2660,7 @@ Deno.test("jsm - pause/unpause", async () => {
 });
 
 Deno.test("jsm - batch direct get multi_last", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.11.0")) {
     return;
   }
@@ -2698,7 +2694,7 @@ Deno.test("jsm - batch direct get multi_last", async () => {
 });
 
 Deno.test("jsm - batch direct get batch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.11.0")) {
     return;
   }
@@ -2733,7 +2729,7 @@ Deno.test("jsm - batch direct get batch", async () => {
 });
 
 Deno.test("jsm - storage", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   let si = await jsm.streams.add({

--- a/jetstream/tests/jsmsg_test.ts
+++ b/jetstream/tests/jsmsg_test.ts
@@ -26,11 +26,11 @@ import type { Msg, MsgImpl } from "@nats-io/nats-core/internal";
 import type { JsMsgImpl } from "../src/jsmsg.ts";
 import { parseInfo, toJsMsg } from "../src/jsmsg.ts";
 import {
-  _setup,
   assertBetween,
   cleanup,
   connect,
   jetstreamServerConf,
+  setup,
 } from "test_helpers";
 import type { JetStreamManagerImpl } from "../src/jsclient.ts";
 import { errors } from "../../core/src/mod.ts";
@@ -143,7 +143,7 @@ Deno.test("jsmsg - acks", async () => {
 });
 
 Deno.test("jsmsg - no ack consumer is ackAck 503", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   await jsm.streams.add({
     name: "A",
@@ -172,7 +172,7 @@ Deno.test("jsmsg - no ack consumer is ackAck 503", async () => {
 });
 
 Deno.test("jsmsg - explicit consumer ackAck", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   await jsm.streams.add({
     name: "A",
@@ -197,7 +197,7 @@ Deno.test("jsmsg - explicit consumer ackAck", async () => {
 });
 
 Deno.test("jsmsg - explicit consumer ackAck timeout", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   await jsm.streams.add({
     name: "A",
@@ -228,7 +228,7 @@ Deno.test("jsmsg - explicit consumer ackAck timeout", async () => {
 });
 
 Deno.test("jsmsg - ackAck js options timeout", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   await jsm.streams.add({
     name: "A",
@@ -260,7 +260,7 @@ Deno.test("jsmsg - ackAck js options timeout", async () => {
 });
 
 Deno.test("jsmsg - ackAck legacy timeout", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc) as JetStreamManagerImpl;
   await jsm.streams.add({
     name: "A",

--- a/jetstream/tests/next_test.ts
+++ b/jetstream/tests/next_test.ts
@@ -13,13 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  _setup,
-  cleanup,
-  connect,
-  flakyTest,
-  jetstreamServerConf,
-} from "test_helpers";
+import { cleanup, flakyTest, jetstreamServerConf, setup } from "test_helpers";
 import { initStream } from "./jstest_util.ts";
 import { AckPolicy, DeliverPolicy } from "../src/jsapi_types.ts";
 import { assertEquals, assertRejects, fail } from "jsr:@std/assert";
@@ -34,7 +28,7 @@ import {
 } from "../src/jserrors.ts";
 
 Deno.test("next - basics", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream, subj } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -70,7 +64,7 @@ Deno.test("next - basics", async () => {
 });
 
 Deno.test("next - sub leaks", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -89,7 +83,7 @@ Deno.test("next - sub leaks", async () => {
 });
 
 Deno.test("next - listener leaks", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "messages", subjects: ["hello"] });
 
@@ -126,7 +120,7 @@ Deno.test("next - listener leaks", async () => {
 Deno.test(
   "next - consumer not found",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
     const jsm = await jetstreamManager(nc);
     await jsm.streams.add({ name: "A", subjects: ["hello"] });
 
@@ -153,7 +147,7 @@ Deno.test(
 );
 
 Deno.test("next - deleted consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["hello"] });
@@ -185,7 +179,7 @@ Deno.test("next - deleted consumer", async () => {
 Deno.test(
   "next - stream not found",
   async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
 
     const jsm = await jetstreamManager(nc);
     await jsm.streams.add({ name: "A", subjects: ["hello"] });
@@ -216,7 +210,7 @@ Deno.test(
 );
 
 Deno.test("next - consumer bind", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });

--- a/jetstream/tests/pushconsumers_ordered_test.ts
+++ b/jetstream/tests/pushconsumers_ordered_test.ts
@@ -18,12 +18,11 @@ import { DeliverPolicy, jetstream, jetstreamManager } from "../src/mod.ts";
 import type { JsMsg } from "../src/mod.ts";
 
 import {
-  _setup,
   cleanup,
-  connect,
   flakyTest,
   jetstreamServerConf,
   notCompatible,
+  setup,
 } from "test_helpers";
 import type {
   PushConsumerImpl,
@@ -33,7 +32,7 @@ import { delay } from "@nats-io/nats-core/internal";
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 
 Deno.test("ordered push consumers - get", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   await assertRejects(
@@ -63,7 +62,7 @@ Deno.test("ordered push consumers - get", async () => {
 Deno.test(
   "ordered push consumers - consume reset",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(connect, jetstreamServerConf());
+    const { ns, nc } = await setup(jetstreamServerConf());
     const js = jetstream(nc);
 
     const jsm = await jetstreamManager(nc);
@@ -103,7 +102,7 @@ Deno.test(
 );
 
 Deno.test("ordered push consumers - consume", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
 
   const jsm = await jetstreamManager(nc);
@@ -128,7 +127,7 @@ Deno.test("ordered push consumers - consume", async () => {
 });
 
 Deno.test("ordered push consumers - filters consume", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -161,7 +160,7 @@ Deno.test("ordered push consumers - filters consume", async () => {
 });
 
 Deno.test("ordered push consumers - last per subject", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -187,7 +186,7 @@ Deno.test("ordered push consumers - last per subject", async () => {
 });
 
 Deno.test("ordered push consumers - start sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
 
@@ -214,7 +213,7 @@ Deno.test("ordered push consumers - start sequence", async () => {
 });
 
 Deno.test("ordered push consumers - sub leak", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
   const js = jetstream(nc);

--- a/jetstream/tests/streams_test.ts
+++ b/jetstream/tests/streams_test.ts
@@ -14,11 +14,10 @@
  */
 
 import {
-  _setup,
   cleanup,
-  connect,
   jetstreamServerConf,
   notCompatible,
+  setup,
 } from "test_helpers";
 import { AckPolicy, jetstream, jetstreamManager } from "../src/mod.ts";
 
@@ -31,7 +30,7 @@ import { initStream } from "./jstest_util.ts";
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 
 Deno.test("streams - get", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   await assertRejects(
@@ -65,7 +64,7 @@ Deno.test("streams - get", async () => {
 });
 
 Deno.test("streams - consumers", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   // add a stream and a message
@@ -106,7 +105,7 @@ Deno.test("streams - consumers", async () => {
 });
 
 Deno.test("streams - delete message", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   // add a stream and a message
@@ -138,7 +137,7 @@ Deno.test("streams - delete message", async () => {
 });
 
 Deno.test("streams - first_seq", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -158,7 +157,7 @@ Deno.test("streams - first_seq", async () => {
 });
 
 Deno.test("streams - first_seq fails if wrong server", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const nci = nc as NatsConnectionImpl;
   nci.features.update("2.9.2");
 

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -63,13 +63,13 @@ import { Base64KeyCodec, NoopKvCodecs } from "../src/mod.ts";
 import { kvPrefix, validateBucket, validateKey } from "../src/internal_mod.ts";
 
 import {
-  _setup,
   cleanup,
   connect,
   jetstreamServerConf,
   Lock,
   NatsServer,
   notCompatible,
+  setup,
 } from "test_helpers";
 import type { QueuedIteratorImpl } from "@nats-io/nats-core/internal";
 import { Kvm } from "../src/kv.ts";
@@ -158,7 +158,7 @@ Deno.test("kv - bucket name validation", () => {
 });
 
 Deno.test("kv - list kv", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const jsm = await jetstreamManager(nc);
   await jsm.streams.add({ name: "A", subjects: ["a"] });
@@ -180,7 +180,7 @@ Deno.test("kv - list kv", async () => {
   await cleanup(ns, nc);
 });
 Deno.test("kv - init creates stream", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -199,7 +199,7 @@ Deno.test("kv - init creates stream", async () => {
 });
 
 Deno.test("kv - bind to existing KV", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -266,7 +266,7 @@ async function crud(bucket: Bucket): Promise<void> {
 }
 
 Deno.test("kv - crud", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -278,7 +278,7 @@ Deno.test("kv - crud", async () => {
 });
 
 Deno.test("kv - codec crud", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -300,7 +300,7 @@ Deno.test("kv - codec crud", async () => {
 });
 
 Deno.test("kv - history", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -322,7 +322,7 @@ Deno.test("kv - history", async () => {
 });
 
 Deno.test("kv - history multiple keys", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const n = nuid.next();
   const js = jetstream(nc);
   const bucket = await new Kvm(js).create(n, { history: 2 });
@@ -345,7 +345,7 @@ Deno.test("kv - history multiple keys", async () => {
 });
 
 Deno.test("kv - cleanups/empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -371,7 +371,7 @@ Deno.test("kv - cleanups/empty", async () => {
 });
 
 Deno.test("kv - history and watch cleanup", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -409,7 +409,7 @@ Deno.test("kv - history and watch cleanup", async () => {
 });
 
 Deno.test("kv - bucket watch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -488,7 +488,7 @@ async function keyWatch(bucket: Bucket): Promise<void> {
 }
 
 Deno.test("kv - key watch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -505,7 +505,7 @@ Deno.test("kv - key watch", async () => {
 });
 
 Deno.test("kv - codec key watch", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -542,7 +542,7 @@ async function keys(b: Bucket): Promise<void> {
 }
 
 Deno.test("kv - keys", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -558,7 +558,7 @@ Deno.test("kv - keys", async () => {
 });
 
 Deno.test("kv - codec keys", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -580,7 +580,7 @@ Deno.test("kv - codec keys", async () => {
 });
 
 Deno.test("kv - ttl", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -604,7 +604,7 @@ Deno.test("kv - ttl", async () => {
 });
 
 Deno.test("kv - no ttl", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -625,7 +625,7 @@ Deno.test("kv - no ttl", async () => {
 });
 
 Deno.test("kv - complex key", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -664,7 +664,7 @@ Deno.test("kv - complex key", async () => {
 });
 
 Deno.test("kv - remove key", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -689,7 +689,7 @@ Deno.test("kv - remove key", async () => {
 });
 
 Deno.test("kv - remove subkey", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -712,7 +712,7 @@ Deno.test("kv - remove subkey", async () => {
 });
 
 Deno.test("kv - create key", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -732,7 +732,7 @@ Deno.test("kv - create key", async () => {
 });
 
 Deno.test("kv - update key", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -754,7 +754,7 @@ Deno.test("kv - update key", async () => {
 });
 
 Deno.test("kv - internal consumer", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -779,7 +779,7 @@ Deno.test("kv - internal consumer", async () => {
 });
 
 Deno.test("kv - is wildcard delete implemented", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -820,7 +820,7 @@ Deno.test("kv - is wildcard delete implemented", async () => {
 });
 
 Deno.test("kv - delta", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -851,7 +851,7 @@ Deno.test("kv - delta", async () => {
 });
 
 Deno.test("kv - watch and history headers only", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const b = await new Kvm(js).create("bucket") as Bucket;
   await b.put("key1", "aaa");
@@ -884,7 +884,7 @@ Deno.test("kv - watch and history headers only", async () => {
 });
 
 Deno.test("kv - mem and file", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const d = await new Kvm(js).create("default") as Bucket;
   assertEquals((await d.status()).backingStore, StorageType.File);
@@ -906,7 +906,7 @@ Deno.test("kv - mem and file", async () => {
 });
 
 Deno.test("kv - example", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const kv = await new Kvm(js).create("testing", { history: 5 });
@@ -1132,7 +1132,7 @@ Deno.test("kv - cross account watch", async () => {
 });
 
 Deno.test("kv - watch iter stops", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const b = await new Kvm(js).create("a") as Bucket;
   const watch = await b.watch();
@@ -1148,7 +1148,7 @@ Deno.test("kv - watch iter stops", async () => {
 });
 
 Deno.test("kv - defaults to discard new - if server 2.7.2", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const b = await new Kvm(js).create("a") as Bucket;
   const jsm = await jetstreamManager(nc);
@@ -1163,7 +1163,7 @@ Deno.test("kv - defaults to discard new - if server 2.7.2", async () => {
 });
 
 Deno.test("kv - initialized watch empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const b = await new Kvm(js).create("a") as Bucket;
@@ -1182,7 +1182,7 @@ Deno.test("kv - initialized watch empty", async () => {
 });
 
 Deno.test("kv - initialized watch with modifications", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const b = await new Kvm(js).create("a") as Bucket;
@@ -1224,7 +1224,7 @@ Deno.test("kv - initialized watch with modifications", async () => {
 });
 
 Deno.test("kv - get revision", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const b = await new Kvm(js).create(nuid.next(), { history: 3 }) as Bucket;
@@ -1257,7 +1257,7 @@ Deno.test("kv - get revision", async () => {
 });
 
 Deno.test("kv - purge deletes", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const b = await new Kvm(js).create("a") as Bucket;
@@ -1283,7 +1283,7 @@ Deno.test("kv - purge deletes", async () => {
 });
 
 Deno.test("kv - allow direct", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1340,7 +1340,7 @@ Deno.test("kv - allow direct", async () => {
 });
 
 Deno.test("kv - direct message", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
@@ -1385,7 +1385,7 @@ Deno.test("kv - direct message", async () => {
 });
 
 Deno.test("kv - republish", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.9.0")) {
     return;
   }
@@ -1413,7 +1413,7 @@ Deno.test("kv - republish", async () => {
 });
 
 Deno.test("kv - ttl is in nanos", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const b = await new Kvm(js).create("a", { ttl: 1000 });
@@ -1428,7 +1428,7 @@ Deno.test("kv - ttl is in nanos", async () => {
 });
 
 Deno.test("kv - size", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
   const b = await new Kvm(js).create("a", { ttl: 1000 });
@@ -1446,8 +1446,7 @@ Deno.test("kv - size", async () => {
 Deno.test(
   "kv - mirror cross domain",
   flakyTest(async () => {
-    const { ns, nc } = await _setup(
-      connect,
+    const { ns, nc } = await setup(
       jetstreamServerConf({
         server_name: "HUB",
         jetstream: { domain: "HUB" },
@@ -1456,8 +1455,7 @@ Deno.test(
     // the ports file doesn't report leaf node
     const varz = await ns.varz() as unknown;
 
-    const { ns: lns, nc: lnc } = await _setup(
-      connect,
+    const { ns: lns, nc: lnc } = await setup(
       jetstreamServerConf({
         server_name: "LEAF",
         jetstream: { domain: "LEAF" },
@@ -1591,7 +1589,7 @@ Deno.test(
 );
 
 Deno.test("kv - previous sequence", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1611,7 +1609,7 @@ Deno.test("kv - previous sequence", async () => {
 });
 
 Deno.test("kv - encoded entry", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1629,7 +1627,7 @@ Deno.test("kv - encoded entry", async () => {
 });
 
 Deno.test("kv - create after delete", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K");
@@ -1646,7 +1644,7 @@ Deno.test("kv - create after delete", async () => {
 });
 
 Deno.test("kv - get non-existing non-direct", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K", { allow_direct: false });
   const v = await kv.get("hello");
@@ -1655,7 +1653,7 @@ Deno.test("kv - get non-existing non-direct", async () => {
 });
 
 Deno.test("kv - get non-existing direct", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K", { allow_direct: true });
   assertEquals(await kv.get("hello"), null);
@@ -1663,7 +1661,7 @@ Deno.test("kv - get non-existing direct", async () => {
 });
 
 Deno.test("kv - string payloads", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K");
@@ -1686,7 +1684,7 @@ Deno.test("kv - string payloads", async () => {
 });
 
 Deno.test("kv - metadata", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1699,7 +1697,7 @@ Deno.test("kv - metadata", async () => {
 });
 
 Deno.test("kv - watch updates only", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K");
@@ -1731,7 +1729,7 @@ Deno.test("kv - watch updates only", async () => {
 });
 
 Deno.test("kv - watch multiple keys", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K");
@@ -1761,7 +1759,7 @@ Deno.test("kv - watch multiple keys", async () => {
 });
 
 Deno.test("kv - watch history", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K", { history: 10 });
@@ -1799,7 +1797,7 @@ Deno.test("kv - watch history", async () => {
 });
 
 Deno.test("kv - watch history no deletes", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
 
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("K", { history: 10 });
@@ -1838,7 +1836,7 @@ Deno.test("kv - watch history no deletes", async () => {
 });
 
 Deno.test("kv - republish header handling", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await jetstreamManager(nc);
   const n = nuid.next();
   await jsm.streams.add({
@@ -1876,7 +1874,7 @@ Deno.test("kv - republish header handling", async () => {
 });
 
 Deno.test("kv - compression", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
   const s2 = await new Kvm(js).create("compressed", {
     compression: true,
@@ -1891,7 +1889,7 @@ Deno.test("kv - compression", async () => {
 });
 
 Deno.test("kv - watch start at", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("a");
   await kv.put("a", "1");
@@ -1912,7 +1910,7 @@ Deno.test("kv - watch start at", async () => {
 });
 
 Deno.test("kv - delete key if revision", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1934,7 +1932,7 @@ Deno.test("kv - delete key if revision", async () => {
 });
 
 Deno.test("kv - purge key if revision", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1956,7 +1954,7 @@ Deno.test("kv - purge key if revision", async () => {
 });
 
 Deno.test("kv - bind no info", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1987,7 +1985,7 @@ Deno.test("kv - bind no info", async () => {
 });
 
 Deno.test("kv - watcher will name and filter", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -2008,7 +2006,7 @@ Deno.test("kv - watcher will name and filter", async () => {
 });
 
 Deno.test("kv - honors checkAPI option", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const sub = nc.subscribe("$JS.API.INFO");
   const si = syncIterator(sub);
@@ -2024,7 +2022,7 @@ Deno.test("kv - honors checkAPI option", async () => {
 });
 
 Deno.test("kv - watcher on server restart", async () => {
-  let { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  let { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const kv = await new Kvm(js).create("A");
   const iter = await kv.watch();
@@ -2051,8 +2049,7 @@ Deno.test("kv - watcher on server restart", async () => {
 });
 
 Deno.test("kv - kv rejects in older servers", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -2082,8 +2079,7 @@ Deno.test("kv - kv rejects in older servers", async () => {
 });
 
 Deno.test("kv - maxBucketSize doesn't override max_bytes", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({}),
   );
   const kvm = new Kvm(nc);
@@ -2094,8 +2090,7 @@ Deno.test("kv - maxBucketSize doesn't override max_bytes", async () => {
 });
 
 Deno.test("kv - keys filter", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({}),
   );
   if (await notCompatible(ns, nc, "2.6.3")) {
@@ -2151,8 +2146,7 @@ Deno.test("kv - replicas", async () => {
 });
 
 Deno.test("kv - sourced", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({}),
   );
   if (await notCompatible(ns, nc, "2.6.3")) {
@@ -2180,8 +2174,7 @@ Deno.test("kv - sourced", async () => {
 });
 
 Deno.test("kv - watch isUpdate", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({}),
   );
   if (await notCompatible(ns, nc, "2.6.3")) {

--- a/obj/tests/objectstore_test.ts
+++ b/obj/tests/objectstore_test.ts
@@ -14,11 +14,10 @@
  */
 
 import {
-  _setup,
   cleanup,
-  connect,
   jetstreamServerConf,
   notCompatible,
+  setup,
 } from "test_helpers";
 import {
   assert,
@@ -95,7 +94,7 @@ function digest(data: Uint8Array): string {
 }
 
 Deno.test("objectstore - basics", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -155,7 +154,7 @@ Deno.test("objectstore - basics", async () => {
 });
 
 Deno.test("objectstore - default status", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -174,8 +173,7 @@ Deno.test("objectstore - default status", async () => {
 });
 
 Deno.test("objectstore - chunked content", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       jetstream: {
         max_memory_store: 10 * 1024 * 1024 + 33,
@@ -203,7 +201,7 @@ Deno.test("objectstore - chunked content", async () => {
 });
 
 Deno.test("objectstore - multi content", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -233,7 +231,7 @@ Deno.test("objectstore - multi content", async () => {
 });
 
 Deno.test("objectstore - delete markers", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -257,7 +255,7 @@ Deno.test("objectstore - delete markers", async () => {
 });
 
 Deno.test("objectstore - get on deleted returns error", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -284,7 +282,7 @@ Deno.test("objectstore - get on deleted returns error", async () => {
 });
 
 Deno.test("objectstore - multi with delete", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -313,7 +311,7 @@ Deno.test("objectstore - multi with delete", async () => {
 });
 
 Deno.test("objectstore - object names", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -349,7 +347,7 @@ Deno.test("objectstore - object names", async () => {
 });
 
 Deno.test("objectstore - metadata", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -382,7 +380,7 @@ Deno.test("objectstore - metadata", async () => {
 });
 
 Deno.test("objectstore - empty entry", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -408,7 +406,7 @@ Deno.test("objectstore - empty entry", async () => {
 });
 
 Deno.test("objectstore - list", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -430,7 +428,7 @@ Deno.test("objectstore - list", async () => {
 });
 
 Deno.test("objectstore - list no updates", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -448,7 +446,7 @@ Deno.test("objectstore - list no updates", async () => {
 });
 
 Deno.test("objectstore - watch isUpdate", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -472,7 +470,7 @@ Deno.test("objectstore - watch isUpdate", async () => {
 });
 
 Deno.test("objectstore - watch initially empty", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -525,7 +523,7 @@ Deno.test("objectstore - watch initially empty", async () => {
 });
 
 Deno.test("objectstore - watch skip history", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -572,7 +570,7 @@ Deno.test("objectstore - watch skip history", async () => {
 });
 
 Deno.test("objectstore - watch history", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -621,7 +619,7 @@ Deno.test("objectstore - watch history", async () => {
 });
 
 Deno.test("objectstore - same store link", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -648,7 +646,7 @@ Deno.test("objectstore - same store link", async () => {
 });
 
 Deno.test("objectstore - link of link rejected", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -673,7 +671,7 @@ Deno.test("objectstore - link of link rejected", async () => {
 });
 
 Deno.test("objectstore - external link", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -698,7 +696,7 @@ Deno.test("objectstore - external link", async () => {
 });
 
 Deno.test("objectstore - store link", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -714,8 +712,7 @@ Deno.test("objectstore - store link", async () => {
 });
 
 Deno.test("objectstore - max chunk is max payload", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 8 * 1024,
     }),
@@ -739,8 +736,7 @@ Deno.test("objectstore - max chunk is max payload", async () => {
 });
 
 Deno.test("objectstore - default chunk is 128k", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -764,8 +760,7 @@ Deno.test("objectstore - default chunk is 128k", async () => {
 });
 
 Deno.test("objectstore - sanitize", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -800,8 +795,7 @@ Deno.test("objectstore - sanitize", async () => {
 });
 
 Deno.test("objectstore - partials", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -841,8 +835,7 @@ Deno.test("objectstore - partials", async () => {
 });
 
 Deno.test("objectstore - no store", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -904,8 +897,7 @@ Deno.test("objectstore - no store", async () => {
 });
 
 Deno.test("objectstore - hashtests", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -949,8 +941,7 @@ Deno.test("objectstore - hashtests", async () => {
 });
 
 Deno.test("objectstore - meta update", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -997,8 +988,7 @@ Deno.test("objectstore - meta update", async () => {
 });
 
 Deno.test("objectstore - cannot put links", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),
@@ -1027,7 +1017,7 @@ Deno.test("objectstore - cannot put links", async () => {
 });
 
 Deno.test("objectstore - put purges old entries", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1061,7 +1051,7 @@ Deno.test("objectstore - put purges old entries", async () => {
 });
 
 Deno.test("objectstore - put previous sequences", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1105,7 +1095,7 @@ Deno.test("objectstore - put previous sequences", async () => {
 });
 
 Deno.test("objectstore - put/get blob", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1137,7 +1127,7 @@ Deno.test("objectstore - put/get blob", async () => {
 });
 
 Deno.test("objectstore - ttl", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1151,7 +1141,7 @@ Deno.test("objectstore - ttl", async () => {
 });
 
 Deno.test("objectstore - allow direct", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.6.3")) {
     return;
   }
@@ -1164,7 +1154,7 @@ Deno.test("objectstore - allow direct", async () => {
 });
 
 Deno.test("objectstore - stream metadata and entry metadata", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf({}));
+  const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
   }
@@ -1192,7 +1182,7 @@ Deno.test("objectstore - stream metadata and entry metadata", async () => {
 });
 
 Deno.test("os - compression", async () => {
-  const { ns, nc } = await _setup(connect, jetstreamServerConf());
+  const { ns, nc } = await setup(jetstreamServerConf());
   const objm = new Objm(nc);
   const s2 = await objm.create("compressed", {
     compression: true,
@@ -1207,8 +1197,7 @@ Deno.test("os - compression", async () => {
 });
 
 Deno.test("os - os rejects in older servers", async () => {
-  const { ns, nc } = await _setup(
-    connect,
+  const { ns, nc } = await setup(
     jetstreamServerConf({
       max_payload: 1024 * 1024,
     }),

--- a/services/tests/service_test.ts
+++ b/services/tests/service_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { _setup, cleanup, connect } from "test_helpers";
+import { cleanup, setup } from "test_helpers";
 import { ServiceImpl } from "../src/service.ts";
 import {
   assert,
@@ -75,7 +75,7 @@ Deno.test("service - control subject", () => {
 });
 
 Deno.test("service - bad name", async () => {
-  const { ns, nc } = await _setup(connect, {}, {});
+  const { ns, nc } = await setup({}, {});
   const svc = new Svc(nc);
   const t = async (name: string, msg: string) => {
     await assertRejects(
@@ -98,7 +98,7 @@ Deno.test("service - bad name", async () => {
 });
 
 Deno.test("service - client", async () => {
-  const { ns, nc } = await _setup(connect, {}, {});
+  const { ns, nc } = await setup({}, {});
   const subj = createInbox();
   const svc = new Svc(nc);
 
@@ -200,7 +200,7 @@ Deno.test("service - client", async () => {
 });
 
 Deno.test("service - basics", async () => {
-  const { ns, nc } = await _setup(connect, {}, {});
+  const { ns, nc } = await setup({}, {});
   const svc = new Svc(nc);
   const conf: ServiceConfig = {
     name: "test",
@@ -259,7 +259,7 @@ Deno.test("service - basics", async () => {
 });
 
 Deno.test("service - stop error", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "a",
@@ -294,7 +294,7 @@ Deno.test("service - stop error", async () => {
 });
 
 Deno.test("service - start error", async () => {
-  const { ns, nc } = await _setup(connect, {
+  const { ns, nc } = await setup({
     authorization: {
       users: [{
         user: "a",
@@ -325,7 +325,7 @@ Deno.test("service - start error", async () => {
 });
 
 Deno.test("service - callback error", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const svc = new Svc(nc);
   const srv = await svc.add({
     name: "test",
@@ -346,7 +346,7 @@ Deno.test("service - callback error", async () => {
 });
 
 Deno.test("service - service error is headers", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const svc = new Svc(nc);
   const srv = await svc.add({
     name: "test",
@@ -365,7 +365,7 @@ Deno.test("service - service error is headers", async () => {
 });
 
 Deno.test("service - sub stop", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const svc = new Svc(nc);
   const service = await svc.add({
     name: "test",
@@ -389,7 +389,7 @@ Deno.test("service - sub stop", async () => {
 });
 
 Deno.test("service - monitoring sub stop", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const svc = new Svc(nc);
   const service = await svc.add({
     name: "test",
@@ -413,7 +413,7 @@ Deno.test("service - monitoring sub stop", async () => {
 });
 
 Deno.test("service - custom stats handler", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const svc = new Svc(nc);
   const srv = await svc.add({
     name: "test",
@@ -438,7 +438,7 @@ Deno.test("service - custom stats handler", async () => {
 });
 
 Deno.test("service - bad stats handler", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const config = {
     name: "test",
@@ -462,7 +462,7 @@ Deno.test("service - bad stats handler", async () => {
 });
 
 Deno.test("service - stats handler error", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const svc = new Svc(nc);
   const srv = await svc.add({
     name: "test",
@@ -488,7 +488,7 @@ Deno.test("service - stats handler error", async () => {
 });
 
 Deno.test("service - reset", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const service = await svc.add({
@@ -530,7 +530,7 @@ Deno.test("service - reset", async () => {
 });
 
 Deno.test("service - iter", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const service = await svc.add({
@@ -566,7 +566,7 @@ Deno.test("service - iter", async () => {
 });
 
 Deno.test("service - iter closed", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const service = await svc.add({
@@ -589,7 +589,7 @@ Deno.test("service - iter closed", async () => {
 });
 
 Deno.test("service - version must be semver", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   const test = (v?: string): Promise<Service> => {
     const svc = new Svc(nc);
     return svc.add({
@@ -626,7 +626,7 @@ Deno.test("service - version must be semver", async () => {
 });
 
 Deno.test("service - service errors", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -719,7 +719,7 @@ Deno.test("service - service errors", async () => {
 // });
 
 Deno.test("service - stats name respects assigned name", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const test = await svc.add({
@@ -740,7 +740,7 @@ Deno.test("service - stats name respects assigned name", async () => {
 });
 
 Deno.test("service - multiple endpoints", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const ms = await svc.add({
@@ -776,7 +776,7 @@ Deno.test("service - multiple endpoints", async () => {
 });
 
 Deno.test("service - multi cb/iterator", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -803,7 +803,7 @@ Deno.test("service - multi cb/iterator", async () => {
 });
 
 Deno.test("service - group and endpoint names", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -831,7 +831,7 @@ Deno.test("service - group and endpoint names", async () => {
 });
 
 Deno.test("service - group subs", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -860,7 +860,7 @@ Deno.test("service - group subs", async () => {
 });
 
 Deno.test("service - metadata", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -886,7 +886,7 @@ Deno.test("service - metadata", async () => {
 });
 
 Deno.test("service - schema metadata", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -907,7 +907,7 @@ Deno.test("service - schema metadata", async () => {
 });
 
 Deno.test("service - json reviver", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({
@@ -960,7 +960,7 @@ async function testQueueName(nc: NatsConnection, subj: string, q?: string) {
 }
 
 Deno.test("service - custom queue group", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
   await testQueueName(nc, "a");
   await testQueueName(nc, "b", "q1");
   await assertRejects(
@@ -1011,7 +1011,7 @@ function checkQueueGroup(srv: Service, subj: string, queue: string) {
 }
 
 Deno.test("service - endpoint default queue group", async () => {
-  const { ns, nc } = await _setup(connect);
+  const { ns, nc } = await setup();
 
   const svc = new Svc(nc);
   const srv = await svc.add({

--- a/test_helpers/asserts.ts
+++ b/test_helpers/asserts.ts
@@ -16,6 +16,6 @@
 import { assertGreaterOrEqual, assertLessOrEqual } from "jsr:@std/assert";
 
 export function assertBetween(n: number, low: number, high: number) {
-  assertGreaterOrEqual(n, low, `${n} >= ${low}`)
-  assertLessOrEqual(n, high, `${n} <= ${high}`)
+  assertGreaterOrEqual(n, low, `${n} >= ${low}`);
+  assertLessOrEqual(n, high, `${n} <= ${high}`);
 }

--- a/test_helpers/launcher.ts
+++ b/test_helpers/launcher.ts
@@ -662,10 +662,10 @@ export class NatsServer implements PortInfo {
    * @param conf
    */
   async reload(conf?: any): Promise<void> {
-    conf = NatsServer.confDefaults(conf);
     conf.host = this.config.host;
     conf.port = this.config.port;
     conf.http = this.config.http;
+    conf.websocket = this.config.websocket;
     conf.leafnodes = this.config.leafnodes;
     conf = Object.assign(this.config, conf);
     await Deno.writeFile(

--- a/test_helpers/mod.ts
+++ b/test_helpers/mod.ts
@@ -27,9 +27,7 @@ import { ConnectFn } from "../core/src/core.ts";
 export { check } from "./check.ts";
 export { Lock } from "./lock.ts";
 export { Connection, TestServer } from "./test_server.ts";
-export {
-  assertBetween,
-} from "./asserts.ts";
+export { assertBetween } from "./asserts.ts";
 export { NatsServer, ServerSignals } from "./launcher.ts";
 
 export function disabled(reason: string): void {
@@ -51,12 +49,12 @@ export function jsopts() {
 }
 
 export function wsopts() {
-    return {
-      websocket: {
-        no_tls: true,
-        port: -1,
-      },
-    };
+  return {
+    websocket: {
+      no_tls: true,
+      port: -1,
+    },
+  };
 }
 
 export function jetstreamExportServerConf(
@@ -99,21 +97,19 @@ export function jetstreamServerConf(
   return conf as Record<string, unknown>;
 }
 
-export function wsServerConf(opts: unknown = {}): Record<string,unknown> {
+export function wsServerConf(opts: unknown = {}): Record<string, unknown> {
   return Object.assign(wsopts(), opts);
 }
 
 export async function _setup(
-  fn: ConnectFn,
+  _fn: ConnectFn,
   serverConf?: Record<string, unknown>,
   clientOpts?: Partial<ConnectionOptions>,
 ): Promise<{ ns: NatsServer; nc: NatsConnection }> {
   const dt = serverConf as { debug: boolean; trace: boolean };
   const debug = dt && (dt.debug || dt.trace);
   const ns = await NatsServer.start(serverConf, debug);
-  clientOpts = clientOpts ? clientOpts : {};
-  const copts = extend({ port: ns.port }, clientOpts) as ConnectionOptions;
-  const nc = await fn(copts);
+  const nc = await ns.connect(clientOpts);
   return { ns, nc };
 }
 
@@ -156,8 +152,8 @@ export async function notCompatible(
 }
 
 export function flakyTest(
-    fn:  () => void | Promise<void>,
-    { count = 3 } = {},
+  fn: () => void | Promise<void>,
+  { count = 3 } = {},
 ): () => Promise<void> {
   return async () => {
     const errors: Error[] = [];
@@ -169,5 +165,5 @@ export function flakyTest(
       }
     }
     throw new AggregateError(errors);
-  }
+  };
 }

--- a/test_helpers/mod.ts
+++ b/test_helpers/mod.ts
@@ -17,13 +17,11 @@ import type {
   ConnectionOptions,
   NatsConnection,
 } from "../core/src/internal_mod.ts";
-import { compare, extend, parseSemVer } from "../core/src/internal_mod.ts";
+import { compare, parseSemVer } from "../core/src/internal_mod.ts";
 
 import { NatsServer } from "./launcher.ts";
 import { red, yellow } from "jsr:@std/fmt/colors";
-import { connect } from "./connect.ts";
 export { connect } from "./connect.ts";
-import { ConnectFn } from "../core/src/core.ts";
 export { check } from "./check.ts";
 export { Lock } from "./lock.ts";
 export { Connection, TestServer } from "./test_server.ts";
@@ -101,8 +99,7 @@ export function wsServerConf(opts: unknown = {}): Record<string, unknown> {
   return Object.assign(wsopts(), opts);
 }
 
-export async function _setup(
-  _fn: ConnectFn,
+export async function setup(
   serverConf?: Record<string, unknown>,
   clientOpts?: Partial<ConnectionOptions>,
 ): Promise<{ ns: NatsServer; nc: NatsConnection }> {
@@ -111,13 +108,6 @@ export async function _setup(
   const ns = await NatsServer.start(serverConf, debug);
   const nc = await ns.connect(clientOpts);
   return { ns, nc };
-}
-
-export function setup(
-  serverConf?: Record<string, unknown>,
-  clientOpts?: Partial<ConnectionOptions>,
-): Promise<{ ns: NatsServer; nc: NatsConnection }> {
-  return _setup(connect, serverConf, clientOpts);
 }
 
 export async function cleanup(


### PR DESCRIPTION
This PR enables tests to use the `wsconnect` and run all the tests using a websocket if the connection is obtained by asking the `NatsServer#connect()` and the environment variable `websocket` is set.

This PR also fixes a timer leak detected on a few of the tests while using the websocket transport and the client was in the middle of a dial when the test ended.