### PR TITLE
fetch()/next() rely on missed heartbeats to detect abnormally ending next requests

### DIFF
--- a/jetstream/tests/jetstream_pullconsumer_test.ts
+++ b/jetstream/tests/jetstream_pullconsumer_test.ts
@@ -70,7 +70,7 @@ Deno.test("jetstream - cross account pull", async () => {
 
   // create a durable config
   await admjsm.consumers.add(stream, {
-    ack_policy: AckPolicy.Explicit,
+    ack_policy: AckPolicy.None,
     durable_name: "me",
   });
 
@@ -90,7 +90,8 @@ Deno.test("jetstream - cross account pull", async () => {
   msg = await c.next();
   assertExists(msg);
   assertEquals(msg.seq, 2);
-  msg = await c.next({ expires: 1000 });
+
+  msg = await c.next({ expires: 5000 });
   assertEquals(msg, null);
 
   await cleanup(ns, admin, nc);

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -744,7 +744,7 @@ Deno.test("jetstream - backoff", async () => {
   });
 
   offset.slice(1).forEach((n, idx) => {
-    assertAlmostEquals(n, ms[idx], 20);
+    assertAlmostEquals(n, ms[idx], 50);
   });
 
   await cleanup(ns, nc);

--- a/migration.md
+++ b/migration.md
@@ -133,6 +133,8 @@ To use JetStream, you must install and import `@nats/jetstream`.
   found error raises, this simplifies client usage and aligns with other APIs in
   the client.
 - MsgRequest for `Stream#getMessage()` removed deprecated number argument.
+- For non-ordered consumers next/fetch() can will now throw/reject when
+  heartbeats are missed.
 
 ## Changes to KV
 

--- a/test_helpers/mod.ts
+++ b/test_helpers/mod.ts
@@ -66,8 +66,8 @@ export function jetstreamExportServerConf(
         jetstream: "enabled",
         users: [{ user: "js", password: "js" }],
         exports: [
-          { service: "$JS.API.>" },
-          { service: "$JS.ACK.>" },
+          { service: "$JS.API.>", response_type: "stream" },
+          { service: "$JS.ACK.>", response_type: "stream" },
           { stream: "A.>", accounts: ["A"] },
         ],
       },


### PR DESCRIPTION
fix(jetstream) fetch/next() now rely on missing heartbeat detection to fail requests that were not properly "finished" by the server. This has the benefit that messages arriving "late" are now likely to complete successfully since the client won't be proactively ending the request.

change(jetstream) non-ordered fetch/next will now throw/reject if heartbeats are missed - previously you could find out if you had statuses enabled on the fetch. On next() it was silently ignored and the client received a null message.

tests(jetstream): removed flapper tests that attempted yield ConsumerNotFound/StreamNotFound when a resource as removed prior to a consume/fetch/next.

tests(jestream): fixed cross-account configurations to have a response_type of "stream"

There's also a small implication for the edge case where a client is partitioned from jetstream towards the end of the fetch/next - in those cases is possible for the request to extend for up-to a minute (max heartbeat interval is 30s, and two misses are required). This is an edge condition when compared to the normal fetch/next that gets a new message towards the end of the expires. In this more common case, there won't be a redelivery since the message won't be dropped because of an overly eager timeout.

Fix #149