### PR TITLE
chore: add utility for managing module versions

### DIFF
--- a/bin/version_manager.ts
+++ b/bin/version_manager.ts
@@ -1,0 +1,931 @@
+import { parse } from "https://deno.land/std@0.224.0/jsonc/parse.ts";
+import * as semver from "https://deno.land/std@0.224.0/semver/mod.ts";
+
+interface PackageJson {
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface DenoJson {
+  name?: string;
+  version?: string;
+  imports?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface Commit {
+  hash: string;
+  message: string;
+  author: string;
+  date: string;
+}
+
+interface VersionSuggestion {
+  module: string;
+  currentVersion: string;
+  suggestedBump: "major" | "minor" | "patch" | "none";
+  reason: string;
+  commits: Commit[];
+}
+
+const NATS_SCOPE = "@nats-io/";
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    const content = await Deno.readTextFile(filePath);
+    return parse(content) as T;
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function writeJsonFile(filePath: string, data: unknown): Promise<void> {
+  const content = JSON.stringify(data, null, 2);
+  await Deno.writeTextFile(filePath, content + "\n");
+}
+
+async function getAllPackageAndDenoJsonPaths(): Promise<string[]> {
+  const paths: string[] = [];
+  for await (const dirEntry of Deno.readDir(".")) {
+    if (dirEntry.isDirectory && !dirEntry.name.startsWith(".")) {
+      const packageJsonPath = `${dirEntry.name}/package.json`;
+      const denoJsonPath = `${dirEntry.name}/deno.json`;
+      try {
+        await Deno.stat(packageJsonPath);
+        paths.push(packageJsonPath);
+      } catch (e) {
+        if (!(e instanceof Deno.errors.NotFound)) {
+          throw e;
+        }
+      }
+      try {
+        await Deno.stat(denoJsonPath);
+        paths.push(denoJsonPath);
+      } catch (e) {
+        if (!(e instanceof Deno.errors.NotFound)) {
+          throw e;
+        }
+      }
+    }
+  }
+  // Add root package.json and deno.json
+  try {
+    await Deno.stat("package.json");
+    paths.push("package.json");
+  } catch (e) {
+    if (!(e instanceof Deno.errors.NotFound)) {
+      throw e;
+    }
+  }
+  try {
+    await Deno.stat("deno.json");
+    paths.push("deno.json");
+  } catch (e) {
+    if (!(e instanceof Deno.errors.NotFound)) {
+      throw e;
+    }
+  }
+  return paths;
+}
+
+async function getModuleVersions(): Promise<Map<string, string>> {
+  const moduleVersions = new Map<string, string>();
+  const paths = await getAllPackageAndDenoJsonPaths();
+
+  // First pass: collect all module versions from their own files
+  for (const path of paths) {
+    if (path.endsWith("package.json")) {
+      const pkg = await readJsonFile<PackageJson>(path);
+      if (pkg && pkg.name && pkg.version && pkg.name.startsWith(NATS_SCOPE)) {
+        const existingVersion = moduleVersions.get(pkg.name);
+        if (existingVersion && existingVersion !== pkg.version) {
+          console.warn(`Warning: ${pkg.name} has different versions in package.json (${pkg.version}) and deno.json (${existingVersion})`);
+          // Use the higher version as the expected one
+          const comparison = semver.compare(semver.parse(pkg.version), semver.parse(existingVersion));
+          if (comparison > 0) {
+            moduleVersions.set(pkg.name, pkg.version);
+          }
+        } else {
+          moduleVersions.set(pkg.name, pkg.version);
+        }
+      }
+    } else if (path.endsWith("deno.json")) {
+      const denoConfig = await readJsonFile<DenoJson>(path);
+      if (
+        denoConfig && denoConfig.name && denoConfig.version &&
+        denoConfig.name.startsWith(NATS_SCOPE)
+      ) {
+        const existingVersion = moduleVersions.get(denoConfig.name);
+        if (existingVersion && existingVersion !== denoConfig.version) {
+          console.warn(`Warning: ${denoConfig.name} has different versions in package.json (${existingVersion}) and deno.json (${denoConfig.version})`);
+          // Use the higher version as the expected one
+          const comparison = semver.compare(semver.parse(denoConfig.version), semver.parse(existingVersion));
+          if (comparison > 0) {
+            moduleVersions.set(denoConfig.name, denoConfig.version);
+          }
+        } else {
+          moduleVersions.set(denoConfig.name, denoConfig.version);
+        }
+      }
+    }
+  }
+  return moduleVersions;
+}
+
+async function checkVersions() {
+  const moduleVersions = await getModuleVersions();
+  const allFiles = await getAllPackageAndDenoJsonPaths();
+  const inconsistencies: Array<{
+    file: string;
+    module: string;
+    expected: string;
+    actual: string;
+  }> = [];
+
+  // First check if each module's own package.json and deno.json have the same version
+  const moduleOwnVersions = new Map<string, { packageVersion?: string; denoVersion?: string }>();
+  
+  for (const filePath of allFiles) {
+    if (filePath.endsWith("package.json")) {
+      const pkg = await readJsonFile<PackageJson>(filePath);
+      if (pkg && pkg.name && pkg.version && pkg.name.startsWith(NATS_SCOPE)) {
+        const existing = moduleOwnVersions.get(pkg.name) || {};
+        existing.packageVersion = pkg.version;
+        moduleOwnVersions.set(pkg.name, existing);
+      }
+    } else if (filePath.endsWith("deno.json")) {
+      const denoConfig = await readJsonFile<DenoJson>(filePath);
+      if (denoConfig && denoConfig.name && denoConfig.version && denoConfig.name.startsWith(NATS_SCOPE)) {
+        const existing = moduleOwnVersions.get(denoConfig.name) || {};
+        existing.denoVersion = denoConfig.version;
+        moduleOwnVersions.set(denoConfig.name, existing);
+      }
+    }
+  }
+
+  // Check for mismatches in module's own files
+  for (const [moduleName, versions] of moduleOwnVersions) {
+    if (versions.packageVersion && versions.denoVersion && versions.packageVersion !== versions.denoVersion) {
+      // Find the actual file paths
+      for (const filePath of allFiles) {
+        if (filePath.endsWith("package.json")) {
+          const pkg = await readJsonFile<PackageJson>(filePath);
+          if (pkg && pkg.name === moduleName) {
+            inconsistencies.push({
+              file: filePath,
+              module: `${moduleName} (own version)`,
+              expected: versions.packageVersion!,
+              actual: versions.packageVersion!,
+            });
+          }
+        } else if (filePath.endsWith("deno.json")) {
+          const denoConfig = await readJsonFile<DenoJson>(filePath);
+          if (denoConfig && denoConfig.name === moduleName) {
+            inconsistencies.push({
+              file: filePath,
+              module: `${moduleName} (own version)`,
+              expected: versions.packageVersion!,
+              actual: versions.denoVersion!,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Now check dependencies
+  for (const filePath of allFiles) {
+    if (filePath.endsWith("package.json")) {
+      const pkg = await readJsonFile<PackageJson>(filePath);
+      if (!pkg) continue;
+
+      const checkDependencies = (deps?: Record<string, string>) => {
+        if (!deps) return;
+        for (const depName in deps) {
+          if (depName.startsWith(NATS_SCOPE)) {
+            const expectedVersion = moduleVersions.get(depName);
+            const actualVersion = deps[depName];
+            if (expectedVersion && actualVersion !== expectedVersion) {
+              inconsistencies.push({
+                file: filePath,
+                module: depName,
+                expected: expectedVersion,
+                actual: actualVersion,
+              });
+            }
+          }
+        }
+      };
+      checkDependencies(pkg.dependencies);
+      checkDependencies(pkg.devDependencies);
+    } else if (filePath.endsWith("deno.json")) {
+      const denoConfig = await readJsonFile<DenoJson>(filePath);
+      if (!denoConfig || !denoConfig.imports) continue;
+
+      for (const importPath in denoConfig.imports) {
+        const importString = denoConfig.imports[importPath];
+        const match = importString.match(/jsr:(@nats-io\/[^@]+)@([\d\.-]+)/);
+        if (match) {
+          const depName = match[1];
+          const actualVersion = match[2];
+          const expectedVersion = moduleVersions.get(depName);
+          if (expectedVersion && actualVersion !== expectedVersion) {
+            inconsistencies.push({
+              file: filePath,
+              module: depName,
+              expected: expectedVersion,
+              actual: actualVersion,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  if (inconsistencies.length === 0) {
+    console.log("All internal NATS module versions are consistent.");
+  } else {
+    console.log(`Found ${inconsistencies.length} version inconsistencies:\n`);
+    console.table(inconsistencies);
+  }
+  return inconsistencies.length > 0;
+}
+
+async function fixVersions() {
+  const moduleVersions = await getModuleVersions();
+  const allFiles = await getAllPackageAndDenoJsonPaths();
+  let fixedCount = 0;
+
+  // First fix module's own version mismatches
+  for (const filePath of allFiles) {
+    if (filePath.endsWith("deno.json")) {
+      const denoConfig = await readJsonFile<DenoJson>(filePath);
+      if (denoConfig && denoConfig.name && denoConfig.version && denoConfig.name.startsWith(NATS_SCOPE)) {
+        const expectedVersion = moduleVersions.get(denoConfig.name);
+        if (expectedVersion && denoConfig.version !== expectedVersion) {
+          denoConfig.version = expectedVersion;
+          await writeJsonFile(filePath, denoConfig);
+          console.log(`Fixed ${filePath}: ${denoConfig.name} own version to ${expectedVersion}`);
+          fixedCount++;
+        }
+      }
+    }
+  }
+
+  // Then fix dependencies
+  for (const filePath of allFiles) {
+    if (filePath.endsWith("package.json")) {
+      const pkg = await readJsonFile<PackageJson>(filePath);
+      if (!pkg) continue;
+
+      let changed = false;
+      const fixDependencies = (deps?: Record<string, string>) => {
+        if (!deps) return;
+        for (const depName in deps) {
+          if (depName.startsWith(NATS_SCOPE)) {
+            const expectedVersion = moduleVersions.get(depName);
+            const actualVersion = deps[depName];
+            if (expectedVersion && actualVersion !== expectedVersion) {
+              deps[depName] = expectedVersion;
+              console.log(
+                `Fixed ${filePath}: ${depName} to ${expectedVersion}`,
+              );
+              changed = true;
+              fixedCount++;
+            }
+          }
+        }
+      };
+      fixDependencies(pkg.dependencies);
+      fixDependencies(pkg.devDependencies);
+
+      if (changed) {
+        await writeJsonFile(filePath, pkg);
+      }
+    } else if (filePath.endsWith("deno.json")) {
+      const denoConfig = await readJsonFile<DenoJson>(filePath);
+      if (!denoConfig || !denoConfig.imports) continue;
+
+      let changed = false;
+      for (const importPath in denoConfig.imports) {
+        const importString = denoConfig.imports[importPath];
+        const match = importString.match(/jsr:(@nats-io\/[^@]+)@([\d\.-]+)/);
+        if (match) {
+          const depName = match[1];
+          const actualVersion = match[2];
+          const expectedVersion = moduleVersions.get(depName);
+          if (expectedVersion && actualVersion !== expectedVersion) {
+            denoConfig.imports[importPath] =
+              `jsr:${depName}@${expectedVersion}`;
+            console.log(
+              `Fixed ${filePath}: ${depName} to ${expectedVersion}`,
+            );
+            changed = true;
+            fixedCount++;
+          }
+        }
+      }
+      if (changed) {
+        await writeJsonFile(filePath, denoConfig);
+      }
+    }
+  }
+  console.log(`Fixed ${fixedCount} version inconsistencies.`);
+}
+
+async function bumpVersion(
+  moduleName: string,
+  bumpType: "major" | "minor" | "patch" | "prerelease",
+) {
+  const allFiles = await getAllPackageAndDenoJsonPaths();
+  let originalVersion: string | undefined;
+  let newVersion: string | undefined;
+
+  // Find ALL files (package.json and deno.json) for the module and bump their versions
+  const moduleFiles: string[] = [];
+  for (const filePath of allFiles) {
+    if (filePath.endsWith("package.json") || filePath.endsWith("deno.json")) {
+      let content: PackageJson | DenoJson | null = null;
+      if (filePath.endsWith("package.json")) {
+        content = await readJsonFile<PackageJson>(filePath);
+      } else {
+        content = await readJsonFile<DenoJson>(filePath);
+      }
+
+      if (content && content.name === moduleName && content.version) {
+        moduleFiles.push(filePath);
+        if (!originalVersion) {
+          originalVersion = content.version;
+          const parsedVersion = semver.parse(originalVersion);
+          const bumped = semver.increment(parsedVersion, bumpType);
+          if (!bumped) {
+            console.error(
+              `Failed to bump version for ${moduleName} with type ${bumpType}`,
+            );
+            return;
+          }
+          newVersion = semver.format(bumped);
+        }
+      }
+    }
+  }
+
+  // Update all module files with the new version
+  for (const filePath of moduleFiles) {
+    let content: PackageJson | DenoJson | null = null;
+    if (filePath.endsWith("package.json")) {
+      content = await readJsonFile<PackageJson>(filePath);
+    } else {
+      content = await readJsonFile<DenoJson>(filePath);
+    }
+
+    if (content && content.version && newVersion) {
+      content.version = newVersion;
+      await writeJsonFile(filePath, content);
+      console.log(
+        `Bumped ${moduleName} from ${originalVersion} to ${newVersion} in ${filePath}`,
+      );
+    }
+  }
+
+  if (!newVersion) {
+    console.error(`Could not find module ${moduleName} to bump its version.`);
+    return;
+  }
+
+  // Update all references to the bumped module
+  let updatedReferences = 0;
+  for (const filePath of allFiles) {
+    if (
+      filePath.endsWith("package.json") || filePath.endsWith("deno.json")
+    ) {
+      let content: PackageJson | DenoJson | null = null;
+      if (filePath.endsWith("package.json")) {
+        content = await readJsonFile<PackageJson>(filePath);
+      } else {
+        content = await readJsonFile<DenoJson>(filePath);
+      }
+
+      if (!content) continue;
+
+      let changed = false;
+      // Update package.json dependencies
+      const updateDeps = (deps?: Record<string, string>) => {
+        if (!deps) return;
+        if (deps[moduleName] && deps[moduleName] !== newVersion) {
+          deps[moduleName] = newVersion;
+          changed = true;
+          updatedReferences++;
+        }
+      };
+      updateDeps((content as PackageJson).dependencies);
+      updateDeps((content as PackageJson).devDependencies);
+
+      // Update deno.json imports
+      if ((content as DenoJson).imports) {
+        for (const importPath in (content as DenoJson).imports) {
+          const importString = (content as DenoJson).imports![importPath];
+          // Escape special regex characters in module name
+          const escapedModuleName = moduleName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const match = importString.match(
+            new RegExp(`(jsr:${escapedModuleName})@([\\d\\.-]+)`),
+          );
+          if (match && match[2] !== newVersion) {
+            (content as DenoJson).imports![importPath] = `${
+              match[1]
+            }@${newVersion}`;
+            changed = true;
+            updatedReferences++;
+          }
+        }
+      }
+
+      if (changed) {
+        await writeJsonFile(filePath, content);
+      }
+    }
+  }
+  console.log(
+    `Updated ${updatedReferences} references to ${moduleName} to version ${newVersion}.`,
+  );
+}
+
+async function fetchRemoteVersions(
+  moduleName?: string,
+  showAll: boolean = false,
+) {
+  const results: Array<{
+    module: string;
+    local?: string;
+    npmLatest?: string;
+    npmNext?: string;
+    jsrLatest?: string;
+    jsrPrerelease?: string;
+  }> = [];
+
+  if (moduleName) {
+    // Single module specified - use it as-is
+    const result = await fetchModuleVersions(moduleName, showAll);
+    if (result) results.push(result);
+  } else {
+    // No module specified - fetch all local NATS modules
+    const modules = Array.from((await getModuleVersions()).keys());
+
+    // Define sort order
+    const sortOrder = [
+      "@nats-io/nats-core",
+      "@nats-io/jetstream",
+      "@nats-io/kv",
+      "@nats-io/obj",
+      "@nats-io/services",
+      "@nats-io/transport-node",
+      "@nats-io/transport-deno",
+    ];
+
+    // Sort modules according to defined order
+    modules.sort((a, b) => {
+      const aIndex = sortOrder.indexOf(a);
+      const bIndex = sortOrder.indexOf(b);
+
+      // If both are in sort order, sort by their position
+      if (aIndex !== -1 && bIndex !== -1) {
+        return aIndex - bIndex;
+      }
+      // If only a is in sort order, it comes first
+      if (aIndex !== -1) return -1;
+      // If only b is in sort order, it comes first
+      if (bIndex !== -1) return 1;
+      // Neither in sort order, sort alphabetically
+      return a.localeCompare(b);
+    });
+
+    for (const mod of modules) {
+      const result = await fetchModuleVersions(mod, showAll);
+      if (result) results.push(result);
+    }
+  }
+
+  if (!showAll && results.length > 0) {
+    // Display as table
+    console.log();
+    console.table(results);
+  }
+}
+
+async function fetchModuleVersions(
+  moduleName: string,
+  showAll: boolean = false,
+) {
+  const result = {
+    module: moduleName,
+    local: undefined as string | undefined,
+    npmLatest: undefined as string | undefined,
+    npmNext: undefined as string | undefined,
+    jsrLatest: undefined as string | undefined,
+    jsrPrerelease: undefined as string | undefined,
+  };
+
+  if (showAll) {
+    console.log(`\nFetching versions for ${moduleName}:`);
+  }
+
+  // Try JSR first - JSR requires scoped packages
+  if (moduleName.startsWith("@")) {
+    try {
+      const jsrUrl = `https://jsr.io/${moduleName}/meta.json`;
+      const response = await fetch(jsrUrl);
+      if (response.ok) {
+        const data = await response.json();
+        const versions = Object.keys(data.versions || {});
+
+        if (showAll) {
+          const displayVersions = versions.slice(0, 10);
+          console.log(
+            `  JSR: ${displayVersions.join(", ")}${
+              displayVersions.length >= 10 ? ", ..." : ""
+            }`,
+          );
+        } else {
+          // Sort versions using semver
+          const sortedVersions = versions.sort((a, b) =>
+            semver.compare(semver.parse(b), semver.parse(a))
+          );
+
+          // Find latest stable and latest prerelease
+          result.jsrLatest = data.latest || sortedVersions.find((v) =>
+            !v.includes("-")
+          ) || sortedVersions[0];
+
+          // Find the latest prerelease
+          const latestPrerelease = sortedVersions.find((v) => v.includes("-"));
+          result.jsrPrerelease = latestPrerelease;
+        }
+      }
+    } catch (_) {
+      // JSR fetch failed, ignore
+    }
+  }
+
+  // Try NPM - works with both scoped and unscoped packages
+  try {
+    const npmUrl = `https://registry.npmjs.org/${moduleName}`;
+    const response = await fetch(npmUrl);
+    if (response.ok) {
+      const data = await response.json();
+
+      if (showAll) {
+        const versions = Object.keys(data.versions || {}).reverse().slice(
+          0,
+          10,
+        );
+        console.log(
+          `  NPM: ${versions.join(", ")}${
+            versions.length >= 10 ? ", ..." : ""
+          }`,
+        );
+      } else {
+        // Use dist-tags for latest versions
+        if (data["dist-tags"]) {
+          result.npmLatest = data["dist-tags"]["latest"];
+          result.npmNext = data["dist-tags"]["next"];
+        }
+      }
+    }
+  } catch (_) {
+    // NPM fetch failed, ignore
+  }
+
+  // Get local version if it exists
+  const localVersions = await getModuleVersions();
+  result.local = localVersions.get(moduleName);
+
+  if (showAll && result.local) {
+    console.log(`  Local: ${result.local}`);
+  }
+
+  return result;
+}
+
+async function getLastReleaseTag(): Promise<string | null> {
+  try {
+    const cmd = new Deno.Command("git", {
+      args: ["describe", "--tags", "--abbrev=0"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code, stdout } = await cmd.output();
+    if (code === 0) {
+      return new TextDecoder().decode(stdout).trim();
+    }
+  } catch (_) {
+    // Ignore errors
+  }
+  return null;
+}
+
+async function getCommitsSinceTag(tag: string, path?: string): Promise<Commit[]> {
+  const commits: Commit[] = [];
+  try {
+    const args = ["log", `${tag}..HEAD`, "--pretty=format:%H|%s|%an|%aI"];
+    if (path) {
+      args.push("--", path);
+    }
+    
+    const cmd = new Deno.Command("git", {
+      args,
+      stdout: "piped",
+      stderr: "piped",
+    });
+    
+    const { code, stdout } = await cmd.output();
+    if (code === 0) {
+      const output = new TextDecoder().decode(stdout).trim();
+      if (output) {
+        const lines = output.split("\n");
+        for (const line of lines) {
+          const [hash, message, author, date] = line.split("|");
+          commits.push({ hash, message, author, date });
+        }
+      }
+    }
+  } catch (_) {
+    // Ignore errors
+  }
+  return commits;
+}
+
+function analyzeCommits(commits: Commit[]): { suggestedBump: "major" | "minor" | "patch" | "none"; reason: string } {
+  if (commits.length === 0) {
+    return { suggestedBump: "none", reason: "No changes" };
+  }
+
+  let hasMajor = false;
+  let hasMinor = false;
+  let hasPatch = false;
+  
+  const changeTypes = new Set<string>();
+
+  for (const commit of commits) {
+    const message = commit.message;
+    const lowerMessage = message.toLowerCase();
+    
+    // Check for breaking changes
+    if (lowerMessage.includes("breaking change") || lowerMessage.includes("breaking:") || message.startsWith("!:") || /^[a-z]+!(\([^)]+\))?:/.test(message)) {
+      hasMajor = true;
+      changeTypes.add("breaking");
+    }
+    // Check for features
+    else if (/^feat(\([^)]+\))?:/i.test(message)) {
+      hasMinor = true;
+      changeTypes.add("features");
+    }
+    // Check for fixes
+    else if (/^fix(\([^)]+\))?:/i.test(message)) {
+      hasPatch = true;
+      changeTypes.add("fixes");
+    }
+    // Check for performance improvements
+    else if (/^perf(\([^)]+\))?:/i.test(message)) {
+      hasPatch = true;
+      changeTypes.add("performance");
+    }
+    // Check for refactoring
+    else if (/^refactor(\([^)]+\))?:/i.test(message)) {
+      hasPatch = true;
+      changeTypes.add("refactoring");
+    }
+    // Check for other changes
+    else if (
+      /^(test|docs|style|build|ci)(\([^)]+\))?:/i.test(message) ||
+      (/^chore(\([^)]+\))?:/i.test(message) && !lowerMessage.includes("deps"))
+    ) {
+      hasPatch = true;
+      changeTypes.add("maintenance");
+    }
+  }
+
+  // Build concise reason string
+  let reason = "";
+  if (changeTypes.has("breaking")) {
+    reason = "Breaking changes";
+  } else if (changeTypes.has("features")) {
+    const others = Array.from(changeTypes).filter(t => t !== "features");
+    reason = others.length > 0 ? `Features + ${others.join(", ")}` : "Features added";
+  } else if (changeTypes.has("fixes")) {
+    const others = Array.from(changeTypes).filter(t => t !== "fixes");
+    reason = others.length > 0 ? `Fixes + ${others.join(", ")}` : "Bug fixes";
+  } else if (changeTypes.has("performance")) {
+    reason = "Performance improvements";
+  } else if (changeTypes.has("refactoring")) {
+    reason = "Code refactoring";
+  } else if (changeTypes.has("maintenance")) {
+    reason = "Maintenance";
+  } else {
+    reason = "No significant changes";
+  }
+
+  if (hasMajor) {
+    return { suggestedBump: "major", reason };
+  } else if (hasMinor) {
+    return { suggestedBump: "minor", reason };
+  } else if (hasPatch) {
+    return { suggestedBump: "patch", reason };
+  } else {
+    return { suggestedBump: "none", reason };
+  }
+}
+
+async function suggestVersionBumps(): Promise<void> {
+  const lastTag = await getLastReleaseTag();
+  if (!lastTag) {
+    console.error("Could not find the last release tag");
+    return;
+  }
+
+  console.log(`Analyzing commits since last release: ${lastTag}\n`);
+
+  const moduleVersions = await getModuleVersions();
+  const suggestions: VersionSuggestion[] = [];
+
+  // Get module directories
+  const moduleDirs = new Map<string, string>();
+  for await (const dirEntry of Deno.readDir(".")) {
+    if (dirEntry.isDirectory && !dirEntry.name.startsWith(".")) {
+      const packageJsonPath = `${dirEntry.name}/package.json`;
+      try {
+        const pkg = await readJsonFile<PackageJson>(packageJsonPath);
+        if (pkg && pkg.name && pkg.name.startsWith(NATS_SCOPE)) {
+          moduleDirs.set(pkg.name, dirEntry.name);
+        }
+      } catch (_) {
+        // Ignore
+      }
+    }
+  }
+
+  // Analyze each module
+  for (const [moduleName, currentVersion] of moduleVersions) {
+    const moduleDir = moduleDirs.get(moduleName);
+    if (!moduleDir) continue;
+
+    // Get commits for this module
+    const commits = await getCommitsSinceTag(lastTag, moduleDir);
+    
+    // Also check for commits that mention the module in the message
+    const allCommits = await getCommitsSinceTag(lastTag);
+    const moduleShortName = moduleName.replace("@nats-io/", "");
+    const relevantCommits = allCommits.filter(commit => {
+      const msg = commit.message.toLowerCase();
+      return msg.includes(moduleShortName) || 
+             msg.includes(`(${moduleShortName})`) ||
+             msg.includes(`[${moduleShortName}]`);
+    });
+
+    // Combine and deduplicate commits
+    const combinedCommits = [...commits];
+    for (const commit of relevantCommits) {
+      if (!combinedCommits.find(c => c.hash === commit.hash)) {
+        combinedCommits.push(commit);
+      }
+    }
+
+    const analysis = analyzeCommits(combinedCommits);
+    
+    suggestions.push({
+      module: moduleName,
+      currentVersion,
+      suggestedBump: analysis.suggestedBump,
+      reason: analysis.reason,
+      commits: combinedCommits,
+    });
+  }
+
+  // Sort suggestions by module order
+  const sortOrder = [
+    "@nats-io/nats-core",
+    "@nats-io/jetstream",
+    "@nats-io/kv",
+    "@nats-io/obj",
+    "@nats-io/services",
+    "@nats-io/transport-node",
+    "@nats-io/transport-deno",
+  ];
+
+  suggestions.sort((a, b) => {
+    const aIndex = sortOrder.indexOf(a.module);
+    const bIndex = sortOrder.indexOf(b.module);
+    if (aIndex !== -1 && bIndex !== -1) {
+      return aIndex - bIndex;
+    }
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
+    return a.module.localeCompare(b.module);
+  });
+
+  // Prepare table data
+  const tableData = suggestions.map(suggestion => {
+    let newVersion = suggestion.currentVersion;
+    if (suggestion.suggestedBump !== "none") {
+      const currentSemver = semver.parse(suggestion.currentVersion);
+      newVersion = semver.format(semver.increment(currentSemver, suggestion.suggestedBump)!);
+    }
+    
+    return {
+      module: suggestion.module,
+      current: suggestion.currentVersion,
+      suggested: suggestion.suggestedBump === "none" ? suggestion.currentVersion : newVersion,
+      bump: suggestion.suggestedBump,
+      commits: suggestion.commits.length,
+      reason: suggestion.reason.length > 50 ? suggestion.reason.substring(0, 47) + "..." : suggestion.reason,
+    };
+  });
+
+  // Display main table
+  console.log("Version Bump Suggestions:");
+  console.log("========================\n");
+  console.table(tableData);
+
+  // Show detailed commits for modules needing bumps
+  const modulesNeedingBumps = suggestions.filter(s => s.suggestedBump !== "none");
+  if (modulesNeedingBumps.length > 0) {
+    console.log("\nDetailed Changes:");
+    console.log("-----------------");
+    for (const suggestion of modulesNeedingBumps) {
+      console.log(`\n${suggestion.module} (${suggestion.commits.length} commits):`);
+      const commitDetails = suggestion.commits.slice(0, 5).map(commit => ({
+        hash: commit.hash.substring(0, 7),
+        message: commit.message.length > 60 ? commit.message.substring(0, 57) + "..." : commit.message,
+        author: commit.author,
+      }));
+      console.table(commitDetails);
+      if (suggestion.commits.length > 5) {
+        console.log(`  ... and ${suggestion.commits.length - 5} more commits`);
+      }
+    }
+  }
+
+  // Show suggested versions summary
+  console.log("\nSuggested Versions:");
+  console.log("-------------------");
+  const versionSummary = suggestions.map(s => {
+    let newVersion = s.currentVersion;
+    if (s.suggestedBump !== "none") {
+      const currentSemver = semver.parse(s.currentVersion);
+      newVersion = semver.format(semver.increment(currentSemver, s.suggestedBump)!);
+    }
+    return {
+      module: s.module,
+      version: newVersion,
+      action: s.suggestedBump === "none" ? "keep current" : `bump ${s.suggestedBump}`,
+    };
+  });
+  console.table(versionSummary);
+}
+
+const args = Deno.args;
+const command = args[0];
+
+if (command === "check") {
+  const hasInconsistencies = await checkVersions();
+  if (hasInconsistencies) {
+    Deno.exit(1);
+  }
+} else if (command === "fix") {
+  await fixVersions();
+} else if (command === "bump") {
+  const moduleName = args[1];
+  const bumpType = args[2] as "major" | "minor" | "patch" | "prerelease";
+  if (!moduleName || !bumpType) {
+    console.error(
+      "Usage: deno run -A bin/version_manager.ts bump <module_name> <major|minor|patch|prerelease>",
+    );
+    Deno.exit(1);
+  }
+  await bumpVersion(moduleName, bumpType);
+} else if (command === "ls" || command === "list") {
+  // Check for --all flag
+  const showAll = args.includes("--all");
+  // Get module name (skip --all if it exists)
+  const moduleName = args.find((arg) => arg !== "ls" && arg !== "list" && arg !== "--all");
+  await fetchRemoteVersions(moduleName, showAll);
+} else if (command === "suggest") {
+  await suggestVersionBumps();
+} else {
+  console.log("Usage:");
+  console.log("  deno run -A bin/version_manager.ts check");
+  console.log("  deno run -A bin/version_manager.ts fix");
+  console.log(
+    "  deno run -A bin/version_manager.ts bump <module_name> <major|minor|patch|prerelease>",
+  );
+  console.log(
+    "  deno run -A bin/version_manager.ts ls [module_name] [--all]",
+  );
+  console.log("  deno run -A bin/version_manager.ts suggest");
+  Deno.exit(1);
+}

--- a/bin/version_manager_test.ts
+++ b/bin/version_manager_test.ts
@@ -3,11 +3,16 @@ import { parse } from "https://deno.land/std@0.224.0/jsonc/parse.ts";
 
 const testDir = await Deno.makeTempDir({ prefix: "version_manager_test_" });
 
-async function createTestFile(path: string, content: object): Promise<void> {
+async function createTestFile(path: string, content: unknown): Promise<void> {
   const fullPath = `${testDir}/${path}`;
   const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
   await Deno.mkdir(dir, { recursive: true });
-  await Deno.writeTextFile(fullPath, JSON.stringify(content, null, 2) + "\n");
+  if (typeof content === "string") {
+    await Deno.writeTextFile(fullPath, content);
+    return;
+  } else {
+    await Deno.writeTextFile(fullPath, JSON.stringify(content, null, 2) + "\n");
+  }
 }
 
 async function readTestFile(path: string): Promise<unknown> {
@@ -16,42 +21,61 @@ async function readTestFile(path: string): Promise<unknown> {
   return parse(content);
 }
 
-async function runVersionManager(args: string[]): Promise<{ success: boolean; output: string }> {
+async function runVersionManager(
+  args: string[],
+): Promise<{ success: boolean; output: string }> {
   // Get the absolute path to version_manager.ts
   const scriptPath = new URL("version_manager.ts", import.meta.url).pathname;
-  
+
   const cmd = new Deno.Command("deno", {
     args: ["run", "-A", scriptPath, ...args],
     cwd: testDir,
     stdout: "piped",
     stderr: "piped",
   });
-  
+
   const { code, stdout, stderr } = await cmd.output();
-  const output = new TextDecoder().decode(stdout) + new TextDecoder().decode(stderr);
+  const output = new TextDecoder().decode(stdout) +
+    new TextDecoder().decode(stderr);
   return { success: code === 0, output };
 }
 
-Deno.test("version_manager - check detects inconsistencies", async () => {
+Deno.test("version_manager - check detects inconsistencies manifests", async () => {
   // Create test files with inconsistencies
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "0.9.0", // Different version
   });
-  
-  await createTestFile("consumer/package.json", {
-    name: "@nats-io/consumer",
+
+  const result = await runVersionManager(["check"]);
+  assertEquals(result.success, false); // Should exit with error when inconsistencies found
+  assertEquals(result.output.includes("Found"), true);
+  assertEquals(result.output.includes("version inconsistencies"), true);
+});
+
+Deno.test("version_manager - check detects inconsistencies src", async () => {
+  // Create test files with inconsistencies
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
     version: "1.0.0",
-    dependencies: {
-      "@nats-io/nats-core": "0.8.0", // Wrong version
-    },
   });
-  
+
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0", // Different version
+  });
+
+  await createTestFile(
+    "core/src/version.ts",
+    "// This file is generated - do not edit\n" +
+      'export const version = "3.0.3-1";\n',
+  );
+
   const result = await runVersionManager(["check"]);
   assertEquals(result.success, false); // Should exit with error when inconsistencies found
   assertEquals(result.output.includes("Found"), true);
@@ -62,46 +86,47 @@ Deno.test("version_manager - check returns success when consistent", async () =>
   // Clean up previous test files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   // Create consistent test files
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
-  await createTestFile("consumer/package.json", {
-    name: "@nats-io/consumer",
-    version: "1.0.0",
-    dependencies: {
-      "@nats-io/nats-core": "1.0.0",
-    },
-  });
-  
+
+  await createTestFile(
+    "core/src/version.ts",
+    "// This file is generated - do not edit\n" +
+      'export const version = "1.0.0";\n',
+  );
+
   const result = await runVersionManager(["check"]);
   assertEquals(result.success, true);
-  assertEquals(result.output.includes("All internal NATS module versions are consistent"), true);
+  assertEquals(
+    result.output.includes("All internal NATS module versions are consistent"),
+    true,
+  );
 });
 
 Deno.test("version_manager - fix updates inconsistent versions", async () => {
   // Clean up and create inconsistent files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "0.9.0",
   });
-  
+
   await createTestFile("consumer/package.json", {
     name: "@nats-io/consumer",
     version: "1.0.0",
@@ -109,7 +134,7 @@ Deno.test("version_manager - fix updates inconsistent versions", async () => {
       "@nats-io/nats-core": "0.8.0",
     },
   });
-  
+
   await createTestFile("consumer/deno.json", {
     name: "@nats-io/consumer",
     version: "1.0.0",
@@ -117,38 +142,46 @@ Deno.test("version_manager - fix updates inconsistent versions", async () => {
       "@nats-io/nats-core": "jsr:@nats-io/nats-core@0.8.0",
     },
   });
-  
+
   // Run fix
   const fixResult = await runVersionManager(["fix"]);
   assertEquals(fixResult.success, true);
   assertEquals(fixResult.output.includes("Fixed"), true);
-  
+
   // Verify files were updated
   const coreDenoJson = await readTestFile("core/deno.json");
   assertEquals((coreDenoJson as { version: string }).version, "1.0.0");
-  
+
   const consumerPkg = await readTestFile("consumer/package.json");
-  assertEquals((consumerPkg as { dependencies: Record<string, string> }).dependencies["@nats-io/nats-core"], "1.0.0");
-  
+  assertEquals(
+    (consumerPkg as { dependencies: Record<string, string> })
+      .dependencies["@nats-io/nats-core"],
+    "1.0.0",
+  );
+
   const consumerDeno = await readTestFile("consumer/deno.json");
-  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["@nats-io/nats-core"], "jsr:@nats-io/nats-core@1.0.0");
+  assertEquals(
+    (consumerDeno as { imports: Record<string, string> })
+      .imports["@nats-io/nats-core"],
+    "jsr:@nats-io/nats-core@1.0.0",
+  );
 });
 
 Deno.test("version_manager - bump updates version correctly", async () => {
   // Clean up and create files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("consumer/package.json", {
     name: "@nats-io/consumer",
     version: "1.0.0",
@@ -156,38 +189,44 @@ Deno.test("version_manager - bump updates version correctly", async () => {
       "@nats-io/nats-core": "1.0.0",
     },
   });
-  
+
   // Test patch bump
   let result = await runVersionManager(["bump", "@nats-io/nats-core", "patch"]);
   assertEquals(result.success, true);
-  
+
   let corePkg = await readTestFile("core/package.json") as { version: string };
   assertEquals(corePkg.version, "1.0.1");
-  
+
   const coreDeno = await readTestFile("core/deno.json") as { version: string };
   assertEquals(coreDeno.version, "1.0.1");
-  
-  const consumerPkg = await readTestFile("consumer/package.json") as { dependencies: Record<string, string> };
+
+  const consumerPkg = await readTestFile("consumer/package.json") as {
+    dependencies: Record<string, string>;
+  };
   assertEquals(consumerPkg.dependencies["@nats-io/nats-core"], "1.0.1");
-  
+
   // Test minor bump
   result = await runVersionManager(["bump", "@nats-io/nats-core", "minor"]);
   assertEquals(result.success, true);
-  
+
   corePkg = await readTestFile("core/package.json") as { version: string };
   assertEquals(corePkg.version, "1.1.0");
-  
+
   // Test major bump
   result = await runVersionManager(["bump", "@nats-io/nats-core", "major"]);
   assertEquals(result.success, true);
-  
+
   corePkg = await readTestFile("core/package.json") as { version: string };
   assertEquals(corePkg.version, "2.0.0");
-  
+
   // Test prerelease bump
-  result = await runVersionManager(["bump", "@nats-io/nats-core", "prerelease"]);
+  result = await runVersionManager([
+    "bump",
+    "@nats-io/nats-core",
+    "prerelease",
+  ]);
   assertEquals(result.success, true);
-  
+
   corePkg = await readTestFile("core/package.json") as { version: string };
   assertEquals(corePkg.version, "2.0.1-0");
 });
@@ -196,12 +235,12 @@ Deno.test("version_manager - handles JSR imports correctly", async () => {
   // Clean up and create files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("consumer/deno.json", {
     name: "@nats-io/consumer",
     version: "1.0.0",
@@ -210,25 +249,31 @@ Deno.test("version_manager - handles JSR imports correctly", async () => {
       "other": "jsr:@std/testing@1.0.0", // Should not be touched
     },
   });
-  
+
   // Run fix
   await runVersionManager(["fix"]);
-  
+
   const consumerDeno = await readTestFile("consumer/deno.json");
-  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["core"], "jsr:@nats-io/nats-core@1.0.0");
-  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["other"], "jsr:@std/testing@1.0.0"); // Unchanged
+  assertEquals(
+    (consumerDeno as { imports: Record<string, string> }).imports["core"],
+    "jsr:@nats-io/nats-core@1.0.0",
+  );
+  assertEquals(
+    (consumerDeno as { imports: Record<string, string> }).imports["other"],
+    "jsr:@std/testing@1.0.0",
+  ); // Unchanged
 });
 
 Deno.test("version_manager - handles modules with special characters", async () => {
   // Clean up and create files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("consumer/deno.json", {
     name: "@nats-io/consumer",
     version: "1.0.0",
@@ -236,30 +281,37 @@ Deno.test("version_manager - handles modules with special characters", async () 
       "core": "jsr:@nats-io/nats-core@1.0.0",
     },
   });
-  
+
   // Bump should handle the special characters in module name
-  const result = await runVersionManager(["bump", "@nats-io/nats-core", "patch"]);
+  const result = await runVersionManager([
+    "bump",
+    "@nats-io/nats-core",
+    "patch",
+  ]);
   assertEquals(result.success, true);
-  
+
   const consumerDeno = await readTestFile("consumer/deno.json");
-  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["core"], "jsr:@nats-io/nats-core@1.0.1");
+  assertEquals(
+    (consumerDeno as { imports: Record<string, string> }).imports["core"],
+    "jsr:@nats-io/nats-core@1.0.1",
+  );
 });
 
 Deno.test("version_manager - detects own version mismatches", async () => {
   // Clean up and create files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "0.9.0", // Mismatch
   });
-  
+
   const result = await runVersionManager(["check"]);
   assertEquals(result.success, false);
   assertEquals(result.output.includes("(own version)"), true);
@@ -269,17 +321,17 @@ Deno.test("version_manager - uses higher version when mismatch detected", async 
   // Clean up and create files
   await Deno.remove(testDir, { recursive: true });
   await Deno.mkdir(testDir);
-  
+
   await createTestFile("core/package.json", {
     name: "@nats-io/nats-core",
     version: "1.0.0",
   });
-  
+
   await createTestFile("core/deno.json", {
     name: "@nats-io/nats-core",
     version: "2.0.0", // Higher version
   });
-  
+
   await createTestFile("consumer/package.json", {
     name: "@nats-io/consumer",
     version: "1.0.0",
@@ -287,12 +339,215 @@ Deno.test("version_manager - uses higher version when mismatch detected", async 
       "@nats-io/nats-core": "1.0.0",
     },
   });
-  
+
   // Fix should use the higher version (2.0.0)
   await runVersionManager(["fix"]);
-  
+
   const consumerPkg = await readTestFile("consumer/package.json");
-  assertEquals((consumerPkg as { dependencies: Record<string, string> }).dependencies["@nats-io/nats-core"], "2.0.0");
+  assertEquals(
+    (consumerPkg as { dependencies: Record<string, string> })
+      .dependencies["@nats-io/nats-core"],
+    "2.0.0",
+  );
+});
+
+Deno.test("version_manager - bump propagates to dependent modules", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+
+  // Create core module
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+
+  // Create services module that depends on core
+  await createTestFile("services/package.json", {
+    name: "@nats-io/services",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "1.0.0",
+    },
+  });
+
+  await createTestFile("services/deno.json", {
+    name: "@nats-io/services",
+    version: "1.0.0",
+  });
+
+  // Create jetstream module that depends on core
+  await createTestFile("jetstream/package.json", {
+    name: "@nats-io/jetstream",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "1.0.0",
+    },
+  });
+
+  await createTestFile("jetstream/deno.json", {
+    name: "@nats-io/jetstream",
+    version: "1.0.0",
+  });
+
+  // Create kv module that depends on both core and jetstream
+  await createTestFile("kv/package.json", {
+    name: "@nats-io/kv",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "1.0.0",
+      "@nats-io/jetstream": "1.0.0",
+    },
+  });
+
+  await createTestFile("kv/deno.json", {
+    name: "@nats-io/kv",
+    version: "1.0.0",
+  });
+
+  // Bump core with minor version - should propagate to all dependents
+  const result = await runVersionManager([
+    "bump",
+    "@nats-io/nats-core",
+    "minor",
+  ]);
+  assertEquals(result.success, true);
+
+  // Check that core was bumped to 1.1.0
+  const corePkg = await readTestFile("core/package.json") as {
+    version: string;
+  };
+  assertEquals(corePkg.version, "1.1.0");
+
+  // Check that services was also bumped (depends on core)
+  const servicesPkg = await readTestFile("services/package.json") as {
+    version: string;
+    dependencies: Record<string, string>;
+  };
+  assertEquals(
+    servicesPkg.version,
+    "1.1.0",
+    "services should be bumped to 1.1.0 due to core dependency",
+  );
+  assertEquals(servicesPkg.dependencies["@nats-io/nats-core"], "1.1.0");
+
+  // Check that jetstream was also bumped (depends on core)
+  const jetstreamPkg = await readTestFile("jetstream/package.json") as {
+    version: string;
+    dependencies: Record<string, string>;
+  };
+  assertEquals(
+    jetstreamPkg.version,
+    "1.1.0",
+    "jetstream should be bumped to 1.1.0 due to core dependency",
+  );
+  assertEquals(jetstreamPkg.dependencies["@nats-io/nats-core"], "1.1.0");
+
+  // Check that kv was also bumped (depends on both core and jetstream)
+  const kvPkg = await readTestFile("kv/package.json") as {
+    version: string;
+    dependencies: Record<string, string>;
+  };
+  assertEquals(
+    kvPkg.version,
+    "1.1.0",
+    "kv should be bumped to 1.1.0 due to dependencies",
+  );
+  assertEquals(kvPkg.dependencies["@nats-io/nats-core"], "1.1.0");
+  assertEquals(kvPkg.dependencies["@nats-io/jetstream"], "1.1.0");
+
+  // Now test major version bump propagation
+  const majorResult = await runVersionManager([
+    "bump",
+    "@nats-io/nats-core",
+    "major",
+  ]);
+  assertEquals(majorResult.success, true);
+
+  // Check that all modules got major bumps
+  const corePkg2 = await readTestFile("core/package.json") as {
+    version: string;
+  };
+  assertEquals(corePkg2.version, "2.0.0");
+
+  const servicesPkg2 = await readTestFile("services/package.json") as {
+    version: string;
+  };
+  assertEquals(
+    servicesPkg2.version,
+    "2.0.0",
+    "services should have major bump due to core major bump",
+  );
+
+  const jetstreamPkg2 = await readTestFile("jetstream/package.json") as {
+    version: string;
+  };
+  assertEquals(
+    jetstreamPkg2.version,
+    "2.0.0",
+    "jetstream should have major bump due to core major bump",
+  );
+
+  const kvPkg2 = await readTestFile("kv/package.json") as { version: string };
+  assertEquals(
+    kvPkg2.version,
+    "2.0.0",
+    "kv should have major bump due to dependencies",
+  );
+});
+
+Deno.test("version_manager - release bump removes prerelease qualifier", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+
+  // Create core module with prerelease version
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0-beta.3",
+  });
+
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0-beta.3",
+  });
+
+  // Test release bump
+  const result = await runVersionManager([
+    "bump",
+    "@nats-io/nats-core",
+    "release",
+  ]);
+  assertEquals(result.success, true);
+  assertEquals(
+    result.output.includes(
+      "Released @nats-io/nats-core from 1.0.0-beta.3 to 1.0.0",
+    ),
+    true,
+  );
+
+  // Verify version was updated
+  const corePkg = await readTestFile("core/package.json") as {
+    version: string;
+  };
+  assertEquals(corePkg.version, "1.0.0");
+
+  const coreDeno = await readTestFile("core/deno.json") as { version: string };
+  assertEquals(coreDeno.version, "1.0.0");
+
+  // Test release on already released version
+  const result2 = await runVersionManager([
+    "bump",
+    "@nats-io/nats-core",
+    "release",
+  ]);
+  assertEquals(result2.success, true);
+  assertEquals(result2.output.includes("is already a release version"), true);
 });
 
 // Cleanup after all tests

--- a/bin/version_manager_test.ts
+++ b/bin/version_manager_test.ts
@@ -1,0 +1,301 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { parse } from "https://deno.land/std@0.224.0/jsonc/parse.ts";
+
+const testDir = await Deno.makeTempDir({ prefix: "version_manager_test_" });
+
+async function createTestFile(path: string, content: object): Promise<void> {
+  const fullPath = `${testDir}/${path}`;
+  const dir = fullPath.substring(0, fullPath.lastIndexOf("/"));
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(fullPath, JSON.stringify(content, null, 2) + "\n");
+}
+
+async function readTestFile(path: string): Promise<unknown> {
+  const fullPath = `${testDir}/${path}`;
+  const content = await Deno.readTextFile(fullPath);
+  return parse(content);
+}
+
+async function runVersionManager(args: string[]): Promise<{ success: boolean; output: string }> {
+  // Get the absolute path to version_manager.ts
+  const scriptPath = new URL("version_manager.ts", import.meta.url).pathname;
+  
+  const cmd = new Deno.Command("deno", {
+    args: ["run", "-A", scriptPath, ...args],
+    cwd: testDir,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  
+  const { code, stdout, stderr } = await cmd.output();
+  const output = new TextDecoder().decode(stdout) + new TextDecoder().decode(stderr);
+  return { success: code === 0, output };
+}
+
+Deno.test("version_manager - check detects inconsistencies", async () => {
+  // Create test files with inconsistencies
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "0.9.0", // Different version
+  });
+  
+  await createTestFile("consumer/package.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "0.8.0", // Wrong version
+    },
+  });
+  
+  const result = await runVersionManager(["check"]);
+  assertEquals(result.success, false); // Should exit with error when inconsistencies found
+  assertEquals(result.output.includes("Found"), true);
+  assertEquals(result.output.includes("version inconsistencies"), true);
+});
+
+Deno.test("version_manager - check returns success when consistent", async () => {
+  // Clean up previous test files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  // Create consistent test files
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("consumer/package.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "1.0.0",
+    },
+  });
+  
+  const result = await runVersionManager(["check"]);
+  assertEquals(result.success, true);
+  assertEquals(result.output.includes("All internal NATS module versions are consistent"), true);
+});
+
+Deno.test("version_manager - fix updates inconsistent versions", async () => {
+  // Clean up and create inconsistent files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "0.9.0",
+  });
+  
+  await createTestFile("consumer/package.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "0.8.0",
+    },
+  });
+  
+  await createTestFile("consumer/deno.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    imports: {
+      "@nats-io/nats-core": "jsr:@nats-io/nats-core@0.8.0",
+    },
+  });
+  
+  // Run fix
+  const fixResult = await runVersionManager(["fix"]);
+  assertEquals(fixResult.success, true);
+  assertEquals(fixResult.output.includes("Fixed"), true);
+  
+  // Verify files were updated
+  const coreDenoJson = await readTestFile("core/deno.json");
+  assertEquals((coreDenoJson as { version: string }).version, "1.0.0");
+  
+  const consumerPkg = await readTestFile("consumer/package.json");
+  assertEquals((consumerPkg as { dependencies: Record<string, string> }).dependencies["@nats-io/nats-core"], "1.0.0");
+  
+  const consumerDeno = await readTestFile("consumer/deno.json");
+  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["@nats-io/nats-core"], "jsr:@nats-io/nats-core@1.0.0");
+});
+
+Deno.test("version_manager - bump updates version correctly", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("consumer/package.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "1.0.0",
+    },
+  });
+  
+  // Test patch bump
+  let result = await runVersionManager(["bump", "@nats-io/nats-core", "patch"]);
+  assertEquals(result.success, true);
+  
+  let corePkg = await readTestFile("core/package.json") as { version: string };
+  assertEquals(corePkg.version, "1.0.1");
+  
+  const coreDeno = await readTestFile("core/deno.json") as { version: string };
+  assertEquals(coreDeno.version, "1.0.1");
+  
+  const consumerPkg = await readTestFile("consumer/package.json") as { dependencies: Record<string, string> };
+  assertEquals(consumerPkg.dependencies["@nats-io/nats-core"], "1.0.1");
+  
+  // Test minor bump
+  result = await runVersionManager(["bump", "@nats-io/nats-core", "minor"]);
+  assertEquals(result.success, true);
+  
+  corePkg = await readTestFile("core/package.json") as { version: string };
+  assertEquals(corePkg.version, "1.1.0");
+  
+  // Test major bump
+  result = await runVersionManager(["bump", "@nats-io/nats-core", "major"]);
+  assertEquals(result.success, true);
+  
+  corePkg = await readTestFile("core/package.json") as { version: string };
+  assertEquals(corePkg.version, "2.0.0");
+  
+  // Test prerelease bump
+  result = await runVersionManager(["bump", "@nats-io/nats-core", "prerelease"]);
+  assertEquals(result.success, true);
+  
+  corePkg = await readTestFile("core/package.json") as { version: string };
+  assertEquals(corePkg.version, "2.0.1-0");
+});
+
+Deno.test("version_manager - handles JSR imports correctly", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("consumer/deno.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    imports: {
+      "core": "jsr:@nats-io/nats-core@0.9.0",
+      "other": "jsr:@std/testing@1.0.0", // Should not be touched
+    },
+  });
+  
+  // Run fix
+  await runVersionManager(["fix"]);
+  
+  const consumerDeno = await readTestFile("consumer/deno.json");
+  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["core"], "jsr:@nats-io/nats-core@1.0.0");
+  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["other"], "jsr:@std/testing@1.0.0"); // Unchanged
+});
+
+Deno.test("version_manager - handles modules with special characters", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("consumer/deno.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    imports: {
+      "core": "jsr:@nats-io/nats-core@1.0.0",
+    },
+  });
+  
+  // Bump should handle the special characters in module name
+  const result = await runVersionManager(["bump", "@nats-io/nats-core", "patch"]);
+  assertEquals(result.success, true);
+  
+  const consumerDeno = await readTestFile("consumer/deno.json");
+  assertEquals((consumerDeno as { imports: Record<string, string> }).imports["core"], "jsr:@nats-io/nats-core@1.0.1");
+});
+
+Deno.test("version_manager - detects own version mismatches", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "0.9.0", // Mismatch
+  });
+  
+  const result = await runVersionManager(["check"]);
+  assertEquals(result.success, false);
+  assertEquals(result.output.includes("(own version)"), true);
+});
+
+Deno.test("version_manager - uses higher version when mismatch detected", async () => {
+  // Clean up and create files
+  await Deno.remove(testDir, { recursive: true });
+  await Deno.mkdir(testDir);
+  
+  await createTestFile("core/package.json", {
+    name: "@nats-io/nats-core",
+    version: "1.0.0",
+  });
+  
+  await createTestFile("core/deno.json", {
+    name: "@nats-io/nats-core",
+    version: "2.0.0", // Higher version
+  });
+  
+  await createTestFile("consumer/package.json", {
+    name: "@nats-io/consumer",
+    version: "1.0.0",
+    dependencies: {
+      "@nats-io/nats-core": "1.0.0",
+    },
+  });
+  
+  // Fix should use the higher version (2.0.0)
+  await runVersionManager(["fix"]);
+  
+  const consumerPkg = await readTestFile("consumer/package.json");
+  assertEquals((consumerPkg as { dependencies: Record<string, string> }).dependencies["@nats-io/nats-core"], "2.0.0");
+});
+
+// Cleanup after all tests
+Deno.test("cleanup", async () => {
+  await Deno.remove(testDir, { recursive: true });
+});


### PR DESCRIPTION
Small tool to manage versions across all modules in the NATS.js monorepo, handling both Node.js (package.json) and Deno (deno.json) modules.

  Commands:

- `check` - Verify version consistency across all modules and their dependencies

- `fix` - Automatically fix version inconsistencies to match expected versions

- `bump <module_name> <version_type>  [--preid <identifier>]` - Bump version of a specific module
  	- Version types: `major`, `minor`, `patch`, `premajor`, `preminor`, `prepatch`, `prerelease`, `release`
  - --preid: Optional identifier for prerelease versions (e.g., alpha, beta, rc)
  - `release`: Special type that removes prerelease suffix (e.g., 3.0.3-1 → 3.0.3)

  `ls [module_name] [--all]` (alias `list`) - List versions from NPM/JSR registries
  - --all: Show all available versions (up to 10) instead of just latest

  `suggest [--show-details] [--apply] [--no-prerelease]` - Analyze commits and suggest version bumps based on conventional commits
  - `--show-details`: Display commit details for modules needing bumps
  - `--apply`: Automatically apply all suggested version bumps
  - `--no-prerelease`: Generate stable versions instead of prerelease versions

  Key Features:

  - Handles dependency propagation (e.g., if nats-core gets a minor bump, dependent modules also get minor bumps)
  - Supports both npm and JSR registry checks
  - Uses semver for all version calculations
  - Properly resets prerelease counters when bumping to new major/minor/patch versions
  - Analyzes conventional commits (feat:, fix:, etc.) to determine appropriate version bumps