### PR TITLE
fix(node): websocket under node doesn't emit close+error (only error) so redials didn't happen

### DIFF
--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.0.0-51",
+  "version": "3.0.0-54",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.0.0-51",
+  "version": "3.0.0-54",
   "files": [
     "lib/",
     "LICENSE",

--- a/core/src/version.ts
+++ b/core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.0-51";
+export const version = "3.0.0-54";

--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-38",
+  "version": "3.0.0-40",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --trace-leaks --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54"
   }
 }

--- a/jetstream/import_map.json
+++ b/jetstream/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-51/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-54/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@std/io": "jsr:@std/io@0.225.0"
   }

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0-38",
+  "version": "3.0.0-40",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "jetstream library - this library implements all the base functionality for NATS JetStream for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.0.0-51"
+    "@nats-io/nats-core": "3.0.0-54"
   },
   "devDependencies": {
     "@types/node": "^22.10.10",

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-32",
+  "version": "3.0.0-34",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,7 +33,7 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-38"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-40"
   }
 }

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -1,9 +1,9 @@
 {
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-51/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-38",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-38/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-54/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-40",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-40/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0-32",
+  "version": "3.0.0-34",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,8 +33,8 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-38",
-    "@nats-io/nats-core": "3.0.0-51"
+    "@nats-io/jetstream": "3.0.0-40",
+    "@nats-io/nats-core": "3.0.0-54"
   },
   "devDependencies": {
     "@types/node": "^22.10.10",

--- a/migration.md
+++ b/migration.md
@@ -39,7 +39,8 @@ The transports have also been migrated:
   support.
 
 Note that when installing `@nats-io/transport-node` or
-`@nats-io/transport-deno`, the `@nats-io/nats-core` APIs are also made available.
+`@nats-io/transport-deno`, the `@nats-io/nats-core` APIs are also made
+available.
 
 Your library selection process will start by selecting your runtime, and
 importing any additional functionality you may be interested in. The

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-34",
+  "version": "3.0.0-36",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,8 +33,8 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-38",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-40",
     "js-sha256": "npm:js-sha256@0.11.0"
   }
 }

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -1,9 +1,9 @@
 {
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-51/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-38",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-38/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-54/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@~3.0.0-40",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0-40/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.0-34",
+  "version": "3.0.0-36",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,8 +33,8 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0-38",
-    "@nats-io/nats-core": "3.0.0-51",
+    "@nats-io/jetstream": "3.0.0-40",
+    "@nats-io/nats-core": "3.0.0-54",
     "js-sha256": "^0.11.0"
   },
   "devDependencies": {

--- a/services/deno.json
+++ b/services/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.0.0-26",
+  "version": "3.0.0-28",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54"
   }
 }

--- a/services/import_map.json
+++ b/services/import_map.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
-    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-51/internal",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
+    "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0-54/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3",

--- a/services/package.json
+++ b/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.0.0-26",
+  "version": "3.0.0-28",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "services library - this library implements all the base functionality for NATS services for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.0.0-51"
+    "@nats-io/nats-core": "3.0.0-54"
   },
   "devDependencies": {
     "@types/node": "^22.10.10",

--- a/transport-deno/deno.json
+++ b/transport-deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-deno",
-  "version": "3.0.0-22",
+  "version": "3.0.0-24",
   "exports": {
     ".": "./src/mod.ts"
   },
@@ -20,7 +20,7 @@
   },
   "imports": {
     "@std/io": "jsr:@std/io@0.225.0",
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-51",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@~3.0.0-54",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@~2.0.2",
     "@nats-io/nuid": "jsr:@nats-io/nuid@~2.0.3"
   }

--- a/transport-deno/src/version.ts
+++ b/transport-deno/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.0-22";
+export const version = "3.0.0-24";

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-node",
-  "version": "3.0.0-36",
+  "version": "3.0.0-38",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -55,14 +55,14 @@
     "node": ">= 18.0.0"
   },
   "dependencies": {
-    "@nats-io/nats-core": "3.0.0-51",
+    "@nats-io/nats-core": "3.0.0-54",
     "@nats-io/nkeys": "2.0.2",
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@nats-io/jetstream": "3.0.0-38",
-    "@nats-io/kv": "3.0.0-32",
-    "@nats-io/obj": "3.0.0-34",
+    "@nats-io/jetstream": "3.0.0-40",
+    "@nats-io/kv": "3.0.0-34",
+    "@nats-io/obj": "3.0.0-36",
     "@types/node": "^22.10.10",
     "minimist": "^1.2.8",
     "shx": "^0.3.3",

--- a/transport-node/src/version.ts
+++ b/transport-node/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.0-36";
+export const version = "3.0.0-38";


### PR DESCRIPTION
Introduce a `cleanup` method for socket event handling, ensuring consistent resource cleanup across close/error scenarios. Additionally, implement a test case to verify websocket reconnect functionality after disconnection.

fixes #210 