### PR TITLE
FEAT: services api queue option empty string means no queue, metadata is read-only

### DIFF
--- a/services/src/service.ts
+++ b/services/src/service.ts
@@ -162,7 +162,7 @@ export class ServiceGroupImpl implements ServiceGroup {
     } else if (parent instanceof ServiceGroupImpl) {
       const sg = parent as ServiceGroupImpl;
       this.srv = sg.srv;
-      if (queue === "" && sg.queue !== "") {
+      if (queue === undefined) {
         queue = sg.queue;
       }
       root = sg.subject;
@@ -198,7 +198,10 @@ export class ServiceGroupImpl implements ServiceGroup {
     return this.srv._addEndpoint(ne);
   }
 
-  addGroup(name = "", queue = ""): ServiceGroup {
+  addGroup(name = "", queue?: string): ServiceGroup {
+    if (queue === undefined) {
+      queue = this.queue;
+    }
     return new ServiceGroupImpl(this, name, queue);
   }
 }
@@ -286,13 +289,18 @@ export class ServiceImpl implements Service {
   ) {
     this.nc = nc;
     this.config = Object.assign({}, config);
-    if (!this.config.queue) {
+    if (this.config.queue === undefined) {
       this.config.queue = "q";
     }
 
+    // don't allow changing metadata
+    config.metadata = Object.freeze(config.metadata || {});
+
     // this will throw if no name
     validateName("name", this.config.name);
-    validateName("queue", this.config.queue);
+    if (this.config.queue) {
+      validateName("queue", this.config.queue);
+    }
 
     // this will throw if not semver
     parseSemVer(this.config.version);

--- a/services/src/types.ts
+++ b/services/src/types.ts
@@ -51,7 +51,8 @@ export type Endpoint = {
   metadata?: Record<string, string>;
   /**
    * Optional queue group to run this particular endpoint in. The service's configuration
-   * queue configuration will be used. See {@link ServiceConfig}.
+   * queue configuration will be used. See {@link ServiceConfig}. Note that if the queue
+   * is set to an empty string, it will not be run in a queue.
    */
   queue?: string;
 };
@@ -81,6 +82,8 @@ export interface ServiceGroup {
    * without requiring editing of the service.
    * Note that an optional queue can be specified, all endpoints added to
    * the group, will use the specified queue unless the endpoint overrides it.
+   * When not set, it uses the parent group configuration. An empty string
+   * means no queue.
    * see {@link EndpointOptions} and {@link ServiceConfig}.
    * @param subject
    * @param queue
@@ -208,9 +211,11 @@ export type ServiceConfig = {
    */
   metadata?: Record<string, string>;
   /**
-   * Optional queue group to run the service in. By default,
-   * then queue name is "q". Note that this configuration will
-   * be the default for all endpoints and groups.
+   * Optional queue group to run the service in. If not set, default,
+   * is set to "q". Note that this configuration will
+   * be the default for all endpoints and groups. If set to an empty
+   * string, the service subscription will NOT have queue, and will
+   * not be run in a queue.
    */
   queue?: string;
 };


### PR DESCRIPTION
breaking (services): the queue property now, if set to an empty string, means that the service/endpoint/group will not be in a queue. Clients that specifically assign queue names should experience no changes. Clients that didn't specify a value for the property (so the property was undefined) should also not experience a change and should see their service/endpoint/group use the `q` group. If explicitly set to an empty string ``, the service will NOT be part of a queue.

breaking (services): The metadata configuration specified when creating the service is now stored read-only. Any edit on the internal copy will result in a `TypeError` as the metadata object is frozen.