### PR TITLE
fix(js): improve handling of 409 status and max_bytes edge cases

### DIFF
--- a/jetstream/src/jserrors.ts
+++ b/jetstream/src/jserrors.ts
@@ -169,11 +169,16 @@ export class JetStreamStatus {
 
   isExceededLimit(): boolean {
     return this.isExceededMaxExpires() || this.isExceededMaxWaiting() ||
-      this.isExceededMaxRequestBatch();
+      this.isExceededMaxRequestBatch() || this.isMessageSizeExceedsMaxBytes();
   }
 
   isMessageNotFound(): boolean {
     return this.code === 404 && this.description === "message not found";
+  }
+
+  isMessageSizeExceedsMaxBytes(): boolean {
+    return this.code === 409 &&
+      this.description === "message size exceeds maxbytes";
   }
 
   isEndOfBatch(): boolean {

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -468,7 +468,7 @@ export type ThresholdMessages = {
 };
 export type ThresholdBytes = {
   /**
-   * Threshold bytes on which the client wil auto-trigger additional message requests
+   * Threshold bytes on which the client auto-triggers additional message requests
    * from the server. This is only applicable to `consume`.
    * @default 75% of {@link MaxBytes}.
    */
@@ -476,11 +476,11 @@ export type ThresholdBytes = {
 };
 export type Expires = {
   /**
-   * Amount of milliseconds to wait for messages before issuing another request.
+   * Number of milliseconds to wait for messages before issuing another request.
    * Note this value shouldn't be set by the user, as the default provides proper behavior.
    * A low value will stress the server.
    *
-   * Minimum value is 1000 (1s).
+   * The minimum value is 1000 (1s).
    * @default 30_000 (30s)
    */
   expires?: number;

--- a/jetstream/tests/consumers_test.ts
+++ b/jetstream/tests/consumers_test.ts
@@ -396,7 +396,7 @@ Deno.test("consumers - threshold_messages bytes", async () => {
   const a = new Array(1001).fill(false);
   const c = await js.consumers.get(stream, "a");
   const iter = await c.consume({
-    expires: 30_000,
+    expires: 2_000,
     max_bytes: 1100,
     threshold_bytes: 1,
   }) as PullConsumerMessagesImpl;


### PR DESCRIPTION
Errors where limits are exceeded (max expires, max waiting, max request batch, message size) - of these only max waiting and message size could auto-heal.