### PR TITLE
subscription closed promise can now provide the reason for the close

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -579,8 +579,13 @@ export function syncIterator<T>(src: AsyncIterable<T>): SyncIterator<T> {
  * Basic interface to a Subscription type
  */
 export interface Subscription extends AsyncIterable<Msg> {
-  /** A promise that resolves when the subscription closes */
-  closed: Promise<void>;
+  /**
+   * A promise that resolves when the subscription closes. If the promise
+   * resolves to an error, the subscription was closed because of an error
+   * typically a permissions error. Note that this promise doesn't reject, but
+   * rather resolves to void (no error) or an Error
+   */
+  closed: Promise<void | Error>;
 
   /**
    * Stop the subscription from receiving messages. You can optionally

--- a/core/tests/auth_test.ts
+++ b/core/tests/auth_test.ts
@@ -945,6 +945,9 @@ Deno.test("auth - perm sub iterator error", async () => {
     `Permissions Violation for Subscription to "q"`,
   );
 
+  const err = await sub.closed;
+  assertEquals(err instanceof errors.PermissionViolationError, true);
+
   await cleanup(ns, nc);
 });
 
@@ -967,7 +970,7 @@ Deno.test("auth - perm error is not in lastError", async () => {
   assertEquals(nci.protocol.lastError, undefined);
 
   const d = deferred<Error | null>();
-  nc.subscribe("q", {
+  const sub = nc.subscribe("q", {
     callback: (err) => {
       d.resolve(err);
     },
@@ -977,6 +980,9 @@ Deno.test("auth - perm error is not in lastError", async () => {
   assert(err !== null);
   assert(err instanceof errors.PermissionViolationError);
   assert(nci.protocol.lastError === undefined);
+
+  const err2 = await sub.closed;
+  assert(err2 instanceof errors.PermissionViolationError);
 
   await cleanup(ns, nc);
 });

--- a/migration.md
+++ b/migration.md
@@ -97,6 +97,8 @@ these modules for cross-runtime consumption.
   data and are easier to use from different modules, since you can provide the
   string name of the type. For more information see
   [Lifecycle and Informational and Events](core/README.md#lifecycle-and-informational-events)
+- Subscription#closed now resolves to void or an Error (it doesn't throw). The
+  error is the reason why the subscription closed.
 
 ## Changes in JetStream
 


### PR DESCRIPTION
feat(core): subscriptions `closed` promise can now resolve to void or Error - if error the subscription was closed due to an error. Note that it doesn't reject, but rather resolves to the Error.