### PR TITLE
Remove deprecated `backingStore` from KV types and tests

### DIFF
--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -120,12 +120,6 @@ export type KvLimits = {
   sources?: StreamSource[];
 
   /**
-   * deprecated: use storage
-   * FIXME: remove this on 1.8
-   */
-  backingStore: StorageType;
-
-  /**
    * Sets the compression level of the KV. This feature is only supported in
    * servers 2.10.x and better.
    */

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -887,19 +887,16 @@ Deno.test("kv - mem and file", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
   const d = await new Kvm(js).create("default") as Bucket;
-  assertEquals((await d.status()).backingStore, StorageType.File);
   assertEquals((await d.status()).storage, StorageType.File);
 
   const f = await new Kvm(js).create("file", {
     storage: StorageType.File,
   }) as Bucket;
-  assertEquals((await f.status()).backingStore, StorageType.File);
   assertEquals((await f.status()).storage, StorageType.File);
 
   const m = await new Kvm(js).create("mem", {
     storage: StorageType.Memory,
   }) as Bucket;
-  assertEquals((await m.status()).backingStore, StorageType.Memory);
   assertEquals((await m.status()).storage, StorageType.Memory);
 
   await cleanup(ns, nc);

--- a/migration.md
+++ b/migration.md
@@ -189,6 +189,9 @@ Removed deprecated KV apis (`KvRemove` - `remove(k)=>Promise<void>`,
 `close()=>Promise<void>`) and options (`maxBucketSize`,
 `placementCluster`,`bucket_location`)
 
+Removed the deprecated option `backingStore` from `KvOptions` and `KvStatus`.
+Use `KvOptions.storage` and `KvStatus.storage`.
+
 ## Changes to ObjectStore
 
 > [!CAUTION]


### PR DESCRIPTION
The `backingStore` field in `KvOptions` and `KvStatus` was removed. References in the tests were updated to use `storage` instead. The migration guide was updated to reflect this change and provide guidance for users.