### PR TITLE
fix(jetstream): ordered consumer created with DeliverPolicy.All would fail since the default was specifying a sequence

### DIFF
--- a/jetstream/src/jsmstream_api.ts
+++ b/jetstream/src/jsmstream_api.ts
@@ -287,6 +287,7 @@ export class ConsumersImpl implements Consumers {
     config.deliver_policy = opts.deliver_policy ||
       DeliverPolicy.StartSequence;
     if (
+      opts.deliver_policy === DeliverPolicy.All ||
       opts.deliver_policy === DeliverPolicy.LastPerSubject ||
       opts.deliver_policy === DeliverPolicy.New ||
       opts.deliver_policy === DeliverPolicy.Last

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -1186,3 +1186,14 @@ Deno.test(
     await cleanup(ns, nc);
   }),
 );
+
+Deno.test("ordered consumer - deliver all policy", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "A", subjects: ["a"] });
+
+  const js = jetstream(nc);
+  await js.consumers.get("A", { deliver_policy: DeliverPolicy.All });
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
Fix #113