### PR TITLE
fix: typo in the documentation of the list() method of the Objm class

### DIFF
--- a/obj/src/objectstore.ts
+++ b/obj/src/objectstore.ts
@@ -152,7 +152,7 @@ export class Objm {
   }
 
   /**
-   * Returns a list of ObjectStoreInfo for all streams that are identified as
+   * Returns a list of ObjectStoreStatus for all streams that are identified as
    * being a ObjectStore (that is having names that have the prefix `OBJ_`)
    */
   list(): Lister<ObjectStoreStatus> {


### PR DESCRIPTION
While reading the documentation https://nats-io.github.io/nats.js/obj/classes/Objm.html#list I noticed a typo. This PR fixes it.