### PR TITLE
fix(jetstream): conditional logic for retry mechanism could bypass rejection of js publish

### DIFF
--- a/jetstream/src/jsclient.ts
+++ b/jetstream/src/jsclient.ts
@@ -226,8 +226,8 @@ export class JetStreamClientImpl extends BaseApiClientImpl
       } catch (err) {
         const re = err instanceof RequestError ? err as RequestError : null;
         if (
-          err instanceof errors.TimeoutError ||
-          re?.isNoResponders() && i + 1 < retries
+          (err instanceof errors.TimeoutError || re?.isNoResponders()) &&
+          i + 1 < retries
         ) {
           await delay(bo.backoff(i));
         } else {


### PR DESCRIPTION
Updated the conditional statement to ensure proper grouping and evaluate the timeout and no-responders error check accurately. This fixes a potential issue where retries may not trigger as intended.

Fix #247 