### PR TITLE
feat(kv): timeout support for put and update operations

### DIFF
--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -582,11 +582,16 @@ export class Bucket implements KV {
     }
   }
 
-  update(k: string, data: Payload, version: number): Promise<number> {
+  update(
+    k: string,
+    data: Payload,
+    version: number,
+    timeout?: number,
+  ): Promise<number> {
     if (version <= 0) {
       throw new Error("version must be greater than 0");
     }
-    return this.put(k, data, { previousSeq: version });
+    return this.put(k, data, { previousSeq: version, timeout });
   }
 
   async put(
@@ -597,7 +602,7 @@ export class Bucket implements KV {
     const ek = this.encodeKey(k);
     this.validateKey(ek);
 
-    const o = {} as JetStreamPublishOptions;
+    const o = { timeout: opts?.timeout } as JetStreamPublishOptions;
     if (opts.previousSeq !== undefined) {
       const h = headers();
       o.headers = h;

--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -286,8 +286,14 @@ export type KV = RoKV & {
    * @param k
    * @param data
    * @param version
+   * @param timeout in millis
    */
-  update(k: string, data: Payload, version: number): Promise<number>;
+  update(
+    k: string,
+    data: Payload,
+    version: number,
+    timeout?: number,
+  ): Promise<number>;
 
   /**
    * Sets or updates the value stored under the specified key.
@@ -335,6 +341,12 @@ export type KvPutOptions = {
    * put will fail.
    */
   previousSeq: number;
+
+  /**
+   * Timeout value in milliseconds for the put, overrides Jetstream context's
+   * default.
+   */
+  timeout: number;
 };
 
 export type KvDeleteOptions = {


### PR DESCRIPTION
Introduced optional timeout parameter for `put` and `update` methods, allowing more flexible handling of operation timeouts. Updated relevant tests to verify timeout behavior, including default and custom values. Enhanced type definitions to document the new timeout functionality.