### PR TITLE
Add badges for CI workflow and test coverage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![License](https://img.shields.io/badge/Licence-Apache%202.0-blue.svg)](./LICENSE)
 [![JSDoc](https://img.shields.io/badge/JSDoc-reference-blue)](https://nats-io.github.io/nats.js/)
+![example workflow](https://github.com/nats-io/nats.js/actions/workflows/test.yml/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/nats-io/nats.js/badge.svg?branch=main)](https://coveralls.io/github/nats-io/nats.js?branch=main)
 
 > [!IMPORTANT]
 >


### PR DESCRIPTION
The README now displays badges for the example CI workflow and test coverage, providing more visibility into the project's status. This helps users quickly assess build health and code coverage.

[ci skip]