### PR TITLE
Bump dependencies and remove typedoc configurations.

### DIFF
--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.0.0-48",
+  "version": "3.0.0-49",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -35,7 +35,7 @@
     "test": "deno test -A --parallel --reload tests/ --import-map=./import_map.json"
   },
   "imports": {
-    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-3",
-    "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.1-2"
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
+    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3"
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.0.0-48",
+  "version": "3.0.0-49",
   "files": [
     "lib/",
     "LICENSE",
@@ -23,7 +23,6 @@
     "pre-process": "npm run clean && deno run -A ../bin/cjs-fix-imports.ts -o ./build/src ./src",
     "build-cjs": "npm run pre-process && tsc",
     "build": "npm run build-cjs",
-    "doc": "npm run build && typedoc --out ../docs/core && touch ../docs/core/.nojekyll",
     "prepack": "npm run build",
     "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",
     "bump-release": "npm version patch --no-commit-hooks --no-git-tag-version"
@@ -34,13 +33,12 @@
   },
   "description": "nats-core library - this library implements all the base functionality for NATS javascript clients",
   "dependencies": {
-    "@nats-io/nkeys": "2.0.0-3",
-    "@nats-io/nuid": "2.0.1-2"
+    "@nats-io/nkeys": "2.0.2",
+    "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@types/node": "^22.7.6",
+    "@types/node": "22.10.7",
     "shx": "^0.3.4",
-    "typedoc": "^0.26.10",
-    "typescript": "^5.5.4"
+    "typescript": "5.6.3"
   }
 }

--- a/core/src/version.ts
+++ b/core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.0-48";
+export const version = "3.0.0-49";

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,14 @@
+{
+  "scripts": {
+    "doc": "npm run core; npm run jetstream; npm run kv; npm run obj; npm run services",
+    "core": "(cd ../core; npm run build && typedoc --out ../docs/core && touch ../docs/core/.nojekyll)",
+    "jetstream": "(cd ../jetstream; npm run build && typedoc --out ../docs/jetstream && touch ../docs/jetstream/.nojekyll)",
+    "kv": "(cd ../kv; npm run build && typedoc --out ../docs/kv && touch ../docs/kv/.nojekyll)",
+    "obj": "(cd ../obj; npm run build && typedoc --out ../docs/obj && touch ../docs/obj/.nojekyll)",
+    "services": "(cd ../services; npm run build && typedoc --out ../docs/services && touch ../docs/services/.nojekyll)"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3",
+    "typedoc": "^0.27.6"
+  }
+}

--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-35",
+  "version": "3.0.0-36",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --trace-leaks --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49"
   }
 }

--- a/jetstream/import_map.json
+++ b/jetstream/import_map.json
@@ -1,10 +1,10 @@
 {
   "imports": {
-    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-3",
-    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2",
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-48/internal",
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
+    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@3.0.0-49/internal",
     "test_helpers": "../test_helpers/mod.ts",
-    "@std/io": "jsr:@std/io@0.224.0"
+    "@std/io": "jsr:@std/io@0.225.0"
   }
 }

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-35",
+  "version": "3.0.0-36",
   "files": [
     "lib/",
     "LICENSE",
@@ -23,7 +23,6 @@
     "pre-process": "npm run clean && deno run -A ../bin/cjs-fix-imports.ts -o ./build/src ./src",
     "build-cjs": "npm run pre-process && tsc",
     "build": "npm run build-cjs",
-    "doc": "npm run build && typedoc --out ../docs/jetstream && touch ../docs/jetstream/.nojekyll",
     "prepack": "npm run build",
     "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",
     "bump-release": "npm version patch --no-commit-hooks --no-git-tag-version"
@@ -34,12 +33,11 @@
   },
   "description": "jetstream library - this library implements all the base functionality for NATS JetStream for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.0.0-48"
+    "@nats-io/nats-core": "3.0.0-49"
   },
   "devDependencies": {
-    "@types/node": "^22.7.6",
+    "@types/node": "^22.10.7",
     "shx": "^0.3.4",
-    "typedoc": "^0.26.10",
-    "typescript": "^5.6.3"
+    "typescript": "5.6.3"
   }
 }

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-29",
+  "version": "3.0.0-30",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,7 +33,7 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-35"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-49",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-36"
   }
 }

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -1,12 +1,12 @@
 {
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-48/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-35",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-35/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@3.0.0-49/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.0-36",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.0-36/internal",
     "test_helpers": "../test_helpers/mod.ts",
-    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-3",
-    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2",
-    "@std/io": "jsr:@std/io@0.224.0"
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
+    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",
+    "@std/io": "jsr:@std/io@0.225.0"
   }
 }

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-29",
+  "version": "3.0.0-30",
   "files": [
     "lib/",
     "LICENSE",
@@ -23,7 +23,6 @@
     "pre-process": "npm run clean && deno run -A ../bin/cjs-fix-imports.ts -o ./build/src ./src",
     "build-cjs": "npm run pre-process && tsc",
     "build": "npm run build-cjs",
-    "doc": "npm run build && typedoc --out ../docs/kv && touch ../docs/kv/.nojekyll",
     "prepack": "npm run build",
     "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",
     "bump-release": "npm version patch --no-commit-hooks --no-git-tag-version"
@@ -34,13 +33,12 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-35",
-    "@nats-io/nats-core": "3.0.0-48"
+    "@nats-io/jetstream": "3.0.0-36",
+    "@nats-io/nats-core": "3.0.0-49"
   },
   "devDependencies": {
-    "@types/node": "^22.7.6",
+    "@types/node": "^22.10.7",
     "shx": "^0.3.4",
-    "typedoc": "^0.26.10",
-    "typescript": "^5.6.3"
+    "typescript": "5.6.3"
   }
 }

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-31",
+  "version": "3.0.0-32",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,7 +33,7 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-35"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-49",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-36"
   }
 }

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -1,12 +1,12 @@
 {
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-48/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-35",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-35/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@3.0.0-49/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.0-36",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.0-36/internal",
     "test_helpers": "../test_helpers/mod.ts",
-    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-3",
-    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2",
-    "@std/io": "jsr:@std/io@0.224.0"
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
+    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",
+    "@std/io": "jsr:@std/io@0.225.0"
   }
 }

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-31",
+  "version": "3.0.0-32",
   "files": [
     "lib/",
     "LICENSE",
@@ -23,7 +23,6 @@
     "pre-process": "npm run clean && deno run -A ../bin/cjs-fix-imports.ts -o ./build/src ./src",
     "build-cjs": "npm run pre-process && tsc",
     "build": "npm run build-cjs",
-    "doc": "npm run build && typedoc --out ../docs/obj && touch ../docs/obj/.nojekyll",
     "prepack": "npm run build",
     "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",
     "bump-release": "npm version patch --no-commit-hooks --no-git-tag-version"
@@ -34,13 +33,12 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-35",
-    "@nats-io/nats-core": "3.0.0-48"
+    "@nats-io/jetstream": "3.0.0-36",
+    "@nats-io/nats-core": "3.0.0-49"
   },
   "devDependencies": {
-    "@types/node": "^22.7.6",
+    "@types/node": "22.10.7",
     "shx": "^0.3.4",
-    "typedoc": "^0.26.10",
-    "typescript": "^5.6.3"
+    "typescript": "5.6.3"
   }
 }

--- a/services/deno.json
+++ b/services/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.0.0-23",
+  "version": "3.0.0-24",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49"
   }
 }

--- a/services/import_map.json
+++ b/services/import_map.json
@@ -1,10 +1,10 @@
 {
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-48/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@3.0.0-49/internal",
     "test_helpers": "../test_helpers/mod.ts",
-    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-3",
-    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2",
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
+    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",
     "@std/io": "jsr:@std/io@0.224.0"
   }
 }

--- a/services/package.json
+++ b/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.0.0-23",
+  "version": "3.0.0-24",
   "files": [
     "lib/",
     "LICENSE",
@@ -23,7 +23,6 @@
     "pre-process": "npm run clean && deno run -A ../bin/cjs-fix-imports.ts -o ./build/src ./src",
     "build-cjs": "npm run pre-process && tsc",
     "build": "npm run build-cjs",
-    "doc": "npm run build && typedoc --out ../docs/services && touch ../docs/services/.nojekyll",
     "prepack": "npm run build",
     "bump-qualifier": "npm version prerelease --no-commit-hooks --no-git-tag-version",
     "bump-release": "npm version patch --no-commit-hooks --no-git-tag-version"
@@ -34,12 +33,11 @@
   },
   "description": "services library - this library implements all the base functionality for NATS services for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.0.0-48"
+    "@nats-io/nats-core": "3.0.0-49"
   },
   "devDependencies": {
-    "@types/node": "^22.7.6",
+    "@types/node": "22.10.7",
     "shx": "^0.3.4",
-    "typedoc": "^0.26.10",
-    "typescript": "^5.6.3"
+    "typescript": "5.6.3"
   }
 }

--- a/transport-deno/deno.json
+++ b/transport-deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-deno",
-  "version": "3.0.0-20",
+  "version": "3.0.0-21",
   "exports": {
     ".": "./src/mod.ts"
   },
@@ -20,8 +20,8 @@
   },
   "imports": {
     "@std/io": "jsr:@std/io@0.225.0",
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-48",
-    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.0-3",
-    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.1-2"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0-49",
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
+    "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3"
   }
 }

--- a/transport-deno/src/version.ts
+++ b/transport-deno/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.0-20";
+export const version = "3.0.0-21";

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-node",
-  "version": "3.0.0-33",
+  "version": "3.0.0-34",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -55,17 +55,17 @@
     "node": ">= 18.0.0"
   },
   "dependencies": {
-    "@nats-io/nats-core": "3.0.0-48",
-    "@nats-io/nkeys": "2.0.0-3",
-    "@nats-io/nuid": "2.0.1-2"
+    "@nats-io/nats-core": "3.0.0-49",
+    "@nats-io/nkeys": "2.0.2",
+    "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@types/node": "^22.7.6",
+    "@types/node": "22.10.7",
     "minimist": "^1.2.8",
     "shx": "^0.3.3",
     "typescript": "5.6.3",
-    "@nats-io/jetstream": "3.0.0-35",
-    "@nats-io/kv": "3.0.0-29",
-    "@nats-io/obj": "3.0.0-31"
+    "@nats-io/jetstream": "3.0.0-36",
+    "@nats-io/kv": "3.0.0-30",
+    "@nats-io/obj": "3.0.0-32"
   }
 }

--- a/transport-node/src/version.ts
+++ b/transport-node/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.0-33";
+export const version = "3.0.0-34";


### PR DESCRIPTION
Updated package versions across multiple modules, including `nats-core`, `jetstream`, `kv`, `nkeys`, and `nuid`. Removed doc scripts and configuration from packages while centralizing documentation generation in a new `docs/package.json` file. These changes aim to simplify dependency management and streamline the documentation process.