### PR TITLE
feat(js): add support for subject-based sequence constraints

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -1258,6 +1258,8 @@ export const PubHeaders = {
   ExpectedLastSeqHdr: "Nats-Expected-Last-Sequence",
   ExpectedLastMsgIdHdr: "Nats-Expected-Last-Msg-Id",
   ExpectedLastSubjectSequenceHdr: "Nats-Expected-Last-Subject-Sequence",
+  ExpectedLastSubjectSequenceSubjectHdr:
+    "Nats-Expected-Last-Subject-Sequence-Subject",
   /**
    * Sets the TTL for a message (Nanos value). Only have effect on streams that
    * enable {@link StreamConfig#allow_msg_ttl}.

--- a/jetstream/src/jsclient.ts
+++ b/jetstream/src/jsclient.ts
@@ -200,6 +200,12 @@ export class JetStreamClientImpl extends BaseApiClientImpl
           `${opts.expect.lastSubjectSequence}`,
         );
       }
+      if (opts.expect.lastSubjectSequenceSubject) {
+        mh.set(
+          PubHeaders.ExpectedLastSubjectSequenceSubjectHdr,
+          opts.expect.lastSubjectSequenceSubject,
+        );
+      }
       if (opts.ttl) {
         mh.set(
           PubHeaders.MessageTTL,

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -141,6 +141,12 @@ export type JetStreamPublishOptions = {
      * The expected last sequence on the stream for a message with this subject
      */
     lastSubjectSequence: number;
+    /**
+     * This option is used in conjunction with {@link lastSubjectSequence}. It enables a
+     * constraint on the sequence to be based on the specified subject (which can
+     * have wildcards) rather than the subject of the message being published.
+     */
+    lastSubjectSequenceSubject: string;
   }>;
 
   /**

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -145,6 +145,29 @@ export type JetStreamPublishOptions = {
      * This option is used in conjunction with {@link lastSubjectSequence}. It enables a
      * constraint on the sequence to be based on the specified subject (which can
      * have wildcards) rather than the subject of the message being published.
+     *
+     * Here's an example set of sequences for specific subjects:
+     *
+     * ┌─────────┬────────┐
+     * │ subj    │ Seq    │
+     * ├─────────┼────────┤
+     * │ a.1.foo │ 1      │
+     * │ a.1.bar │ 6      │
+     * │ a.2.foo │ 3      │
+     * │ a.3.bar │ 4      │
+     * │ a.1.baz │ 5      │
+     * │ a.2.baz │ 7      │
+     * └─────────┴────────┘
+     *
+     *  The LastSubjectSequenceSubject for wildcards in the last token
+     *  Are evaluated for to the largest sequence matching the subject:
+     * ┌────────────────────┬────────┐
+     * | Last Subj Seq Subj | Seq    |
+     * ├────────────────────┼────────┤
+     * │ a.1.*              │ 6      │
+     * │ a.2.*              │ 7      │
+     * │ a.3.*              │ 4      │
+     * └────────────────────┴────────┘
      */
     lastSubjectSequenceSubject: string;
   }>;


### PR DESCRIPTION
Introduced the `lastSubjectSequenceSubject` option to enable subject-specific sequence constraints when publishing messages. Updated relevant headers, types, and tests to support this feature.

See https://github.com/nats-io/nats-server/issues/5280