### PR TITLE
feat(kv,jetstream)Add support for per-message TTLs in KV and JetStream

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -172,6 +172,12 @@ export type StreamConfig = StreamUpdateConfig & {
    * as it may disrupt the synchronization logic.
    */
   "first_seq": number;
+
+  /**
+   * Enables allows header initiated per-message TTLs. If disabled, then the `NATS-TTL`
+   * header will be ignored.
+   */
+  "allow_msg_ttl": boolean;
 };
 
 /**
@@ -286,6 +292,10 @@ export type StreamUpdateConfig = {
    * become an upper bound for all clients.
    */
   "consumer_limits"?: StreamConsumerLimits;
+  /**
+   * Sets a duration for adding server markers for delete, purge and max age limits.
+   */
+  "subject_delete_marker_ttl"?: Nanos;
 };
 
 export type Republish = {
@@ -1248,5 +1258,10 @@ export const PubHeaders = {
   ExpectedLastSeqHdr: "Nats-Expected-Last-Sequence",
   ExpectedLastMsgIdHdr: "Nats-Expected-Last-Msg-Id",
   ExpectedLastSubjectSequenceHdr: "Nats-Expected-Last-Subject-Sequence",
+  /**
+   * Sets the TTL for a message (Nanos value). Only have effect on streams that
+   * enable {@link StreamConfig#allow_msg_ttl}.
+   */
+  MessageTTL: "Nats-TTL",
 } as const;
 export type PubHeaders = typeof PubHeaders[keyof typeof PubHeaders];

--- a/jetstream/src/jsclient.ts
+++ b/jetstream/src/jsclient.ts
@@ -200,6 +200,12 @@ export class JetStreamClientImpl extends BaseApiClientImpl
           `${opts.expect.lastSubjectSequence}`,
         );
       }
+      if (opts.ttl) {
+        mh.set(
+          PubHeaders.MessageTTL,
+          `${opts.ttl}`,
+        );
+      }
     }
 
     const to = opts.timeout || this.timeout;

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -144,6 +144,13 @@ export type JetStreamPublishOptions = {
   }>;
 
   /**
+   * Sets {@link PubHeaders#MessageTtl} this only applies to streams that enable
+   * {@link StreamConfig#allow_msg_ttl}. The format of this value is "1s" or "1h",
+   * etc, or a plain number interpreted as the number of seconds.
+   */
+  ttl?: string;
+
+  /**
    * Continue to attempt to publish if the publish fails due to a no responders error.
    * Default is 1.
    */

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2765,14 +2765,16 @@ Deno.test("jsm - stream message ttls", async () => {
   assertEquals(si.config.allow_msg_ttl, true);
   assertEquals(si.config.subject_delete_marker_ttl, nanos(60_000));
 
-  await assertRejects(
-    () => {
-      //@ts-expect-error: this is a test
-      return jsm.streams.update("A", { allow_msg_ttl: false });
-    },
-    Error,
-    "subject marker delete cannot be set if message TTLs are disabled",
-  );
+  // server seems to have changed behaviour.
+  // https://github.com/nats-io/nats-server/issues/6872
+  // await assertRejects(
+  //   () => {
+  //     //@ts-expect-error: this is a test
+  //     return jsm.streams.update("A", { allow_msg_ttl: false });
+  //   },
+  //   Error,
+  //   "subject marker delete cannot be set if message TTLs are disabled",
+  // );
 
   await jsm.streams.update("A", { subject_delete_marker_ttl: 0 });
 

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -27,6 +27,7 @@ import { Feature } from "@nats-io/nats-core/internal";
 import type { NatsConnection } from "@nats-io/nats-core";
 import {
   deferred,
+  delay,
   Empty,
   errors,
   headers,
@@ -81,6 +82,7 @@ import type { JetStreamManagerImpl } from "../src/jsclient.ts";
 import { stripNatsMetadata } from "./util.ts";
 import { jserrors } from "../src/jserrors.ts";
 import type { WithRequired } from "../../core/src/util.ts";
+import { assertBetween } from "../../test_helpers/mod.ts";
 
 const StreamNameRequired = "stream name required";
 const ConsumerNameRequired = "durable name required";
@@ -2743,6 +2745,85 @@ Deno.test("jsm - pull consumer priority groups", async (t) => {
     assertEquals(ci.config.priority_policy, PriorityPolicy.Overflow);
     assertEquals(ci.config.priority_groups, ["hello"]);
   });
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - stream message ttls", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  const si = await jsm.streams.add({
+    name: "A",
+    subjects: ["a"],
+    allow_msg_ttl: true,
+    subject_delete_marker_ttl: nanos(60_000),
+  });
+  assertEquals(si.config.allow_msg_ttl, true);
+  assertEquals(si.config.subject_delete_marker_ttl, nanos(60_000));
+
+  await assertRejects(
+    () => {
+      //@ts-expect-error: this is a test
+      return jsm.streams.update("A", { allow_msg_ttl: false });
+    },
+    Error,
+    "subject marker delete cannot be set if message TTLs are disabled",
+  );
+
+  await jsm.streams.update("A", { subject_delete_marker_ttl: 0 });
+
+  await assertRejects(
+    () => {
+      //@ts-expect-error: this is a test
+      return jsm.streams.update("A", { allow_msg_ttl: false });
+    },
+    Error,
+    "message TTL status can not be changed after stream creation",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - message ttls", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({
+    name: "A",
+    subjects: ["a"],
+    allow_msg_ttl: true,
+  });
+
+  const js = jsm.jetstream();
+  const c = await js.consumers.get("A");
+  const iter = await c.consume();
+
+  (async () => {
+    for await (const m of iter) {
+      console.log(m.seq, m.headers);
+    }
+  })().then();
+
+  await js.publish("a", "hello", { ttl: "4s" });
+
+  const start = Date.now();
+  for (let i = 0;; i++) {
+    const m = await jsm.streams.getMessage("A", { last_by_subj: "a" });
+    if (m === null) {
+      break;
+    }
+    console.log(`${i} still here...`);
+    await delay(1000);
+  }
+  const end = Date.now() - start;
+  assertBetween(end, 4000, 4200);
 
   await cleanup(ns, nc);
 });

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2784,7 +2784,7 @@ Deno.test("jsm - stream message ttls", async () => {
       return jsm.streams.update("A", { allow_msg_ttl: false });
     },
     Error,
-    "message TTL status can not be changed after stream creation",
+    "message TTL status can not be disabled",
   );
 
   await cleanup(ns, nc);

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -1111,11 +1111,13 @@ class KvStoredEntryImpl implements KvEntry {
   }
 
   get operation(): OperationType {
-    const op = this.sm.header.get(kvOperationHdr);
-    if (op === "MaxAge") {
-      return "PURGE";
+    if (this.sm.header?.has("Nats-Marker-Reason")) {
+      const op = this.sm.header?.get("Nats-Marker-Reason");
+      if (op === "MaxAge") {
+        return "PURGE";
+      }
     }
-    return op as OperationType || "PUT";
+    return this.sm.header?.get(kvOperationHdr) as OperationType || "PUT";
   }
 
   get length(): number {

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -1161,11 +1161,13 @@ class KvJsMsgEntryImpl implements KvEntry, KvWatchEntry {
   }
 
   get operation(): OperationType {
-    const op = this.sm.headers?.get(kvOperationHdr);
-    if (op === "MaxAge") {
-      return "PURGE";
+    if (this.sm.headers?.has("Nats-Marker-Reason")) {
+      const op = this.sm.headers?.get("Nats-Marker-Reason");
+      if (op === "MaxAge") {
+        return "PURGE";
+      }
     }
-    return op as OperationType || "PUT";
+    return this.sm.headers?.get(kvOperationHdr) as OperationType || "PUT";
   }
 
   get delta(): number {

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -560,7 +560,7 @@ export class Bucket implements KV {
     return new KvJsMsgEntryImpl(this.bucket, key, jm, isUpdate);
   }
 
-  async create(k: string, data: Payload, markerTTL?: 0): Promise<number> {
+  async create(k: string, data: Payload, markerTTL?: string): Promise<number> {
     let firstErr;
     try {
       const opts: Partial<KvPutOptions> = { previousSeq: 0 };
@@ -620,8 +620,7 @@ export class Bucket implements KV {
     }
     if (opts.ttl) {
       const h = o.headers || headers();
-      const ttl = nanos(opts.ttl);
-      h.set(PubHeaders.MessageTTL, `${ttl}`);
+      h.set(PubHeaders.MessageTTL, opts.ttl);
     }
     try {
       const pa = await this.js.publish(this.subjectForKey(ek, true), data, o);

--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -292,7 +292,7 @@ export type KV = RoKV & {
    * @param data
    * @param markerTTL - in milliseconds
    */
-  create(k: string, data: Payload, markerTTL?: number): Promise<number>;
+  create(k: string, data: Payload, markerTTL?: string): Promise<number>;
 
   /**
    * Updates the existing entry provided that the previous sequence
@@ -361,7 +361,7 @@ export type KvPutOptions = {
    * of millis. Note that for this option to work, the KvBucket must have the
    * markerTTL option.
    */
-  ttl: number;
+  ttl: string;
 
   /**
    * Timeout value in milliseconds for the put, overrides Jetstream context's

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -2231,10 +2231,12 @@ Deno.test("kv - get entry ttl markerTTL", async () => {
   }
   const kvm = await new Kvm(nc);
   const kv = await kvm.create("A", { markerTTL: 2000 });
-  await kv.create("a", Empty, "3s");
+  await kv.create("a", Empty, "1s");
   await kv.delete("a");
-  await kv.purge("a", { ttl: "3s" });
+  await kv.purge("a", { ttl: "1s" });
+  await delay(2000);
   const e = await kv.get("a");
+  console.log(e);
   assertEquals(e?.operation, "PURGE");
   await cleanup(ns, nc);
 });

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -2233,30 +2233,27 @@ Deno.test("kv - entries ttl", async () => {
   assertEquals(si.markerTTL, 2000);
 
   const iter = await kv.watch();
-  const done = (async () => {
+  (async () => {
     for await (const e of iter) {
       console.log(e.revision, e.operation);
       //@ts-expect-error: test
       const jsMsg = e.sm;
       console.log(jsMsg.headers);
-      if (e.operation === "PURGE") {
-        break;
-      }
     }
   })().then();
 
-  await kv.put("a", "hello");
+  await kv.create("a", "hello");
   await kv.delete("a");
   await kv.purge("a", { ttl: "2s" });
 
-  await done;
+  // await done;
   const start = Date.now();
-  while (true) {
+  for (let i = 0;; i++) {
     const b = await kv.get("a");
     if (b === null) {
       break;
     }
-    console.log("still there");
+    console.log("still there", i);
     await delay(1000);
   }
 

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -2222,6 +2222,23 @@ Deno.test("kv - entries ttl markerTTL", async () => {
   await cleanup(ns, nc);
 });
 
+Deno.test("kv - get entry ttl markerTTL", async () => {
+  const { ns, nc } = await setup(
+    jetstreamServerConf({}),
+  );
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return;
+  }
+  const kvm = await new Kvm(nc);
+  const kv = await kvm.create("A", { markerTTL: 2000 });
+  await kv.create("a", Empty, "3s");
+  await kv.delete("a");
+  await kv.purge("a", { ttl: "3s" });
+  const e = await kv.get("a");
+  assertEquals(e?.operation, "PURGE");
+  await cleanup(ns, nc);
+});
+
 Deno.test("kv - entries ttl", async () => {
   const { ns, nc } = await setup(
     jetstreamServerConf({}),


### PR DESCRIPTION
Introduced `markerTTL` and per-message TTL options, allowing fine-grained control over retention policies. Updated KV methods, types, and tests to support these features, ensuring compatibility with streams enabling `allow_msg_ttl`.