### PR TITLE
Drop wrong badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # NATS.js - The JavaScript clients for [NATS](http://nats.io)
 
 [![License](https://img.shields.io/badge/Licence-Apache%202.0-blue.svg)](./LICENSE)
-![Test NATS.deno](https://github.com/nats-io/nats.deno/workflows/NATS.deno/badge.svg)
-[![Coverage Status](https://coveralls.io/repos/github/nats-io/nats.deno/badge.svg?branch=main)](https://coveralls.io/github/nats-io/nats.deno?branch=main)
 [![JSDoc](https://img.shields.io/badge/JSDoc-reference-blue)](https://nats-io.github.io/nats.js/)
 
 > [!IMPORTANT]


### PR DESCRIPTION
1. each lib has it's own release badge now
2. @aricart to fix the coverage badge eventually

[ci skip]