### PR TITLE
Add support for Node-specific TLS options

### DIFF
--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-node",
-  "version": "3.0.2",
+  "version": "3.0.3-1",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",

--- a/transport-node/src/connect.ts
+++ b/transport-node/src/connect.ts
@@ -18,13 +18,24 @@ import {
   NatsConnection,
   NatsConnectionImpl,
   setTransportFactory,
+  type TlsOptions,
   Transport,
   TransportFactory,
 } from "./nats-base-client";
 
 import { errors, hasWsProtocol } from "./nats-base-client";
 
-export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
+export type NodeTlsOptions = {
+  rejectUnauthorized?: boolean;
+} & TlsOptions;
+
+export type NodeConnectionOptions = Omit<ConnectionOptions, "tls"> & {
+  tls?: NodeTlsOptions | null;
+};
+
+export function connect(
+  opts: NodeConnectionOptions = {},
+): Promise<NatsConnection> {
   if (hasWsProtocol(opts)) {
     return Promise.reject(
       errors.InvalidArgumentError.format(

--- a/transport-node/src/mod.ts
+++ b/transport-node/src/mod.ts
@@ -12,5 +12,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { connect } from "./connect";
+export { connect, NodeConnectionOptions } from "./connect";
 export * from "./nats-base-client";

--- a/transport-node/src/node_transport.ts
+++ b/transport-node/src/node_transport.ts
@@ -33,6 +33,7 @@ import { existsSync, readFile } from "node:fs";
 import dns from "node:dns";
 import { Buffer } from "node:buffer";
 import { version } from "./version";
+import type { NodeConnectionOptions } from "./connect";
 
 export const VERSION = version;
 const LANG = "nats.js";
@@ -56,7 +57,7 @@ export class NodeTransport implements Transport {
   }
   async connect(
     hp: { hostname: string; port: number; tlsName: string },
-    options: ConnectionOptions,
+    options: NodeConnectionOptions,
   ): Promise<void> {
     this.tlsName = hp.tlsName;
     this.options = options;

--- a/transport-node/src/version.ts
+++ b/transport-node/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.2";
+export const version = "3.0.3-1";

--- a/transport-node/tests/tls_test.js
+++ b/transport-node/tests/tls_test.js
@@ -316,4 +316,27 @@ describe("tls", { timeout: 20_000, concurrency: true, forceExit: true }, () => {
     await nc.close();
     await ns.stop();
   });
+  it("tls first reject unauthorized", async () => {
+    const ns = await NatsServer.start({
+      host: "0.0.0.0",
+      tls: {
+        handshake_first: true,
+        cert_file: resolve(join(dir, "./tests/certs/server.pem")),
+        key_file: resolve(join(dir, "./tests/certs/key.pem")),
+        ca_file: resolve(join(dir, "./tests/certs/ca.pem")),
+      },
+    });
+
+    const nc = await connect({
+      port: ns.port,
+      tls: {
+        handshakeFirst: true,
+        rejectUnauthorized: false,
+      },
+    });
+
+    await nc.flush();
+    await nc.close();
+    await ns.stop();
+  });
 });


### PR DESCRIPTION
Introduced `NodeTlsOptions` and `NodeConnectionOptions` types to handle Node.js-specific TLS configuration `rejectUnauthorized`. Updated  transport-node's `connect()` function and related logic to use the new type, and added a relevant test case for TLS behavior. 