### PR TITLE
change(jetstream): Stream.getMessage() to return null for non-existent messages

### DIFF
--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-24",
+  "version": "3.0.0-25",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-24",
+  "version": "3.0.0-25",
   "files": [
     "lib/",
     "LICENSE",

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -223,7 +223,7 @@ export interface StreamAPI {
    * @param stream
    * @param query
    */
-  getMessage(stream: string, query: MsgRequest): Promise<StoredMsg>;
+  getMessage(stream: string, query: MsgRequest): Promise<StoredMsg | null>;
 
   /**
    * Find the stream that stores the specified subject.
@@ -789,7 +789,7 @@ export interface DirectStreamAPI {
   getMessage(
     stream: string,
     query: DirectMsgRequest,
-  ): Promise<StoredMsg>;
+  ): Promise<StoredMsg | null>;
 
   /**
    * Retrieves all last subject messages for the specified subjects
@@ -917,7 +917,7 @@ export interface Stream {
   //     | BoundPushConsumerOptions,
   // ): Promise<PushConsumer>;
 
-  getMessage(query: MsgRequest): Promise<StoredMsg>;
+  getMessage(query: MsgRequest): Promise<StoredMsg | null>;
 
   deleteMessage(seq: number, erase?: boolean): Promise<boolean>;
 }

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -152,7 +152,7 @@ Deno.test("jetstream - publish id", async () => {
 
   const jsm = await jetstreamManager(nc);
   const sm = await jsm.streams.getMessage(stream, { seq: 1 });
-  assertEquals(sm.header.get(PubHeaders.MsgIdHdr), "a");
+  assertEquals(sm?.header.get(PubHeaders.MsgIdHdr), "a");
 
   await cleanup(ns, nc);
 });
@@ -225,7 +225,7 @@ Deno.test("jetstream - get message last by subject", async () => {
   const sm = await jsm.streams.getMessage(stream, {
     last_by_subj: `${stream}.A`,
   });
-  assertEquals(sm.string(), "aa");
+  assertEquals(sm?.string(), "aa");
 
   await cleanup(ns, nc);
 });
@@ -960,7 +960,7 @@ Deno.test("jetstream - input transform", async () => {
   assertEquals(pa.seq, 1);
 
   const m = await jsm.streams.getMessage(si.config.name, { seq: 1 });
-  assertEquals(m.subject, "transformed.foo");
+  assertEquals(m?.subject, "transformed.foo");
 
   await cleanup(ns, nc);
 });

--- a/jetstream/tests/streams_test.ts
+++ b/jetstream/tests/streams_test.ts
@@ -78,6 +78,7 @@ Deno.test("streams - consumers", async () => {
 
   // get a message
   const sm = await s.getMessage({ seq: 1 });
+  assertExists(sm);
   let d = sm.json<{ hello: string }>();
   assertEquals(d.hello, "world");
 
@@ -122,13 +123,7 @@ Deno.test("streams - delete message", async () => {
   assertExists(sm);
 
   assertEquals(await s.deleteMessage(2, true), true);
-  await assertRejects(
-    async () => {
-      await s.getMessage({ seq: 2 });
-    },
-    Error,
-    "no message found",
-  );
+  assertEquals(await s.getMessage({ seq: 2 }), null);
 
   const si = await s.info(false, { deleted_details: true });
   assertEquals(si.state.deleted, [2]);

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-18",
+  "version": "3.0.0-19",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,6 +34,6 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-36",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-24"
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-25"
   }
 }

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-36",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-36/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-24",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-24/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-25",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-25/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@1.2.0-4",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.1-2",

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-18",
+  "version": "3.0.0-19",
   "files": [
     "lib/",
     "LICENSE",
@@ -34,7 +34,7 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-24",
+    "@nats-io/jetstream": "3.0.0-25",
     "@nats-io/nats-core": "3.0.0-36"
   },
   "devDependencies": {

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -619,7 +619,7 @@ export class Bucket implements KV {
       arg = { seq: opts.revision };
     }
 
-    let sm: StoredMsg;
+    let sm: StoredMsg | null = null;
     try {
       if (this.direct) {
         const direct =
@@ -628,18 +628,15 @@ export class Bucket implements KV {
       } else {
         sm = await this.jsm.streams.getMessage(this.bucketName(), arg);
       }
+      if (sm === null) {
+        return null;
+      }
       const ke = this.smToEntry(sm);
       if (ke.key !== ek) {
         return null;
       }
       return ke;
     } catch (err) {
-      if (err instanceof JetStreamApiError) {
-        const jserr = err as JetStreamApiError;
-        if (jserr.code === JetStreamApiCodes.NoMessageFound) {
-          return null;
-        }
-      }
       throw err;
     }
   }

--- a/migration.md
+++ b/migration.md
@@ -120,6 +120,9 @@ To use JetStream, you must install and import `@nats/jetstream`.
   `StreamNotFound`, `JetStreamNotEnabled` are subtypes of the above. For API
   calls where the server could return an error, these are `JetStreamAPIError`
   and contain all the information returned by the server.
+- JetStream `Stream.getMessage()` will now return null if when a message not
+  found error raises, this simplifies client usage and aligns with other APIs in
+  the client.
 
 ## Changes to KV
 

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-19",
+  "version": "3.0.0-20",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,6 +34,6 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-36",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-24"
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-25"
   }
 }

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-36",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-36/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-24",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-24/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-25",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-25/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@1.2.0-4",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.1-2",

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-19",
+  "version": "3.0.0-20",
   "files": [
     "lib/",
     "LICENSE",
@@ -34,7 +34,7 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-24",
+    "@nats-io/jetstream": "3.0.0-25",
     "@nats-io/nats-core": "3.0.0-36"
   },
   "devDependencies": {

--- a/obj/src/objectstore.ts
+++ b/obj/src/objectstore.ts
@@ -362,16 +362,13 @@ export class ObjectStoreImpl implements ObjectStore {
       const m = await this.jsm.streams.getMessage(this.stream, {
         last_by_subj: meta,
       });
+      if (m === null) {
+        return null;
+      }
       const soi = m.json<ServerObjectInfo>();
       soi.revision = m.seq;
       return soi;
     } catch (err) {
-      if (
-        err instanceof JetStreamApiError &&
-        err.code === JetStreamApiCodes.NoMessageFound
-      ) {
-        return null;
-      }
       return Promise.reject(err);
     }
   }


### PR DESCRIPTION
Refactor JetStream's getMessage() method to return null instead of throwing an error when a message is not found. This change simplifies error handling in client code and aligns with other API behaviors.

Fix #122 