### PR TITLE
BREAKING: KV TTL to use nanoseconds for consistency

### DIFF
--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -27,6 +27,7 @@ import {
 
 import type {
   MsgHdrs,
+  Nanos,
   NatsConnection,
   NatsConnectionImpl,
   Payload,
@@ -408,7 +409,7 @@ export class Bucket implements KV {
 
     sc.num_replicas = bo.replicas;
     if (bo.ttl) {
-      sc.max_age = nanos(bo.ttl);
+      sc.max_age = bo.ttl;
     }
     sc.allow_rollup_hdrs = true;
 
@@ -977,8 +978,8 @@ export class KvStatusImpl implements KvStatus {
     return this.si.config.max_msgs_per_subject;
   }
 
-  get ttl(): number {
-    return millis(this.si.config.max_age);
+  get ttl(): Nanos {
+    return this.si.config.max_age;
   }
 
   get bucket_location(): string {

--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -19,7 +19,7 @@ import type {
   StreamInfo,
   StreamSource,
 } from "@nats-io/jetstream";
-import type { Payload, QueuedIterator } from "@nats-io/nats-core";
+import type { Nanos, Payload, QueuedIterator } from "@nats-io/nats-core";
 
 export type KvEntry = {
   bucket: string;
@@ -92,12 +92,12 @@ export type KvLimits = {
    */
   maxValueSize: number;
   /**
-   * The maximum number of millis the key should live
+   * The maximum number of nanos the key should live
    * in the KV. The server will automatically remove
    * keys older than this amount. Note that deletion of
    * delete markers are not performed.
    */
-  ttl: number; // millis
+  ttl: Nanos;
   /**
    * The backing store of the stream hosting the KV
    */

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -586,7 +586,9 @@ Deno.test("kv - ttl", async () => {
   }
 
   const js = jetstream(nc);
-  const b = await new Kvm(js).create(nuid.next(), { ttl: 1000 }) as Bucket;
+  const b = await new Kvm(js).create(nuid.next(), {
+    ttl: nanos(1000),
+  }) as Bucket;
 
   const jsm = await jetstreamManager(nc);
   const si = await jsm.streams.info(b.stream);
@@ -1413,9 +1415,9 @@ Deno.test("kv - ttl is in nanos", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
-  const b = await new Kvm(js).create("a", { ttl: 1000 });
+  const b = await new Kvm(js).create("a", { ttl: nanos(1000) });
   const status = await b.status();
-  assertEquals(status.ttl, 1000);
+  assertEquals(status.ttl, nanos(1000));
   assertEquals(status.size, 0);
 
   const jsm = await jetstreamManager(nc);
@@ -1428,7 +1430,7 @@ Deno.test("kv - size", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   const js = jetstream(nc);
 
-  const b = await new Kvm(js).create("a", { ttl: 1000 });
+  const b = await new Kvm(js).create("a", { ttl: nanos(1000) });
   let status = await b.status();
   assertEquals(status.size, 0);
   assertEquals(status.size, status.streamInfo.state.bytes);

--- a/migration.md
+++ b/migration.md
@@ -110,9 +110,9 @@ these modules for cross-runtime consumption.
   object store have been moved to @nats-io/obj.
 - `MsgCallback` - `(err: Error|null, msg: T) => void` has changed to be
   `(err: Error|null, msg:T) => void | Promise<never>` to indicate that they
-  cannot contain `await`. If you want to perform async handling, it must be
-  done inside an async iterator, or outside the callback.
-- 
+  cannot contain `await`. If you want to perform async handling, it must be done
+  inside an async iterator, or outside the callback.
+-
 
 ## Changes in JetStream
 
@@ -155,14 +155,35 @@ To use JetStream, you must install and import `@nats/jetstream`.
 - `JsMsg.info.redeliveryCount` was renamed to `JsMsg.info.deliveryCount` as it
   tracks all delivery attempts, not just redeliveries.
 - `ConsumerCallbackFn` - `(m: JsMsg) => void` has changed to be
-  `(m: JsMsg) => void | Promise<never>` to indicate that they
-  cannot contain `await`. If you want to perform async handling, it must be
-  done inside an async iterator, or outside the callback.
+  `(m: JsMsg) => void | Promise<never>` to indicate that they cannot contain
+  `await`. If you want to perform async handling, it must be done inside an
+  async iterator, or outside the callback.
 
 ## Changes to KV
 
-To use KV, you must install and import `@nats-io/kv`, and create an instance of
-Kvm:
+- To use KV, you must install and import `@nats-io/kv`
+
+- `Bucket#ttl` and `KvStatus#ttl` have changed from millis to Nanos. This change
+  aligns ObjectStore and JetStream streams on consistent units.
+
+- `KvWatchOption.initializedFn` has been removed. Previous versions of
+  `Kv.watch()` allowed the client to specify a function that was called when the
+  watch was done providing history values. In this version, you can find out if
+  a watch is yielding an update by examining the `isUpdate` property. Note that
+  an empty Kv will not yield any watch information. You can test for this
+  initial condition, by getting the status of the KV, and inspecting the
+  `values` property, which will state the number of entries in the Kv. Also note
+  that watches with the option to do updates only, cannot notify until there's
+  an update.
+
+- Removed deprecated KV apis (`KvRemove` - `remove(k)=>Promise<void>`,
+  `close()=>Promise<void>`) and options (`maxBucketSize`,
+  `placementCluster`,`bucket_location`)
+
+- Removed the deprecated option `backingStore` from `KvOptions` and `KvStatus`.
+  Use `KvOptions.storage` and `KvStatus.storage`.
+
+To create a KV, create an instance of Kvm:
 
 ```typescript
 import { connect } from "@nats-io/transport-deno";
@@ -183,26 +204,6 @@ await kvm.create("mykv");
 // To access a KV but fail if it doesn't exist:
 await kvm.open("mykv");
 ```
-
-### KvWatchOption.initializedFn has been removed
-
-Previous versions of `Kv.watch()` allowed the client to specify a function that
-was called when the watch was done providing history values. In this version,
-you can find out if a watch is yielding an update by examining the `isUpdate`
-property. Note that an empty Kv will not yield any watch information. You can
-test for this initial condition, by getting the status of the KV, and inspecting
-the `values` property, which will state the number of entries in the Kv. Also
-note that watches with the option to do updates only, cannot notify until
-there's an update.
-
-### Removal of deprecations
-
-Removed deprecated KV apis (`KvRemove` - `remove(k)=>Promise<void>`,
-`close()=>Promise<void>`) and options (`maxBucketSize`,
-`placementCluster`,`bucket_location`)
-
-Removed the deprecated option `backingStore` from `KvOptions` and `KvStatus`.
-Use `KvOptions.storage` and `KvStatus.storage`.
 
 ## Changes to ObjectStore
 


### PR DESCRIPTION
Updated KV TTL from milliseconds to nanoseconds across the codebase to align with ObjectStore and JetStream standards. Adjusted related tests, types, and documentation to reflect this change and ensure consistent behavior.