### PR TITLE
feat(js): expose direct APIs

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -523,8 +523,6 @@ export type DirectMsgRequest =
 
 export type CompletionResult = { err?: Error };
 export type BatchCallback<T> = (done: CompletionResult | null, d: T) => void;
-export type StartSeq = { seq?: number };
-export type StartTime = { start_time?: Date | string };
 
 export type DirectBatch = {
   batch: number;
@@ -532,20 +530,26 @@ export type DirectBatch = {
 export type DirectMaxBytes = MaxBytes;
 
 export type DirectBatchLimits = {
-  batch?: number;
-  max_bytes?: number;
-  callback?: BatchCallback<StoredMsg>;
+  batch: number;
+  max_bytes: number;
+  callback: BatchCallback<StoredMsg>;
   next_by_subj?: string;
 };
-export type DirectBatchStartSeq = StartSeq & DirectBatchLimits;
-export type DirectBatchStartTime = StartTime & DirectBatchLimits;
-export type DirectBatchOptions = DirectBatchStartSeq & DirectBatchStartTime;
+export type DirectBatchStartSeq = Partial<DirectBatchLimits> & {
+  seq: number;
+  start_time: never;
+};
+export type DirectBatchStartTime = Partial<DirectBatchLimits> & {
+  start_time: Date | string;
+  seq: never;
+};
+export type DirectBatchOptions = DirectBatchStartSeq | DirectBatchStartTime;
 
 export type DirectLastFor = {
   multi_last: string[];
   up_to_time?: Date | string;
   up_to_seq?: number;
-} & DirectBatchLimits;
+} & Partial<DirectBatchLimits>;
 
 export type StreamState = {
   /**

--- a/jetstream/src/jsm_direct.ts
+++ b/jetstream/src/jsm_direct.ts
@@ -339,7 +339,7 @@ export class DirectConsumer {
     if (this.cursor.last === 0) {
       // we have never pulled, honor initial request options
       if (isDirectBatchStartTime(this.start)) {
-        dbo.start_time = this.start.start_time;
+        dbo.start_time = this.start.start_time!;
       } else {
         dbo.seq = this.start.seq || 1;
       }
@@ -353,7 +353,7 @@ export class DirectConsumer {
       dbo.batch = opts.batch ?? 100;
     }
 
-    return dbo;
+    return dbo as DirectBatchOptions;
   }
 
   status(): AsyncIterable<ConsumerNotification> {

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -323,6 +323,14 @@ export type JetStreamManager = {
    * JetStream API to interact with Streams
    */
   streams: StreamAPI;
+  /**
+   * API for accessing messages in a stream without using a Consumer.
+   * This API can retrieve values from any of the stream replicas,
+   * which means that it may not reflect inflight changes to the stream.
+   * Direct APIs require the stream to have the `direct` option
+   * enabled.
+   */
+  direct: DirectStreamAPI;
 
   /**
    * Returns JetStreamAccountStats for the current client account.
@@ -852,14 +860,22 @@ export type Consumers = {
  * The Direct stream API is a bit more performant for retrieving messages,
  * but requires the stream to have enabled direct access.
  * See {@link StreamConfig.allow_direct}.
+ *
+ * These APIs are intended to support other APIs in the library.
+ *
+ * Note that these APIs are marked as non-stable, this means that
+ * these APIs are subject to change.
+ *
+ * Note that these API can retrieve values from any replica, so it is possible
+ * for a lookup after an update to not include the message that was just added.
  */
 export type DirectStreamAPI = {
   /**
    * Retrieves the message matching the specified query. Messages can be
    * retrieved by sequence number or by last sequence matching a subject, or
    * by looking for the next message sequence that matches a subject.
-   * @param stream
-   * @param query
+   *
+   * This API is Non-Stable and subject to change.
    */
   getMessage(
     stream: string,
@@ -867,9 +883,10 @@ export type DirectStreamAPI = {
   ): Promise<StoredMsg | null>;
 
   /**
-   * Retrieves all last subject messages for the specified subjects
-   * @param stream
-   * @param opts
+   * Retrieves a batch of messages with an optional filter starting at a specific
+   * sequence or start time. Note that only a single subject filter is supported.
+   *
+   * This API is Non-Stable and subject to change.
    */
   getBatch(
     stream: string,
@@ -882,8 +899,8 @@ export type DirectStreamAPI = {
    * Care should be given on the specified filters to ensure that
    * the results match what the client is expecting and to avoid missing
    * expected data.
-   * @param stream
-   * @param opts
+   *
+   * This API is Non-Stable and subject to change.
    */
   getLastMessagesFor(
     stream: string,

--- a/jetstream/tests/direct_consumer_test.ts
+++ b/jetstream/tests/direct_consumer_test.ts
@@ -21,7 +21,11 @@ import {
   notCompatible,
   setup,
 } from "test_helpers";
-import { DirectConsumer, DirectStreamAPIImpl } from "../src/jsm_direct.ts";
+import {
+  DirectConsumer,
+  type DirectStartOptions,
+  DirectStreamAPIImpl,
+} from "../src/jsm_direct.ts";
 
 Deno.test("direct consumer - next", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
@@ -38,7 +42,11 @@ Deno.test("direct consumer - next", async () => {
     js.publish("a"),
   ]);
 
-  const dc = new DirectConsumer("A", new DirectStreamAPIImpl(nc), { seq: 0 });
+  const dc = new DirectConsumer(
+    "A",
+    new DirectStreamAPIImpl(nc),
+    { seq: 0 } as DirectStartOptions,
+  );
 
   const m = await dc.next();
   assertEquals(m?.seq, 1);
@@ -68,7 +76,7 @@ Deno.test("direct consumer - batch", async () => {
   const dc = new DirectConsumer(
     "A",
     new DirectStreamAPIImpl(nc),
-    { seq: 0 },
+    { seq: 0 } as DirectStartOptions,
   );
 
   let iter = await dc.fetch({ batch: 5 });
@@ -123,7 +131,7 @@ Deno.test("direct consumer - consume", async () => {
   const dc = new DirectConsumer(
     "A",
     new DirectStreamAPIImpl(nc),
-    { seq: 0 },
+    { seq: 0 } as DirectStartOptions,
   );
 
   dc.debug();

--- a/jetstream/tests/jsm_direct_test.ts
+++ b/jetstream/tests/jsm_direct_test.ts
@@ -66,7 +66,10 @@ Deno.test("direct - version checks", async () => {
 
   await assertRejects(
     () => {
-      return jsm.direct.getBatch("A", { seq: 1, batch: 100 });
+      return jsm.direct.getBatch(
+        "A",
+        { seq: 1, batch: 100 } as DirectBatchOptions,
+      );
     },
     Error,
     "batch direct require server 2.11.0",
@@ -74,7 +77,10 @@ Deno.test("direct - version checks", async () => {
 
   await assertRejects(
     () => {
-      return jsm.direct.getBatch("A", { seq: 1, batch: 100 });
+      return jsm.direct.getBatch(
+        "A",
+        { seq: 1, batch: 100 } as DirectBatchOptions,
+      );
     },
     Error,
     "batch direct require server 2.11.0",
@@ -228,14 +234,13 @@ Deno.test("direct - callback", async (t) => {
   await t.step("no stream", async () => {
     const d = deferred();
     const iter = await jsm.direct.getBatch("hello", {
-      //@ts-ignore: test
       seq: 1,
       callback: (done, _) => {
         assertExists(done);
         assertIsError(done.err, Error, "no responders");
         d.resolve();
       },
-    }) as QueuedIteratorImpl<StoredMsg>;
+    } as DirectBatchOptions) as QueuedIteratorImpl<StoredMsg>;
 
     const err = await iter.iterClosed;
     assertIsError(err, Error, "no responders");
@@ -256,7 +261,7 @@ Deno.test("direct - callback", async (t) => {
         assertExists(done);
         assertIsError(done.err, JetStreamStatusError, "message not found");
       },
-    }) as QueuedIteratorImpl<StoredMsg>;
+    } as DirectBatchOptions) as QueuedIteratorImpl<StoredMsg>;
 
     const err = await iter.iterClosed;
     assertIsError(err, JetStreamStatusError, "message not found");
@@ -292,7 +297,7 @@ Deno.test("direct - callback", async (t) => {
         }
         buf.push(sm);
       },
-    }) as QueuedIteratorImpl<StoredMsg>;
+    } as DirectBatchOptions) as QueuedIteratorImpl<StoredMsg>;
 
     const err = await iter.iterClosed;
     assertEquals(err, undefined);
@@ -368,7 +373,7 @@ Deno.test("direct - batch", async (t) => {
         return assertBatch({
           opts: {
             batch: 3,
-          },
+          } as DirectBatchOptions,
           expect: [],
         });
       },
@@ -550,7 +555,7 @@ Deno.test("direct - batch next_by_subj", async () => {
     seq: 0,
     batch: 100,
     next_by_subj: "a",
-  });
+  } as DirectBatchOptions);
   for await (const m of iter) {
     msgs.push(m.subject);
   }
@@ -564,7 +569,7 @@ Deno.test("direct - batch next_by_subj", async () => {
     seq: 50,
     batch: 100,
     next_by_subj: "b",
-  });
+  } as DirectBatchOptions);
   for await (const m of iter) {
     msgs.push(m.subject);
   }


### PR DESCRIPTION
The direct APIs are internally used by some operations (KV), but can be very useful to read messages from a stream without having a consumer and by directly interacting with stream replicas. This API can be very useful for some types of applications. This API is non-stable, which means that the API is subject to change.

Refactor direct batch option handling and enforce stricter typing.

Revised typings for `DirectBatchOptions`, ensuring stricter type enforcement and improved clarity between sequence and start time options. Updated corresponding tests and refactored code to align with new type definitions. Added documentation for DirectStreamAPI with notes on non-stable status and potential replica-based inconsistencies.