### PR TITLE
Add heartbeat handling to key iteration

### DIFF
--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -797,6 +797,19 @@ export class Bucket implements KV {
       qi.push(fn);
     });
 
+    (async () => {
+      for await (const s of iter.status()) {
+        switch (s.type) {
+          // if we get a heartbeat we got all the keys
+          case "heartbeat":
+            qi.push(() => {
+              qi.stop();
+            });
+            break;
+        }
+      }
+    })().then();
+
     // if they break from the iterator stop the consumer
     qi.iterClosed.then(() => {
       iter.stop();

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -899,6 +899,19 @@ export class Bucket implements KV {
       },
     });
 
+    (async () => {
+      for await (const s of iter.status()) {
+        switch (s.type) {
+          // if we get a heartbeat we got all the keys
+          case "heartbeat":
+            keys.push(() => {
+              keys.stop();
+            });
+            break;
+        }
+      }
+    })().then();
+
     iter.closed().then(() => {
       keys.push(() => {
         keys.stop();


### PR DESCRIPTION
Introduce a heartbeat case to handle key iteration status updates. This ensures proper key fetching and stops the iteration appropriately upon receiving a heartbeat.