### PR TITLE
Update redeliveryCount to deliveryCount across codebase

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -979,7 +979,8 @@ export type ConsumerUpdateConfig = PriorityGroups & {
    */
   "ack_wait"?: Nanos;
   /**
-   * The number of times a message will be redelivered to consumers if not acknowledged in time
+   * The maximum number of times a message will be delivered to consumers if not acknowledged in time.
+   * Default is -1 (will redeliver until acknowledged).
    */
   "max_deliver"?: number;
   /**
@@ -1163,9 +1164,9 @@ export type DeliveryInfo = {
    */
   consumer: string;
   /**
-   * The number of times the message has been redelivered.
+   * The number of times the message has been delivered.
    */
-  redeliveryCount: number;
+  deliveryCount: number;
   /**
    * The sequence number of the message in the stream
    */

--- a/jetstream/src/jsmsg.ts
+++ b/jetstream/src/jsmsg.ts
@@ -162,9 +162,9 @@ export function parseInfo(s: string): DeliveryInfo {
   }
 
   // old
-  // "$JS.ACK.<stream>.<consumer>.<redeliveryCount><streamSeq><deliverySequence>.<timestamp>.<pending>"
+  // "$JS.ACK.<stream>.<consumer>.<deliveryCount><streamSeq><deliverySequence>.<timestamp>.<pending>"
   // new
-  // $JS.ACK.<domain>.<accounthash>.<stream>.<consumer>.<redeliveryCount>.<streamSeq>.<deliverySequence>.<timestamp>.<pending>.<random>
+  // $JS.ACK.<domain>.<accounthash>.<stream>.<consumer>.<deliveryCount>.<streamSeq>.<deliverySequence>.<timestamp>.<pending>.<random>
   const di = {} as DeliveryInfo;
   // if domain is "_", replace with blank
   di.domain = tokens[2] === "_" ? "" : tokens[2];

--- a/jetstream/src/jsmsg.ts
+++ b/jetstream/src/jsmsg.ts
@@ -171,8 +171,8 @@ export function parseInfo(s: string): DeliveryInfo {
   di.account_hash = tokens[3];
   di.stream = tokens[4];
   di.consumer = tokens[5];
-  di.redeliveryCount = parseInt(tokens[6], 10);
-  di.redelivered = di.redeliveryCount > 1;
+  di.deliveryCount = parseInt(tokens[6], 10);
+  di.redelivered = di.deliveryCount > 1;
   di.streamSequence = parseInt(tokens[7], 10);
   di.deliverySequence = parseInt(tokens[8], 10);
   di.timestampNanos = parseInt(tokens[9], 10);
@@ -216,7 +216,7 @@ export class JsMsgImpl implements JsMsg {
   }
 
   get redelivered(): boolean {
-    return this.info.redeliveryCount > 1;
+    return this.info.deliveryCount > 1;
   }
 
   get reply(): string {

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -730,7 +730,7 @@ Deno.test("jetstream - backoff", async () => {
   const iter = await c.consume({
     callback: (m) => {
       when.push(Date.now());
-      if (m.info.redeliveryCount === 4) {
+      if (m.info.deliveryCount === 4) {
         iter.stop();
       }
     },
@@ -779,7 +779,7 @@ Deno.test("jetstream - redelivery", async () => {
       if (m.redelivered) {
         redeliveries++;
       }
-      if (m.info.redeliveryCount === 4) {
+      if (m.info.deliveryCount === 4) {
         setTimeout(() => {
           iter.stop();
         }, 2000);

--- a/jetstream/tests/jsmsg_test.ts
+++ b/jetstream/tests/jsmsg_test.ts
@@ -48,7 +48,7 @@ Deno.test("jsmsg - parse", () => {
   const info = parseInfo(rs);
   assertEquals(info.stream, "streamname");
   assertEquals(info.consumer, "consumername");
-  assertEquals(info.redeliveryCount, 2);
+  assertEquals(info.deliveryCount, 2);
   assertEquals(info.streamSequence, 3);
   assertEquals(info.pending, 100);
 });
@@ -63,7 +63,7 @@ Deno.test("jsmsg - parse long", () => {
   assertEquals(info.account_hash, "account");
   assertEquals(info.stream, "streamname");
   assertEquals(info.consumer, "consumername");
-  assertEquals(info.redeliveryCount, 2);
+  assertEquals(info.deliveryCount, 2);
   assertEquals(info.streamSequence, 3);
   assertEquals(info.pending, 100);
 });

--- a/jetstream/tests/jsmsg_test.ts
+++ b/jetstream/tests/jsmsg_test.ts
@@ -43,7 +43,7 @@ import type { JetStreamManagerImpl } from "../src/jsclient.ts";
 import { errors } from "../../core/src/mod.ts";
 
 Deno.test("jsmsg - parse", () => {
-  // "$JS.ACK.<stream>.<consumer>.<redeliveryCount><streamSeq><deliverySequence>.<timestamp>.<pending>"
+  // "$JS.ACK.<stream>.<consumer>.<deliveryCount><streamSeq><deliverySequence>.<timestamp>.<pending>"
   const rs = `$JS.ACK.streamname.consumername.2.3.4.${nanos(Date.now())}.100`;
   const info = parseInfo(rs);
   assertEquals(info.stream, "streamname");
@@ -54,7 +54,7 @@ Deno.test("jsmsg - parse", () => {
 });
 
 Deno.test("jsmsg - parse long", () => {
-  // $JS.ACK.<domain>.<accounthash>.<stream>.<consumer>.<redeliveryCount>.<streamSeq>.<deliverySequence>.<timestamp>.<pending>.<random>
+  // $JS.ACK.<domain>.<accounthash>.<stream>.<consumer>.<deliveryCount>.<streamSeq>.<deliverySequence>.<timestamp>.<pending>.<random>
   const rs = `$JS.ACK.domain.account.streamname.consumername.2.3.4.${
     nanos(Date.now())
   }.100.rand`;
@@ -100,7 +100,7 @@ Deno.test("jsmsg - acks", async () => {
         fail(err.message);
       }
       msg.respond(Empty, {
-        // "$JS.ACK.<stream>.<consumer>.<redeliveryCount><streamSeq><deliverySequence>.<timestamp>.<pending>"
+        // "$JS.ACK.<stream>.<consumer>.<deliveryCount><streamSeq><deliverySequence>.<timestamp>.<pending>"
         reply:
           `MY.TEST.streamname.consumername.1.${counter}.${counter}.${Date.now()}.0`,
       });

--- a/migration.md
+++ b/migration.md
@@ -144,6 +144,8 @@ To use JetStream, you must install and import `@nats/jetstream`.
 - The `ConsumerEvents` and `ConsumerDebugEvents` enum has been removed and
   replaced with `ConsumerNotification` which have a discriminating field `type`.
   The status objects provide a more specific API for querying those events.
+- `JsMsg.info.redeliveryCount` was renamed to `JsMsg.info.deliveryCount` as it
+  tracks all delivery attempts, not just redeliveries
 
 ## Changes to KV
 


### PR DESCRIPTION
Renamed `redeliveryCount` to `deliveryCount` to better reflect its purpose, as it tracks all delivery attempts, not just redeliveries. Updated related logic, documentation, and test cases to align with the new naming. Added a migration note for developers regarding this change.

Fixes #186 