### PR TITLE
Refactor ConsumerAPI to separate add and update logic

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -718,10 +718,18 @@ export type PurgeResponse = Success & {
   purged: number;
 };
 
+export type ConsumerCreateOptions = {
+  /**
+   * If true, the server will check that the consumer configuration aligns with
+   * stream settings that affect the consumer.
+   */
+  pedantic?: boolean;
+};
+
 /**
  * Additional options that express the intention of the API
  */
-export type ConsumerApiOptions = ConsumerApiAction | {
+export type ConsumerApiOptions = {
   action?: ConsumerApiAction;
   pedantic?: boolean;
 };

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2039,7 +2039,9 @@ Deno.test("jsm - consumer api action", async () => {
   const api = jsm.consumers as ConsumerAPIImpl;
   await assertRejects(
     async () => {
-      await api.add("stream", config, ConsumerApiAction.Update);
+      await api.addUpdate("stream", config, {
+        action: ConsumerApiAction.Update,
+      });
     },
     Error,
     "consumer does not exist",
@@ -2051,7 +2053,7 @@ Deno.test("jsm - consumer api action", async () => {
   config.inactive_threshold = nanos(60 * 1000);
   await assertRejects(
     async () => {
-      await api.add("stream", config, ConsumerApiAction.Create);
+      await api.add("stream", config);
     },
     Error,
     "consumer already exists",


### PR DESCRIPTION
Inadvertently exposed ConsumerApiOptions, which at this time should only expose the `pedantic` option. Refactored the type to be backward compatible in case someone is already using it even though it has not not been released.

Introduced `addUpdate` method to handle shared logic for consumer creation and updates, while keeping `add` and `update` methods for specific actions. This enhances code clarity and maintains backward compatibility by adapting argument handling in the `add` method.