### PR TITLE
Add support for per-message TTL in JetStream.

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -172,6 +172,12 @@ export type StreamConfig = StreamUpdateConfig & {
    * as it may disrupt the synchronization logic.
    */
   "first_seq": number;
+
+  /**
+   * Enables allows header initiated per-message TTLs. If disabled, then the `NATS-TTL`
+   * header will be ignored.
+   */
+  "allow_msg_ttl": boolean;
 };
 
 /**
@@ -286,6 +292,10 @@ export type StreamUpdateConfig = {
    * become an upper bound for all clients.
    */
   "consumer_limits"?: StreamConsumerLimits;
+  /**
+   * Sets a duration for adding server markers for delete, purge and max age limits.
+   */
+  "subject_delete_marker_ttl"?: Nanos;
 };
 
 export type Republish = {
@@ -1249,5 +1259,10 @@ export const PubHeaders = {
   ExpectedLastSeqHdr: "Nats-Expected-Last-Sequence",
   ExpectedLastMsgIdHdr: "Nats-Expected-Last-Msg-Id",
   ExpectedLastSubjectSequenceHdr: "Nats-Expected-Last-Subject-Sequence",
+  /**
+   * Sets the TTL for a message (Nanos value). Only have effect on streams that
+   * enable {@link StreamConfig#allow_msg_ttl}.
+   */
+  MessageTTL: "Nats-TTL",
 } as const;
 export type PubHeaders = typeof PubHeaders[keyof typeof PubHeaders];

--- a/jetstream/src/jsclient.ts
+++ b/jetstream/src/jsclient.ts
@@ -200,6 +200,12 @@ export class JetStreamClientImpl extends BaseApiClientImpl
           `${opts.expect.lastSubjectSequence}`,
         );
       }
+      if (opts.ttl) {
+        mh.set(
+          PubHeaders.MessageTTL,
+          `${opts.ttl}`,
+        );
+      }
     }
 
     const to = opts.timeout || this.timeout;

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -144,6 +144,13 @@ export type JetStreamPublishOptions = {
   }>;
 
   /**
+   * Sets {@link PubHeaders#MessageTtl} this only applies to streams that enable
+   * {@link StreamConfig#allow_msg_ttl}. The format of this value is "1s" or "1h",
+   * etc, or a plain number interpreted as the number of seconds.
+   */
+  ttl?: string;
+
+  /**
    * Continue to attempt to publish if the publish fails due to a no responders error.
    * Default is 1.
    */

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -210,7 +210,8 @@ export class Kvm {
   }
 
   /**
-   * Open to the specified KV. If the KV doesn't exist, this API will fail.
+   * Open to the specified KV. If the KV doesn't exist, this API will fail on accessing
+   * the KV.
    * @param name
    * @param opts
    */
@@ -344,6 +345,10 @@ export class Bucket implements KV {
     }
     if (opts.description) {
       sc.description = opts.description;
+    }
+    if (opts.markerTTL) {
+      sc.allow_msg_ttl = true;
+      sc.subject_delete_marker_ttl = bo.markerTTL;
     }
     if (opts.mirror) {
       const mirror = Object.assign({}, opts.mirror);
@@ -554,10 +559,14 @@ export class Bucket implements KV {
     return new KvJsMsgEntryImpl(this.bucket, key, jm, isUpdate);
   }
 
-  async create(k: string, data: Payload): Promise<number> {
+  async create(k: string, data: Payload, markerTTL?: 0): Promise<number> {
     let firstErr;
     try {
-      const n = await this.put(k, data, { previousSeq: 0 });
+      const opts: Partial<KvPutOptions> = { previousSeq: 0 };
+      if (markerTTL) {
+        opts.ttl = markerTTL;
+      }
+      const n = await this.put(k, data, opts);
       return Promise.resolve(n);
     } catch (err) {
       firstErr = err;
@@ -607,6 +616,11 @@ export class Bucket implements KV {
       const h = headers();
       o.headers = h;
       h.set(PubHeaders.ExpectedLastSubjectSequenceHdr, `${opts.previousSeq}`);
+    }
+    if (opts.ttl) {
+      const h = o.headers || headers();
+      const ttl = nanos(opts.ttl);
+      h.set(PubHeaders.MessageTTL, `${ttl}`);
     }
     try {
       const pa = await this.js.publish(this.subjectForKey(ek, true), data, o);
@@ -723,6 +737,10 @@ export class Bucket implements KV {
     h.set(kvOperationHdr, op);
     if (op === "PURGE") {
       h.set(JsHeaders.RollupHdr, JsHeaders.RollupValueSubject);
+      if (typeof opts?.ttl === "number") {
+        const ttl = nanos(opts.ttl);
+        h.set(PubHeaders.MessageTTL, `${ttl}`);
+      }
     }
     if (opts?.previousSeq) {
       h.set(PubHeaders.ExpectedLastSubjectSequenceHdr, `${opts.previousSeq}`);
@@ -988,6 +1006,13 @@ export class KvStatusImpl implements KvStatus {
 
   get ttl(): number {
     return millis(this.si.config.max_age);
+  }
+
+  get markerTTL(): number {
+    if (typeof this.si.config.subject_delete_marker_ttl === "number") {
+      return millis(this.si.config.subject_delete_marker_ttl);
+    }
+    return 0;
   }
 
   get bucket_location(): string {


### PR DESCRIPTION
Introduced the `ttl` option for publishing messages with time-to-live headers. This feature requires streams to enable the `allow_msg_ttl` configuration. Tests and documentation were updated to ensure proper handling and validation of message TTL functionality.