### PR TITLE
feat(jetstream): support for pedantic mode in consumer creation

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -718,6 +718,14 @@ export type PurgeResponse = Success & {
   purged: number;
 };
 
+/**
+ * Additional options that express the intention of the API
+ */
+export type ConsumerApiOptions = ConsumerApiAction | {
+  action?: ConsumerApiAction;
+  pedantic?: boolean;
+};
+
 export const ConsumerApiAction = {
   CreateOrUpdate: "",
   Update: "update",
@@ -730,6 +738,7 @@ export type CreateConsumerRequest = {
   "stream_name": string;
   config: Partial<ConsumerConfig>;
   action?: ConsumerApiAction;
+  pedantic?: boolean;
 };
 
 export type StreamMsgResponse = ApiResponse & {

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -30,6 +30,7 @@ import {
   InvalidArgumentError,
 } from "@nats-io/nats-core/internal";
 import type {
+  ConsumerApiOptions,
   ConsumerConfig,
   ConsumerInfo,
   ConsumerListResponse,
@@ -55,9 +56,13 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
   async add(
     stream: string,
     cfg: ConsumerConfig,
-    action: ConsumerApiAction = ConsumerApiAction.Create,
+    opts: ConsumerApiOptions = ConsumerApiAction.Create,
   ): Promise<ConsumerInfo> {
     validateStreamName(stream);
+
+    if (typeof opts === "string") {
+      opts = { action: opts as ConsumerApiAction };
+    }
 
     if (cfg.deliver_group && cfg.flow_control) {
       throw InvalidArgumentError.format(
@@ -89,7 +94,8 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     const cr = {} as CreateConsumerRequest;
     cr.config = cfg;
     cr.stream_name = stream;
-    cr.action = action;
+    cr.action = opts.action;
+    cr.pedantic = opts.pedantic;
 
     if (cr.config.durable_name) {
       validateDurableName(cr.config.durable_name);

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -23,6 +23,7 @@ import type {
 } from "@nats-io/nats-core/internal";
 
 import type {
+  ConsumerApiOptions,
   DeliverPolicy,
   DirectLastFor,
   PullOptions,
@@ -271,7 +272,11 @@ export type ConsumerAPI = {
    * @param stream
    * @param cfg
    */
-  add(stream: string, cfg: Partial<ConsumerConfig>): Promise<ConsumerInfo>;
+  add(
+    stream: string,
+    cfg: Partial<ConsumerConfig>,
+    opts?: ConsumerApiOptions,
+  ): Promise<ConsumerInfo>;
 
   /**
    * Updates the consumer configuration for the specified consumer on the specified


### PR DESCRIPTION
Introduced a `pedantic` option in `ConsumerApiOptions` to ensure stricter validation of consumer configuration during creation. Updated the `add` method in `jsmconsumer_api.ts` to handle this option, and added a test case to validate pedantic behavior. This enhances flexibility while enforcing stricter checks when needed.

Note the original API allowed for an optional action (a string), now it also allows a ConsumerApiOptions object that allows setting the action and whether it should be pedantic.