### PR TITLE
Update imports to use package names and enhance test helpers

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -53,7 +53,7 @@
     "*": {
       "@nats-io/nats-core": "./core/src/mod.ts",
       "@nats-io/nats-core/internal": "./core/src/internal_mod.ts",
-      "@nats-io/nats-transport-deno": "./transport-deno/src/mod.ts",
+      "@nats-io/transport-deno": "./transport-deno/src/mod.ts",
       "@nats-io/jetstream": "./jetstream/src/mod.ts",
       "@nats-io/jetstream/internal": "./jetstream/src/internal_mod.ts",
       "@nats-io/kv": "./kv/src/mod.ts",
@@ -70,7 +70,8 @@
     "./jetstream",
     "./kv",
     "./obj",
-    "./services"
+    "./services",
+    "./test_helpers"
   ],
   "nodeModulesDir": "none"
 }

--- a/test_helpers/certs.ts
+++ b/test_helpers/certs.ts
@@ -1,4 +1,4 @@
-import { deferred } from "../core/src/internal_mod.ts";
+import { deferred } from "@nats-io/nats-core";
 import { join } from "jsr:@std/path";
 
 export class Certs {

--- a/test_helpers/cluster.ts
+++ b/test_helpers/cluster.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { NatsServer } from "./mod.ts";
+import { NatsServer } from "./launcher.ts";
 import { parseArgs } from "jsr:@std/cli/parse-args";
 import { rgb24 } from "jsr:@std/fmt/colors";
 

--- a/test_helpers/connect.ts
+++ b/test_helpers/connect.ts
@@ -1,1 +1,1 @@
-export { connect } from "../transport-deno/src/mod.ts";
+export { connect } from "@nats-io/transport-deno";

--- a/test_helpers/deno.json
+++ b/test_helpers/deno.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true
+  },
+  "imports": {
+    "@nats-io/nats-core": "../core/src/mod.ts",
+    "@nats-io/nats-core/internal": "../core/src/internal_mod.ts",
+    "@nats-io/transport-deno": "../transport-deno/src/mod.ts",
+    "@nats-io/jetstream": "../jetstream/src/mod.ts",
+    "@nats-io/jetstream/internal": "../jetstream/src/internal_mod.ts",
+    "@nats-io/kv": "../kv/src/mod.ts",
+    "@nats-io/kv/internal": "../kv/src/internal_mod.ts",
+    "@nats-io/obj": "../obj/src/mod.ts",
+    "@nats-io/obj/internal": "../obj/src/internal_mod.ts",
+    "@nats-io/services": "../services/src/mod.ts",
+    "@nats-io/services/internal": "../services/src/internal_mod.ts"
+  }
+}

--- a/test_helpers/launcher.ts
+++ b/test_helpers/launcher.ts
@@ -16,16 +16,17 @@
 import { join, resolve } from "jsr:@std/path";
 import { rgb24 } from "jsr:@std/fmt/colors";
 import { check, jsopts } from "./mod.ts";
-import { extend, timeout } from "../core/src/util.ts";
-import type { Deferred } from "../core/src/util.ts";
 import {
   ConnectionOptions,
+  Deferred,
   deferred,
   delay,
+  extend,
   NatsConnection,
   nuid,
+  timeout,
   wsconnect,
-} from "../core/src/mod.ts";
+} from "@nats-io/nats-core/internal";
 import { Certs } from "./certs.ts";
 import { connect } from "./connect.ts";
 

--- a/test_helpers/mod.ts
+++ b/test_helpers/mod.ts
@@ -13,11 +13,8 @@
  * limitations under the License.
  */
 
-import type {
-  ConnectionOptions,
-  NatsConnection,
-} from "../core/src/internal_mod.ts";
-import { compare, parseSemVer } from "../core/src/internal_mod.ts";
+import type { ConnectionOptions, NatsConnection } from "@nats-io/nats-core";
+import { compare, parseSemVer } from "@nats-io/nats-core/internal";
 
 import { NatsServer } from "./launcher.ts";
 import { red, yellow } from "jsr:@std/fmt/colors";

--- a/test_helpers/test_server.ts
+++ b/test_helpers/test_server.ts
@@ -12,8 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Deferred } from "../core/src/internal_mod.ts";
-import { deferred } from "../core/src/internal_mod.ts";
+import { type Deferred, deferred } from "@nats-io/nats-core/internal";
 
 export class Connection {
   conn: Deno.Conn | null;

--- a/test_helpers/util.ts
+++ b/test_helpers/util.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { deferred, timeout } from "../core/src/internal_mod.ts";
+import { deferred, timeout } from "@nats-io/nats-core/internal";
 import { assert } from "jsr:@std/assert";
 
 export function consume<T>(iter: Iterable<T>, ms = 1000): Promise<T[]> {

--- a/transport-deno/examples/bench.js
+++ b/transport-deno/examples/bench.js
@@ -5,7 +5,7 @@ import {
   connect,
   Metric,
   Nuid,
-} from "jsr:@nats-io/nats-transport-deno@3.0.0-5";
+} from "jsr:@nats-io/transport-deno@3.0.0-22";
 const defaults = {
   s: "127.0.0.1:4222",
   c: 100000,


### PR DESCRIPTION
Replaced file path imports with package-based imports for improved clarity and maintainability. Added a new `test_helpers/deno.json` configuration and updated the `test_helpers` module structure to streamline the usage of helper utilities. Also updated the transport package reference in the examples for consistency.