### PR TITLE
Additional hardening of the object store client

### DIFF
--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.1-1",
+  "version": "3.0.1-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0",
+  "version": "3.0.1-1",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.0",
+  "version": "3.0.1-1",
   "files": [
     "lib/",
     "LICENSE",

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.1-1",
+  "version": "3.0.1-2",
   "files": [
     "lib/",
     "LICENSE",

--- a/jetstream/src/internal_mod.ts
+++ b/jetstream/src/internal_mod.ts
@@ -95,6 +95,8 @@ export type {
   ThresholdMessages,
 } from "./types.ts";
 
+export type { PushConsumerMessagesImpl } from "./pushconsumer.ts";
+
 export type { StreamNames } from "./jsbaseclient_api.ts";
 export type {
   AccountLimits,

--- a/jetstream/src/jsmstream_api.ts
+++ b/jetstream/src/jsmstream_api.ts
@@ -185,6 +185,8 @@ export class ConsumersImpl implements Consumers {
     cc.inactive_threshold = nanos(5 * 60 * 1000);
     cc.num_replicas = 1;
     cc.max_deliver = 1;
+    cc.flow_control = true;
+    cc.idle_heartbeat = nanos(30_000);
 
     if (Array.isArray(filter_subjects)) {
       cc.filter_subjects = filter_subjects;

--- a/jetstream/src/pushconsumer.ts
+++ b/jetstream/src/pushconsumer.ts
@@ -252,6 +252,9 @@ export class PushConsumerMessagesImpl extends QueuedIteratorImpl<JsMsg>
         ms,
         (count): boolean => {
           this.notify({ type: "heartbeats_missed", count });
+          if (this.ordered) {
+            this.reset();
+          }
           return false;
         },
         { maxOut: 2 },

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -34,6 +34,6 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.0"
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1"
   }
 }

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0",
+  "version": "3.0.1-1",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,6 +34,6 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1"
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-2"
   }
 }

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.0",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.1-1/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.1-1/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-2",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.1-2/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.0",
+  "version": "3.0.1-1",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.1-1",
+    "@nats-io/jetstream": "3.0.1-2",
     "@nats-io/nats-core": "3.0.0"
   },
   "devDependencies": {

--- a/kv/package.json
+++ b/kv/package.json
@@ -33,7 +33,7 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0",
+    "@nats-io/jetstream": "3.0.1-1",
     "@nats-io/nats-core": "3.0.0"
   },
   "devDependencies": {

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.2-1",
+  "version": "3.0.2-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,7 +34,7 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-2",
     "js-sha256": "npm:js-sha256@0.11.0"
   }
 }

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.1",
+  "version": "3.0.2-1",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -34,7 +34,7 @@
   },
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.0",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1",
     "js-sha256": "npm:js-sha256@0.11.0"
   }
 }

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.0",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@~3.0.0/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.1-1/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -2,8 +2,8 @@
   "imports": {
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.0",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@~3.0.0/internal",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-1",
-    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.1-1/internal",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.1-2",
+    "@nats-io/jetstream/internal": "jsr:@nats-io/jetstream@3.0.1-2/internal",
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.1",
+  "version": "3.0.2-1",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.0",
+    "@nats-io/jetstream": "3.0.1-1",
     "@nats-io/nats-core": "3.0.0",
     "js-sha256": "^0.11.0"
   },

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.2-1",
+  "version": "3.0.2-2",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.1-1",
+    "@nats-io/jetstream": "3.0.1-2",
     "@nats-io/nats-core": "3.0.0",
     "js-sha256": "^0.11.0"
   },

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -60,9 +60,9 @@
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@nats-io/jetstream": "3.0.0",
+    "@nats-io/jetstream": "3.0.1-1",
     "@nats-io/kv": "3.0.0",
-    "@nats-io/obj": "3.0.0",
+    "@nats-io/obj": "3.0.2-1",
     "@types/node": "^22.10.10",
     "minimist": "^1.2.8",
     "shx": "^0.3.3",

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -60,9 +60,9 @@
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@nats-io/jetstream": "3.0.1-1",
-    "@nats-io/kv": "3.0.0",
-    "@nats-io/obj": "3.0.2-1",
+    "@nats-io/jetstream": "3.0.1-2",
+    "@nats-io/kv": "3.0.1-1",
+    "@nats-io/obj": "3.0.2-2",
     "@types/node": "^22.10.10",
     "minimist": "^1.2.8",
     "shx": "^0.3.3",


### PR DESCRIPTION
- made obj put publish messages sequentially - as current server can drop requests when the producer is too fast. This will degrade put performance.

- changed the internal push consumer used on get, to have an idle_heartbeat, if this fires, the get has stalled, and the ordered consumer should reset.

- enabled flow control on the ordered consumer, this prevents slow consumers when the client is getting very large objects