### PR TITLE
Use github-hosted free runners

### DIFF
--- a/.github/workflows/consistency_checks.yml
+++ b/.github/workflows/consistency_checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test core changes with released dependencies
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/deno_checks.yml
+++ b/.github/workflows/deno_checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/jetstream.yml
+++ b/.github/workflows/jetstream.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: test jetstream with released dependencies
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/kv.yml
+++ b/.github/workflows/kv.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: test kv with released dependencies
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/node_checks.yml
+++ b/.github/workflows/node_checks.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   node-tests-workspace:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/obj.yml
+++ b/.github/workflows/obj.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: test obj with released dependencies
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: test services with released dependencies
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     strategy:
       matrix:
         deno-version: [2.2.x]

--- a/.github/workflows/transport-node-test.yml
+++ b/.github/workflows/transport-node-test.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: [23.x]
 
     name: test node transport with local dependencies
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
 
     steps:
       - name: Git Checkout Core

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -6,7 +6,7 @@ on: workflow_dispatch
 jobs:
   build:
     name: version bump
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latests
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
## Description

The default GitHub ubuntu-latest runners already have 4-cores, so using this hosted runner incurs a cost that isn't necessary. 

Please direct any questions to myself, @krook and @RobertKielty