### PR TITLE
chore: bump versions across modules and update dependencies

### DIFF
--- a/.github/workflows/consistency_checks.yml
+++ b/.github/workflows/consistency_checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deno-version: [2.2.x]
+        deno-version: [2.4.x]
         module: [
           core,
           jetstream,

--- a/.github/workflows/deno_checks.yml
+++ b/.github/workflows/deno_checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deno-version: [2.2.x]
+        deno-version: [2.4.x]
         module: [core, jetstream, kv, obj, services, transport-deno]
 
     steps:

--- a/.github/workflows/node_checks.yml
+++ b/.github/workflows/node_checks.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        deno-version: [2.2.x]
-        node-version: [23.x]
+        deno-version: [2.4.x]
+        node-version: [24.x]
 
     steps:
       - name: Git Checkout Sources

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [23.x]
-        deno-version: [2.2.x]
+        node-version: [24.x]
+        deno-version: [2.4.x]
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/transport-node-test.yml
+++ b/.github/workflows/transport-node-test.yml
@@ -18,8 +18,8 @@ jobs:
   test:
     strategy:
       matrix:
-        deno-version: [2.2.x]
-        node-version: [23.x]
+        deno-version: [2.4.x]
+        node-version: [24.x]
 
     name: test node transport with local dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/transport-node-test.yml
+++ b/.github/workflows/transport-node-test.yml
@@ -47,14 +47,15 @@ jobs:
           name: nats-server
           cache: true
 
-      - name: Disable NPM workspace
+      - name: Build workspace
         run: |
-          deno task disable-npm-workspace
+          npm install --workspaces
+          npm run build --workspaces
 
-      - name: Test Node Transport with specified dependencies
+
+      - name: Test Node Transport with local dependencies
         working-directory: transport-node
         env:
           CI: true
         run: |
-          npm install
           npm test

--- a/bin/cjs-fix-imports.ts
+++ b/bin/cjs-fix-imports.ts
@@ -1,4 +1,4 @@
-import { parseArgs } from "jsr:@std/cli@0.224.3/parse-args";
+import { parseArgs } from "jsr:@std/cli@1.0.20/parse-args";
 import {
   basename,
   extname,

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"

--- a/core/import_map.json
+++ b/core/import_map.json
@@ -3,6 +3,6 @@
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nats-core": "./src/mod.ts",
     "@nats-io/nats-core/internal": "./src/internal_mod.ts",
-    "@std/io": "jsr:@std/io@0.225.0"
+    "@std/io": "jsr:@std/io@0.225.2"
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "files": [
     "lib/",
     "LICENSE",
@@ -37,8 +37,8 @@
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@types/node": "^22.13.10",
+    "@types/node": "^24.0.11",
     "shx": "^0.4.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/nats-core",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "files": [
     "lib/",
     "LICENSE",

--- a/core/src/version.ts
+++ b/core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.3-1";
+export const version = "3.1.0-2";

--- a/core/src/version.ts
+++ b/core/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.1.0-2";
+export const version = "3.1.0";

--- a/core/tests/auth_test.ts
+++ b/core/tests/auth_test.ts
@@ -26,7 +26,7 @@ import {
   encodeAccount,
   encodeOperator,
   encodeUser,
-} from "jsr:@nats-io/jwt@0.0.9-3";
+} from "jsr:@nats-io/jwt@0.0.11";
 import type {
   MsgImpl,
   NatsConnectionImpl,

--- a/core/tests/authenticator_test.ts
+++ b/core/tests/authenticator_test.ts
@@ -39,7 +39,7 @@ import {
   encodeOperator,
   encodeUser,
   fmtCreds,
-} from "jsr:@nats-io/jwt@0.0.9-3";
+} from "jsr:@nats-io/jwt@0.0.11";
 import { assertBetween } from "test_helpers";
 
 function disconnectReconnect(nc: NatsConnection): Promise<void> {

--- a/docs/services/media/02_multiple_endpoints.ts
+++ b/docs/services/media/02_multiple_endpoints.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "jsr:@nats-io/nats-transport-deno@3.0.0-5";
+import { connect } from "jsr:@nats-io/transport-deno";
 import { ServiceError, Svcm } from "../src/mod.ts";
 import type { ServiceMsg } from "../src/mod.ts";
 

--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --trace-leaks --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.3-1"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2"
   }
 }

--- a/jetstream/deno.json
+++ b/jetstream/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --trace-leaks --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0"
   }
 }

--- a/jetstream/import_map.json
+++ b/jetstream/import_map.json
@@ -5,6 +5,6 @@
     "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.3-1",
     "@nats-io/nats-core/internal": "jsr:@nats-io/nats-core@3.0.3-1/internal",
     "test_helpers": "../test_helpers/mod.ts",
-    "@std/io": "jsr:@std/io@0.225.0"
+    "@std/io": "jsr:@std/io@0.225.2"
   }
 }

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,11 +33,11 @@
   },
   "description": "jetstream library - this library implements all the base functionality for NATS JetStream for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.0.3-1"
+    "@nats-io/nats-core": "3.1.0-2"
   },
   "devDependencies": {
-    "@types/node": "^22.13.10",
+    "@types/node": "^24.0.11",
     "shx": "^0.4.0",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/jetstream",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "jetstream library - this library implements all the base functionality for NATS JetStream for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.1.0-2"
+    "@nats-io/nats-core": "3.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.11",

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -70,7 +70,7 @@ import {
   encodeAccount,
   encodeOperator,
   encodeUser,
-} from "jsr:@nats-io/jwt@0.0.9-3";
+} from "jsr:@nats-io/jwt@0.0.11";
 import { convertStreamSourceDomain } from "../src/jsmstream_api.ts";
 import type { ConsumerAPIImpl } from "../src/jsmconsumer_api.ts";
 import {

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,7 +33,7 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.1.0-2"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.1.0"
   }
 }

--- a/kv/deno.json
+++ b/kv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,7 +33,7 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.3-1",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.3-1"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.1.0-2"
   }
 }

--- a/kv/import_map.json
+++ b/kv/import_map.json
@@ -7,6 +7,6 @@
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",
-    "@std/io": "jsr:@std/io@0.225.0"
+    "@std/io": "jsr:@std/io@0.225.2"
   }
 }

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,8 +33,8 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.1.0-2",
-    "@nats-io/nats-core": "3.1.0-2"
+    "@nats-io/jetstream": "3.1.0",
+    "@nats-io/nats-core": "3.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.11",

--- a/kv/package.json
+++ b/kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/kv",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,12 +33,12 @@
   },
   "description": "kv library - this library implements all the base functionality for NATS KV javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.3-1",
-    "@nats-io/nats-core": "3.0.3-1"
+    "@nats-io/jetstream": "3.1.0-2",
+    "@nats-io/nats-core": "3.1.0-2"
   },
   "devDependencies": {
-    "@types/node": "^22.10.10",
-    "shx": "^0.3.4",
-    "typescript": "^5.8.2"
+    "@types/node": "^24.0.11",
+    "shx": "^0.4.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,8 +33,8 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.3-1",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.0.3-1",
-    "js-sha256": "npm:js-sha256@0.11.0"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.1.0-2",
+    "js-sha256": "npm:js-sha256@0.11.1"
   }
 }

--- a/obj/deno.json
+++ b/obj/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,8 +33,8 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2",
-    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.1.0-2",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0",
+    "@nats-io/jetstream": "jsr:@nats-io/jetstream@3.1.0",
     "js-sha256": "npm:js-sha256@0.11.1"
   }
 }

--- a/obj/import_map.json
+++ b/obj/import_map.json
@@ -7,6 +7,6 @@
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",
-    "@std/io": "jsr:@std/io@0.225.0"
+    "@std/io": "jsr:@std/io@0.225.2"
   }
 }

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,8 +33,8 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.1.0-2",
-    "@nats-io/nats-core": "3.1.0-2",
+    "@nats-io/jetstream": "3.1.0",
+    "@nats-io/nats-core": "3.1.0",
     "js-sha256": "^0.11.1"
   },
   "devDependencies": {

--- a/obj/package.json
+++ b/obj/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/obj",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,13 +33,13 @@
   },
   "description": "obj library - this library implements all the base functionality for NATS objectstore for javascript clients",
   "dependencies": {
-    "@nats-io/jetstream": "3.0.3-1",
-    "@nats-io/nats-core": "3.0.3-1",
-    "js-sha256": "^0.11.0"
+    "@nats-io/jetstream": "3.1.0-2",
+    "@nats-io/nats-core": "3.1.0-2",
+    "js-sha256": "^0.11.1"
   },
   "devDependencies": {
-    "@types/node": "^22.10.10",
-    "shx": "^0.3.4",
-    "typescript": "^5.8.2"
+    "@types/node": "^24.0.11",
+    "shx": "^0.4.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/services/deno.json
+++ b/services/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0"
   }
 }

--- a/services/deno.json
+++ b/services/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "exports": {
     ".": "./src/mod.ts",
     "./internal": "./src/internal_mod.ts"
@@ -33,6 +33,6 @@
     "test": "deno test -A --parallel --reload --quiet tests/ --import-map=import_map.json"
   },
   "imports": {
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.3-1"
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2"
   }
 }

--- a/services/examples/02_multiple_endpoints.ts
+++ b/services/examples/02_multiple_endpoints.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "jsr:@nats-io/nats-transport-deno@3.0.0-5";
+import { connect } from "jsr:@nats-io/transport-deno";
 import { ServiceError, Svcm } from "../src/mod.ts";
 import type { ServiceMsg } from "../src/mod.ts";
 

--- a/services/examples/03_bigdata.ts
+++ b/services/examples/03_bigdata.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "jsr:@nats-io/nats-transport-deno@3.0.0-5";
+import { connect } from "jsr:@nats-io/transport-deno";
 import { Svcm } from "../src/mod.ts";
 import { humanizeBytes } from "./03_util.ts";
 import type { DataRequest } from "./03_util.ts";

--- a/services/import_map.json
+++ b/services/import_map.json
@@ -5,6 +5,6 @@
     "test_helpers": "../test_helpers/mod.ts",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3",
-    "@std/io": "jsr:@std/io@0.224.0"
+    "@std/io": "jsr:@std/io@0.225.2"
   }
 }

--- a/services/package.json
+++ b/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,11 +33,11 @@
   },
   "description": "services library - this library implements all the base functionality for NATS services for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.0.3-1"
+    "@nats-io/nats-core": "3.1.0-2"
   },
   "devDependencies": {
-    "@types/node": "^22.10.10",
-    "shx": "^0.3.4",
-    "typescript": "^5.8.2"
+    "@types/node": "^24.0.11",
+    "shx": "^0.4.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/services/package.json
+++ b/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/services",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "files": [
     "lib/",
     "LICENSE",
@@ -33,7 +33,7 @@
   },
   "description": "services library - this library implements all the base functionality for NATS services for javascript clients",
   "dependencies": {
-    "@nats-io/nats-core": "3.1.0-2"
+    "@nats-io/nats-core": "3.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.11",

--- a/transport-deno/README.md
+++ b/transport-deno/README.md
@@ -20,7 +20,7 @@ NATS client functionality.
 You can get the latest release version like this:
 
 ```typescript
-import * as nats from "jsr:@nats-io/nats-transport-deno";
+import * as nats from "jsr:@nats-io/transport-deno";
 ```
 
 To specify a specific released version, simply replace nats with

--- a/transport-deno/deno.json
+++ b/transport-deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-deno",
-  "version": "3.0.3-1",
+  "version": "3.1.0-2",
   "exports": {
     ".": "./src/mod.ts"
   },
@@ -20,7 +20,7 @@
   },
   "imports": {
     "@std/io": "jsr:@std/io@0.225.2",
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.0.3-1",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3"
   }

--- a/transport-deno/deno.json
+++ b/transport-deno/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-deno",
-  "version": "3.1.0-2",
+  "version": "3.1.0",
   "exports": {
     ".": "./src/mod.ts"
   },
@@ -20,7 +20,7 @@
   },
   "imports": {
     "@std/io": "jsr:@std/io@0.225.2",
-    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0-2",
+    "@nats-io/nats-core": "jsr:@nats-io/nats-core@3.1.0",
     "@nats-io/nkeys": "jsr:@nats-io/nkeys@2.0.3",
     "@nats-io/nuid": "jsr:@nats-io/nuid@2.0.3"
   }

--- a/transport-deno/src/version.ts
+++ b/transport-deno/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.3-1";
+export const version = "3.1.0-2";

--- a/transport-deno/src/version.ts
+++ b/transport-deno/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.1.0-2";
+export const version = "3.1.0";

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-node",
-  "version": "3.1.0-3",
+  "version": "3.1.0",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -55,14 +55,14 @@
     "node": ">= 18.0.0"
   },
   "dependencies": {
-    "@nats-io/nats-core": "3.1.0-2",
+    "@nats-io/nats-core": "3.1.0",
     "@nats-io/nkeys": "2.0.3",
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@nats-io/jetstream": "3.1.0-2",
-    "@nats-io/kv": "3.1.0-2",
-    "@nats-io/obj": "3.1.0-2",
+    "@nats-io/jetstream": "3.1.0",
+    "@nats-io/kv": "3.1.0",
+    "@nats-io/obj": "3.1.0",
     "@types/node": "^24.0.11",
     "minimist": "^1.2.8",
     "shx": "^0.4.0",

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nats-io/transport-node",
-  "version": "3.0.3-2",
+  "version": "3.1.0-3",
   "description": "Node.js client for NATS, a lightweight, high-performance cloud native messaging system",
   "keywords": [
     "nats",
@@ -55,17 +55,17 @@
     "node": ">= 18.0.0"
   },
   "dependencies": {
-    "@nats-io/nats-core": "3.0.3-1",
+    "@nats-io/nats-core": "3.1.0-2",
     "@nats-io/nkeys": "2.0.3",
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@nats-io/jetstream": "3.0.3-1",
-    "@nats-io/kv": "3.0.3-1",
-    "@nats-io/obj": "3.0.3-1",
-    "@types/node": "^22.10.10",
+    "@nats-io/jetstream": "3.1.0-2",
+    "@nats-io/kv": "3.1.0-2",
+    "@nats-io/obj": "3.1.0-2",
+    "@types/node": "^24.0.11",
     "minimist": "^1.2.8",
-    "shx": "^0.3.3",
-    "typescript": "^5.8.2"
+    "shx": "^0.4.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/transport-node/src/version.ts
+++ b/transport-node/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.1.0-3";
+export const version = "3.1.0";

--- a/transport-node/src/version.ts
+++ b/transport-node/src/version.ts
@@ -1,2 +1,2 @@
 // This file is generated - do not edit
-export const version = "3.0.3-2";
+export const version = "3.1.0-3";


### PR DESCRIPTION
- Updated versions for NATS modules, including core, JetStream, KV, object store, services, and transport.
- Upgraded `@types/node`, `shx`, `typescript`, and `js-sha256` dependencies.