### PR TITLE
Add 'Promise<never>' to ConsumerCallbackFn

### DIFF
--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -463,7 +463,7 @@ export type IdleHeartbeat = {
   idle_heartbeat?: number;
 };
 
-export type ConsumerCallbackFn = (r: JsMsg) => void;
+export type ConsumerCallbackFn = (r: JsMsg) => void | Promise<never>;
 export type ConsumeCallback = {
   /**
    * Process messages using a callback instead of an iterator. Note that when using callbacks,


### PR DESCRIPTION
This PR changes the `callback` type on `ConsumeOptions` to allow linters to explicitly call out the fact that the `callback` parameter **will not be `await`'d and is therefore an error if an `async` method is passed in**.