### PR TITLE
fix(core): use InstanceType for TE and TD type annotations

### DIFF
--- a/core/src/encoders.ts
+++ b/core/src/encoders.ts
@@ -14,8 +14,8 @@
  */
 export const Empty: Uint8Array = new Uint8Array(0);
 
-export const TE: TextEncoder = new TextEncoder();
-export const TD: TextDecoder = new TextDecoder();
+export const TE: InstanceType<typeof TextEncoder> = new TextEncoder();
+export const TD: InstanceType<typeof TextDecoder> = new TextDecoder();
 
 function concat(...bufs: Uint8Array[]): Uint8Array {
   let max = 0;


### PR DESCRIPTION
With this change, the `TextEncoder` and `TextDecoder` instances are correctly typed as `InstanceType<typeof TextEncoder>` and `InstanceType<typeof TextDecoder>`, respectively. This ensures that the types are inferred correctly, especially in environments where these classes might not be available globally.

Refs: #297
Resolves: #297