### PR TITLE
ConsumerStatus changed to simple type `ConsumerNotification`

### DIFF
--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-29",
+  "version": "3.0.0-31",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-29",
+  "version": "3.0.0-31",
   "files": [
     "lib/",
     "LICENSE",

--- a/jetstream/src/internal_mod.ts
+++ b/jetstream/src/internal_mod.ts
@@ -15,8 +15,6 @@
 
 export {
   AdvisoryKind,
-  ConsumerDebugEvents,
-  ConsumerEvents,
   DirectMsgHeaders,
   isBoundPushConsumerOptions,
   isOrderedPushConsumerOptions,
@@ -48,8 +46,8 @@ export type {
   ConsumerCallbackFn,
   ConsumerKind,
   ConsumerMessages,
+  ConsumerNotification,
   Consumers,
-  ConsumerStatus,
   DeleteableConsumer,
   Destroyable,
   DirectStreamAPI,

--- a/jetstream/src/jserrors.ts
+++ b/jetstream/src/jserrors.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Msg } from "@nats-io/nats-core";
-import { JsHeaders } from "./types.ts";
+import { type Heartbeat, JsHeaders } from "./types.ts";
 import type { ApiError } from "./jsapi_types.ts";
 
 export class JetStreamNotEnabled extends Error {
@@ -89,14 +89,15 @@ export class JetStreamStatus {
   }
 
   parseHeartbeat():
-    | { natsLastConsumer: number; natsLastStream: number }
+    | Heartbeat
     | null {
     if (this.isIdleHeartbeat()) {
       return {
-        natsLastConsumer: parseInt(
+        type: "heartbeat",
+        lastConsumerSequence: parseInt(
           this.msg.headers?.get("Nats-Last-Consumer") || "0",
         ),
-        natsLastStream: parseInt(
+        lastStreamSequence: parseInt(
           this.msg.headers?.get("Nats-Last-Stream") || "0",
         ),
       };

--- a/jetstream/src/mod.ts
+++ b/jetstream/src/mod.ts
@@ -17,8 +17,6 @@ export { jetstream, jetstreamManager } from "./internal_mod.ts";
 export {
   AckPolicy,
   AdvisoryKind,
-  ConsumerDebugEvents,
-  ConsumerEvents,
   DeliverPolicy,
   DirectMsgHeaders,
   DiscardPolicy,
@@ -56,8 +54,8 @@ export type {
   ConsumerInfo,
   ConsumerKind,
   ConsumerMessages,
+  ConsumerNotification,
   Consumers,
-  ConsumerStatus,
   ConsumerUpdateConfig,
   DeleteableConsumer,
   DeliveryInfo,

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -21,12 +21,7 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "jsr:@std/assert";
-import {
-  ConsumerEvents,
-  DeliverPolicy,
-  jetstream,
-  jetstreamManager,
-} from "../src/mod.ts";
+import { DeliverPolicy, jetstream, jetstreamManager } from "../src/mod.ts";
 import type { ConsumerMessages, JsMsg } from "../src/mod.ts";
 import {
   cleanup,
@@ -884,7 +879,7 @@ Deno.test("ordered consumers - fetch reset", async () => {
   function countResets(iter: ConsumerMessages): Promise<void> {
     return (async () => {
       for await (const s of iter.status()) {
-        if (s.type === ConsumerEvents.OrderedConsumerRecreated) {
+        if (s.type === "ordered_consumer_recreated") {
           recreates++;
         }
       }
@@ -933,7 +928,7 @@ Deno.test("ordered consumers - consume reset", async () => {
   function countRecreates(iter: ConsumerMessages): Promise<void> {
     return (async () => {
       for await (const s of iter.status()) {
-        if (s.type === ConsumerEvents.OrderedConsumerRecreated) {
+        if (s.type === "ordered_consumer_recreated") {
           recreates++;
         }
       }
@@ -1106,7 +1101,7 @@ Deno.test(
     function countRecreates(iter: ConsumerMessages): Promise<void> {
       return (async () => {
         for await (const s of iter.status()) {
-          if (s.type === ConsumerEvents.OrderedConsumerRecreated) {
+          if (s.type === "ordered_consumer_recreated") {
             recreates++;
           }
         }

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-23",
+  "version": "3.0.0-25",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,6 +34,6 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-42",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-29"
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-31"
   }
 }

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-42",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-42/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-29",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-29/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-31",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-31/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2",

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-23",
+  "version": "3.0.0-25",
   "files": [
     "lib/",
     "LICENSE",
@@ -34,7 +34,7 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-29",
+    "@nats-io/jetstream": "3.0.0-31",
     "@nats-io/nats-core": "3.0.0-42"
   },
   "devDependencies": {

--- a/migration.md
+++ b/migration.md
@@ -135,6 +135,9 @@ To use JetStream, you must install and import `@nats/jetstream`.
 - MsgRequest for `Stream#getMessage()` removed deprecated number argument.
 - For non-ordered consumers next/fetch() can will now throw/reject when
   heartbeats are missed.
+- The `ConsumerEvents` and `ConsumerDebugEvents` enum has been removed and
+  replaced with `ConsumerNotification` which have a discriminating field `type`.
+  The status objects provide a more specific API for querying those events.
 
 ## Changes to KV
 

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-24",
+  "version": "3.0.0-26",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,6 +34,6 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-42",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-29"
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-31"
   }
 }

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-42",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-42/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-29",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-29/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-31",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-31/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2",

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-24",
+  "version": "3.0.0-26",
   "files": [
     "lib/",
     "LICENSE",
@@ -34,7 +34,7 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-29",
+    "@nats-io/jetstream": "3.0.0-31",
     "@nats-io/nats-core": "3.0.0-42"
   },
   "devDependencies": {

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -64,8 +64,8 @@
     "nats-jwt": "^0.0.9",
     "shx": "^0.3.3",
     "typescript": "5.6.3",
-    "@nats-io/jetstream": "3.0.0-29",
-    "@nats-io/kv": "3.0.0-23",
-    "@nats-io/obj": "3.0.0-24"
+    "@nats-io/jetstream": "3.0.0-31",
+    "@nats-io/kv": "3.0.0-25",
+    "@nats-io/obj": "3.0.0-26"
   }
 }


### PR DESCRIPTION
change(jetstream): `ConsumerStatus` and `ConsumerDebugStatus` are now… replaced by `ConsumerNotification` which is an alias for specific types for the the different notifications. All discriminated by their `type` field. This simplifies down-stream consumption and provides a richer API for accessing the data in the notification.