### PR TITLE
Add test and logic to bypass JetStream checks for bind-only

### DIFF
--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -54,6 +54,7 @@ import type {
   JetStreamClient,
   JetStreamClientImpl,
   JetStreamManager,
+  JetStreamManagerOptions,
   JetStreamPublishOptions,
   JsMsg,
   Lister,
@@ -302,7 +303,10 @@ export class Bucket implements KV {
     name: string,
     opts: Partial<KvOptions> = {},
   ): Promise<KV> {
-    const jsm = await js.jetstreamManager();
+    const checkAPI = (js.getOptions() as JetStreamManagerOptions)?.checkAPI ||
+      opts.bindOnly === false;
+
+    const jsm = await js.jetstreamManager(checkAPI);
     const info = {
       config: {
         allow_direct: opts.allow_direct,


### PR DESCRIPTION
This update introduces a test to ensure JetStream API calls are skipped when using bind-only mode. Additionally, the `jetstreamManager` method now respects the `checkAPI` flag to optimize operations by reducing unnecessary API interactions.