### PR TITLE
chore: update `@std` imports and bump dependencies across modules

### DIFF
--- a/bin/bundle.ts
+++ b/bin/bundle.ts
@@ -12,13 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { cli } from "jsr:@aricart/cobra";
-import * as esbuild from "npm:esbuild";
+import { cli } from "@aricart/cobra";
+import * as esbuild from "esbuild";
 // Import the Wasm build on platforms where running subprocesses is not
 // permitted, such as Deno Deploy, or when running without `--allow-run`.
 // import * as esbuild from "https://deno.land/x/esbuild@0.20.2/wasm.js";
 
-import { denoPlugins } from "jsr:@luca/esbuild-deno-loader";
+import { denoPlugins } from "@luca/esbuild-deno-loader";
 
 const root = cli({
   use: "bundle javascript/typescript",

--- a/bin/check-bundle-version.ts
+++ b/bin/check-bundle-version.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parseArgs } from "jsr:@std/cli/parse-args";
-import { join } from "jsr:@std/path";
+import { parseArgs } from "@std/cli/parse-args";
+import { join } from "@std/path";
 import { loadVersions, SemVer } from "./lib/bundle_versions.ts";
 
 // Check that a particular bundle has consistent versions across

--- a/bin/check-dep-versions.ts
+++ b/bin/check-dep-versions.ts
@@ -19,7 +19,7 @@
 // raises the minimum version of the dependency to currently released versions
 // of the dependency.
 
-import { join } from "jsr:@std/path";
+import { join } from "@std/path";
 import { loadPackageFile, SemVer } from "./lib/bundle_versions.ts";
 
 type PackageJSON = {

--- a/bin/cjs-fix-imports.ts
+++ b/bin/cjs-fix-imports.ts
@@ -1,10 +1,5 @@
-import { parseArgs } from "jsr:@std/cli@1.0.20/parse-args";
-import {
-  basename,
-  extname,
-  join,
-  resolve,
-} from "https://deno.land/std@0.136.0/path/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
+import { basename, extname, join, resolve } from "@std/path";
 
 const argv = parseArgs(
   Deno.args,

--- a/bin/dependencies.ts
+++ b/bin/dependencies.ts
@@ -13,11 +13,7 @@
  * limitations under the License.
  */
 
-import {
-  extname,
-  join,
-  resolve,
-} from "https://deno.land/std@0.221.0/path/mod.ts";
+import { extname, join, resolve } from "@std/path";
 
 // resolve the specified directories to fq
 // let dirs = ["src", "nats-base-client", "jetstream", "bin"].map((n) => {

--- a/bin/exports.ts
+++ b/bin/exports.ts
@@ -13,13 +13,8 @@
  * limitations under the License.
  */
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
-import {
-  basename,
-  extname,
-  join,
-  resolve,
-} from "https://deno.land/std@0.221.0/path/mod.ts";
+import { parse } from "@std/flags";
+import { basename, extname, join, resolve } from "@std/path";
 
 const argv = parse(
   Deno.args,

--- a/bin/fix-os.ts
+++ b/bin/fix-os.ts
@@ -12,13 +12,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parse } from "@std/flags";
 import { ObjectStoreImpl, ServerObjectInfo } from "../os/objectstore.ts";
-import {
-  connect,
-  ConnectionOptions,
-  credsAuthenticator,
-} from "https://raw.githubusercontent.com/nats-io/nats.deno/main/src/mod.ts";
+import { connect, ConnectionOptions, credsAuthenticator } from "nats-deno";
 
 const argv = parse(
   Deno.args,

--- a/bin/lib/bundle_versions.ts
+++ b/bin/lib/bundle_versions.ts
@@ -1,4 +1,4 @@
-import { join } from "jsr:@std/path";
+import { join } from "@std/path";
 
 export class ModuleVersions {
   file?: SemVer;

--- a/bin/licenses.js
+++ b/bin/licenses.js
@@ -1,6 +1,6 @@
-import $ from "jsr:@david/dax";
+import $ from "@david/dax";
 $.setPrintCommand(true);
-import checker from "npm:license-checker";
+import checker from "license-checker";
 
 const modules = [
   "core",

--- a/bin/os_compatibility.ts
+++ b/bin/os_compatibility.ts
@@ -14,7 +14,7 @@
  */
 
 import { connect, millis, Msg } from "../src/mod.ts";
-import { sha256 } from "https://denopkg.com/chiefbiiko/sha256@v1.0.0/mod.ts";
+import { sha256 } from "@chiefbiiko/sha256";
 
 const servers = Deno.env.get("NATS_URL") || "nats://localhost:4222";
 const nc = await connect({ servers });

--- a/bin/version_manager.ts
+++ b/bin/version_manager.ts
@@ -17,8 +17,8 @@
  * All operations are local only.
  */
 
-import { parse } from "https://deno.land/std@0.224.0/jsonc/parse.ts";
-import * as semver from "https://deno.land/std@0.224.0/semver/mod.ts";
+import { parse } from "@std/jsonc/parse";
+import * as semver from "@std/semver";
 
 interface PackageJson {
   name: string;

--- a/bin/version_manager_test.ts
+++ b/bin/version_manager_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
-import { parse } from "https://deno.land/std@0.224.0/jsonc/parse.ts";
+import { assertEquals } from "@std/assert";
+import { parse } from "@std/jsonc/parse";
 
 const testDir = await Deno.makeTempDir({ prefix: "version_manager_test_" });
 

--- a/core/package.json
+++ b/core/package.json
@@ -37,8 +37,8 @@
     "@nats-io/nuid": "2.0.3"
   },
   "devDependencies": {
-    "@types/node": "^24.0.11",
+    "@types/node": "^24.3.1",
     "shx": "^0.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/core/tests/auth_test.ts
+++ b/core/tests/auth_test.ts
@@ -21,12 +21,8 @@ import {
   assertRejects,
   assertStringIncludes,
   fail,
-} from "jsr:@std/assert";
-import {
-  encodeAccount,
-  encodeOperator,
-  encodeUser,
-} from "jsr:@nats-io/jwt@0.0.11";
+} from "@std/assert";
+import { encodeAccount, encodeOperator, encodeUser } from "@nats-io/jwt";
 import type {
   MsgImpl,
   NatsConnectionImpl,

--- a/core/tests/authenticator_test.ts
+++ b/core/tests/authenticator_test.ts
@@ -33,13 +33,13 @@ import type {
   NatsConnectionImpl,
 } from "../src/internal_mod.ts";
 
-import { assertEquals, assertThrows } from "jsr:@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import {
   encodeAccount,
   encodeOperator,
   encodeUser,
   fmtCreds,
-} from "jsr:@nats-io/jwt@0.0.11";
+} from "@nats-io/jwt";
 import { assertBetween } from "test_helpers";
 
 function disconnectReconnect(nc: NatsConnection): Promise<void> {

--- a/core/tests/autounsub_test.ts
+++ b/core/tests/autounsub_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals, assertRejects } from "jsr:@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 
 import { createInbox, Empty, errors } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl, Subscription } from "../src/internal_mod.ts";

--- a/core/tests/basics_test.ts
+++ b/core/tests/basics_test.ts
@@ -20,7 +20,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import {
   collect,

--- a/core/tests/bench_test.ts
+++ b/core/tests/bench_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert, assertEquals, assertThrows } from "jsr:@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import { Bench, createInbox, Metric } from "../src/mod.ts";
 import { connect } from "./connect.ts";
 import type { BenchOpts } from "../src/mod.ts";

--- a/core/tests/binary_test.ts
+++ b/core/tests/binary_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 import { createInbox, deferred } from "../src/internal_mod.ts";
 import type { Msg } from "../src/internal_mod.ts";
 import { cleanup, setup } from "test_helpers";

--- a/core/tests/buffer_test.ts
+++ b/core/tests/buffer_test.ts
@@ -7,7 +7,7 @@
 // This code removes all Deno specific functionality to enable its use
 // in a browser environment
 
-import { assert, assertEquals, assertThrows } from "jsr:@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 import {
   DenoBuffer,
   MAX_SIZE,

--- a/core/tests/clobber_test.ts
+++ b/core/tests/clobber_test.ts
@@ -16,7 +16,7 @@
 import { NatsServer } from "../../test_helpers/launcher.ts";
 import { createInbox, DataBuffer } from "../src/internal_mod.ts";
 import { connect } from "./connect.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 function makeBuffer(N: number): Uint8Array {
   const buf = new Uint8Array(N);

--- a/core/tests/databuffer_test.ts
+++ b/core/tests/databuffer_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 import { DataBuffer } from "../src/internal_mod.ts";
 
 Deno.test("databuffer - empty", () => {

--- a/core/tests/doublesubs_test.ts
+++ b/core/tests/doublesubs_test.ts
@@ -16,7 +16,7 @@ import { NatsServer } from "../../test_helpers/launcher.ts";
 
 import { deferred, Empty, extend, headers } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/internal_mod.ts";
-import { assertArrayIncludes, assertEquals } from "jsr:@std/assert";
+import { assertArrayIncludes, assertEquals } from "@std/assert";
 import { connect } from "./connect.ts";
 
 async function runDoubleSubsTest(tls: boolean) {

--- a/core/tests/drain_test.ts
+++ b/core/tests/drain_test.ts
@@ -12,12 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  assert,
-  assertEquals,
-  assertRejects,
-  assertThrows,
-} from "jsr:@std/assert";
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { createInbox } from "../src/internal_mod.ts";
 import { Lock } from "test_helpers";
 import { cleanup, setup } from "test_helpers";

--- a/core/tests/encoders_test.ts
+++ b/core/tests/encoders_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 import { decode, Empty, encode } from "../src/encoders.ts";
 

--- a/core/tests/events_test.ts
+++ b/core/tests/events_test.ts
@@ -14,12 +14,11 @@
  */
 import { Lock, NatsServer, ServerSignals } from "test_helpers";
 import { connect } from "./connect.ts";
-import { assertEquals } from "jsr:@std/assert";
-import { delay } from "../src/internal_mod.ts";
+import { assertEquals } from "@std/assert";
+import { deferred, delay } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/internal_mod.ts";
 import { setup } from "test_helpers";
 import { cleanup } from "../../test_helpers/mod.ts";
-import { deferred } from "https://deno.land/x/nats@v1.10.2/nats-base-client/mod.ts";
 
 Deno.test("events - close on close", async () => {
   const { ns, nc } = await setup();

--- a/core/tests/headers_test.ts
+++ b/core/tests/headers_test.ts
@@ -29,12 +29,7 @@ import type {
   RequestOptions,
 } from "../src/internal_mod.ts";
 import { NatsServer } from "../../test_helpers/launcher.ts";
-import {
-  assert,
-  assertEquals,
-  assertFalse,
-  assertThrows,
-} from "jsr:@std/assert";
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import { TestDispatcher } from "./parser_test.ts";
 import { cleanup, setup } from "test_helpers";
 import { errors } from "../src/errors.ts";

--- a/core/tests/heartbeats_test.ts
+++ b/core/tests/heartbeats_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert, assertEquals, fail } from "jsr:@std/assert";
+import { assert, assertEquals, fail } from "@std/assert";
 
 import { deferred, delay, Heartbeat } from "../src/internal_mod.ts";
 import type { PH, Status } from "../src/internal_mod.ts";

--- a/core/tests/idleheartbeats_test.ts
+++ b/core/tests/idleheartbeats_test.ts
@@ -19,7 +19,7 @@ import {
   assertEquals,
   assertExists,
   assertNotEquals,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 Deno.test("idleheartbeat - basic", async () => {
   const d = deferred<number>();

--- a/core/tests/iterators_test.ts
+++ b/core/tests/iterators_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { connect } from "./connect.ts";
-import { assertEquals, assertRejects } from "jsr:@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { Lock, NatsServer } from "test_helpers";
 import {
   createInbox,

--- a/core/tests/json_test.ts
+++ b/core/tests/json_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 import { createInbox } from "../src/internal_mod.ts";
 import type { Msg } from "../src/internal_mod.ts";
 import { Lock } from "test_helpers";

--- a/core/tests/mrequest_test.ts
+++ b/core/tests/mrequest_test.ts
@@ -20,7 +20,7 @@ import type {
 } from "../src/internal_mod.ts";
 import { createInbox, deferred, delay, Empty } from "../src/internal_mod.ts";
 
-import { assert, assertEquals, assertRejects, fail } from "jsr:@std/assert";
+import { assert, assertEquals, assertRejects, fail } from "@std/assert";
 import { errors } from "../src/errors.ts";
 
 async function requestManyCount(noMux = false): Promise<void> {

--- a/core/tests/parseip_test.ts
+++ b/core/tests/parseip_test.ts
@@ -15,7 +15,7 @@
 
 import { ipV4, parseIP } from "../src/internal_mod.ts";
 
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 Deno.test("ipparser", () => {
   const tests = [

--- a/core/tests/parser_test.ts
+++ b/core/tests/parser_test.ts
@@ -29,7 +29,7 @@ import type {
   ParserEvent,
   Publisher,
 } from "../src/internal_mod.ts";
-import { assert, assertEquals, assertThrows } from "jsr:@std/assert";
+import { assert, assertEquals, assertThrows } from "@std/assert";
 
 const te = new TextEncoder();
 const td = new TextDecoder();

--- a/core/tests/properties_test.ts
+++ b/core/tests/properties_test.ts
@@ -19,7 +19,7 @@ import {
   assertExists,
   assertFalse,
   assertMatch,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import type {
   Authenticator,

--- a/core/tests/protocol_test.ts
+++ b/core/tests/protocol_test.ts
@@ -22,7 +22,7 @@ import {
   Subscriptions,
 } from "../src/internal_mod.ts";
 import type { Msg, ProtocolHandler } from "../src/internal_mod.ts";
-import { assertEquals, assertRejects, equal } from "jsr:@std/assert";
+import { assertEquals, assertRejects, equal } from "@std/assert";
 import { errors } from "../src/errors.ts";
 
 Deno.test("protocol - mux subscription cancel", async () => {

--- a/core/tests/queues_test.ts
+++ b/core/tests/queues_test.ts
@@ -15,7 +15,7 @@
 
 import { createInbox } from "../src/core.ts";
 import type { Subscription } from "../src/core.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 import { cleanup, setup } from "test_helpers";
 
 Deno.test("queues - deliver to single queue", async () => {

--- a/core/tests/reconnect_test.ts
+++ b/core/tests/reconnect_test.ts
@@ -12,12 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert, assertEquals, assertInstanceOf, fail } from "jsr:@std/assert";
+import { assert, assertEquals, assertInstanceOf, fail } from "@std/assert";
 import { connect } from "./connect.ts";
 import { Lock, NatsServer } from "test_helpers";
 import {
   createInbox,
   DataBuffer,
+  deadline,
   deferred,
   delay,
   tokenAuthenticator,
@@ -25,7 +26,6 @@ import {
 import type { NatsConnectionImpl } from "../src/nats.ts";
 
 import { cleanup, setup } from "test_helpers";
-import { deadline } from "jsr:@std/async";
 import { ConnectionError } from "../src/errors.ts";
 
 Deno.test("reconnect - should receive when some servers are invalid", async () => {

--- a/core/tests/resub_test.ts
+++ b/core/tests/resub_test.ts
@@ -20,7 +20,7 @@ import type {
   NatsConnection,
   NatsConnectionImpl,
 } from "../src/internal_mod.ts";
-import { assert, assertEquals, assertExists, fail } from "jsr:@std/assert";
+import { assert, assertEquals, assertExists, fail } from "@std/assert";
 import type { NatsServer } from "../../test_helpers/launcher.ts";
 
 Deno.test("resub - iter", async () => {

--- a/core/tests/semver_test.ts
+++ b/core/tests/semver_test.ts
@@ -14,12 +14,7 @@
  */
 
 import { compare, Feature, Features, parseSemVer } from "../src/semver.ts";
-import {
-  assert,
-  assertEquals,
-  assertFalse,
-  assertThrows,
-} from "jsr:@std/assert";
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 
 Deno.test("semver", () => {
   const pt: { a: string; b: string; r: number }[] = [

--- a/core/tests/servers_test.ts
+++ b/core/tests/servers_test.ts
@@ -18,7 +18,7 @@ import {
   setTransportFactory,
 } from "../src/internal_mod.ts";
 import type { ServerInfo } from "../src/internal_mod.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 Deno.test("servers - single", () => {
   const servers = new Servers(["127.0.0.1:4222"], { randomize: false });

--- a/core/tests/timeout_test.ts
+++ b/core/tests/timeout_test.ts
@@ -16,7 +16,7 @@ import {
   assertInstanceOf,
   assertRejects,
   assertStringIncludes,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import { createInbox, Empty, errors } from "../src/internal_mod.ts";
 import { cleanup, setup } from "../../test_helpers/mod.ts";
 

--- a/core/tests/tls_test.ts
+++ b/core/tests/tls_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals, assertRejects } from "jsr:@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { connect } from "./connect.ts";
 import { errors } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/internal_mod.ts";

--- a/core/tests/token_test.ts
+++ b/core/tests/token_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertRejects } from "jsr:@std/assert";
+import { assertRejects } from "@std/assert";
 import { NatsServer } from "test_helpers";
 import { connect } from "./connect.ts";
 import { errors } from "../src/errors.ts";

--- a/core/tests/types_test.ts
+++ b/core/tests/types_test.ts
@@ -16,7 +16,7 @@
 import { connect } from "./connect.ts";
 import type { Msg, NatsConnection } from "../src/internal_mod.ts";
 import { createInbox, DataBuffer, deferred } from "../src/internal_mod.ts";
-import { assert, assertEquals } from "jsr:@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { NatsServer } from "../../test_helpers/launcher.ts";
 
 function mh(nc: NatsConnection, subj: string): Promise<Msg> {

--- a/core/tests/util_test.ts
+++ b/core/tests/util_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert, assertEquals, assertRejects } from "jsr:@std/assert";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import {
   backoff,
   deadline,

--- a/core/tests/ws_test.ts
+++ b/core/tests/ws_test.ts
@@ -19,7 +19,7 @@ import {
   assertExists,
   assertFalse,
   assertRejects,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import {
   createInbox,

--- a/core/unsafe_tests/tlsunsafe_test.ts
+++ b/core/unsafe_tests/tlsunsafe_test.ts
@@ -1,8 +1,8 @@
-import { join, resolve } from "jsr:@std/path";
+import { join, resolve } from "@std/path";
 import { cleanup, connect, NatsServer, wsServerConf } from "test_helpers";
 import { delay, wsconnect } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/internal_mod.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 Deno.test("tls-unsafe - handshake first", async () => {
   const cwd = Deno.cwd();

--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,26 @@
     "strict": true
   },
   "imports": {
-    "test_helpers": "./test_helpers/mod.ts"
+    "test_helpers": "./test_helpers/mod.ts",
+    "@std/cli": "jsr:@std/cli@1.0.20",
+    "@std/path": "jsr:@std/path@1.0.8",
+    "@std/flags": "jsr:@std/flags@1.0.0", 
+    "@aricart/cobra": "jsr:@aricart/cobra@1.0.3",
+    "esbuild": "npm:esbuild@0.24.0",
+    "@luca/esbuild-deno-loader": "jsr:@luca/esbuild-deno-loader@0.10.3",
+    "@nats-io/transport-deno": "jsr:@nats-io/transport-deno@3.1.0",
+    "@david/dax": "jsr:@david/dax@0.42.0",
+    "license-checker": "npm:license-checker@25.0.1",
+    "@std/assert": "jsr:@std/assert@1.0.8",
+    "@std/async": "jsr:@std/async@1.0.8",
+    "@std/bytes": "jsr:@std/bytes@1.0.4",
+    "@std/fmt": "jsr:@std/fmt@1.0.3",
+    "@std/jsonc": "jsr:@std/jsonc@1.0.1",
+    "@std/semver": "jsr:@std/semver@1.0.3",
+    "@nats-io/jwt": "jsr:@nats-io/jwt@0.0.11",
+    "@chiefbiiko/sha256": "https://denopkg.com/chiefbiiko/sha256@v1.0.0/mod.ts",
+    "nats-deno": "https://raw.githubusercontent.com/nats-io/nats.deno/main/src/mod.ts",
+    "ajv": "npm:ajv@8.17.1"
   },
   "tasks": {
     "clean": "rm -Rf ./coverage core/lib core/build jetstream/lib jetstream/build services/lib services/build kv/lib kv/build obj/lib obj/build transport-node/lib transport-ws/lib",

--- a/docs/services/media/01_services.ts
+++ b/docs/services/media/01_services.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect, type QueuedIterator } from "jsr:@nats-io/transport-deno";
+import { connect, type QueuedIterator } from "@nats-io/transport-deno";
 
 import {
   ServiceError,
@@ -22,7 +22,7 @@ import {
   Svcm,
 } from "../src/mod.ts";
 import type { ServiceMsg, ServiceStats } from "../src/mod.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 // connect to NATS on demo.nats.io
 const nc = await connect({ servers: ["demo.nats.io"] });

--- a/docs/services/media/02_multiple_endpoints.ts
+++ b/docs/services/media/02_multiple_endpoints.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "jsr:@nats-io/transport-deno";
+import { connect } from "@nats-io/transport-deno";
 import { ServiceError, Svcm } from "../src/mod.ts";
 import type { ServiceMsg } from "../src/mod.ts";
 

--- a/jetstream/package.json
+++ b/jetstream/package.json
@@ -36,8 +36,8 @@
     "@nats-io/nats-core": "3.1.0"
   },
   "devDependencies": {
-    "@types/node": "^24.0.11",
+    "@types/node": "^24.3.1",
     "shx": "^0.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/jetstream/tests/consume_test.ts
+++ b/jetstream/tests/consume_test.ts
@@ -20,7 +20,7 @@ import {
   assertExists,
   assertFalse,
   assertRejects,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import { initStream, setupStreamAndConsumer } from "./jstest_util.ts";
 import {
   deadline,

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -20,7 +20,7 @@ import {
   assertExists,
   assertRejects,
   assertStringIncludes,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import {
   type ConsumerNotification,
   DeliverPolicy,

--- a/jetstream/tests/consumers_push_test.ts
+++ b/jetstream/tests/consumers_push_test.ts
@@ -9,12 +9,7 @@ import {
 import { isBoundPushConsumerOptions } from "../src/types.ts";
 import { cleanup, jetstreamServerConf, Lock, setup } from "test_helpers";
 import { nanos } from "@nats-io/nats-core";
-import {
-  assert,
-  assertEquals,
-  assertExists,
-  assertFalse,
-} from "jsr:@std/assert";
+import { assert, assertEquals, assertExists, assertFalse } from "@std/assert";
 import type { PushConsumerMessagesImpl } from "../src/pushconsumer.ts";
 import { deadline, delay } from "@nats-io/nats-core/internal";
 

--- a/jetstream/tests/consumers_test.ts
+++ b/jetstream/tests/consumers_test.ts
@@ -19,7 +19,7 @@ import {
   assertFalse,
   assertRejects,
   assertStringIncludes,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import {
   AckPolicy,
   DeliverPolicy,

--- a/jetstream/tests/direct_consumer_test.ts
+++ b/jetstream/tests/direct_consumer_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert, assertEquals } from "jsr:@std/assert";
+import { assert, assertEquals } from "@std/assert";
 
 import { jetstreamManager, type StoredMsg } from "../src/mod.ts";
 import {

--- a/jetstream/tests/fetch_test.ts
+++ b/jetstream/tests/fetch_test.ts
@@ -15,7 +15,7 @@
 
 import { cleanup, jetstreamServerConf, setup } from "test_helpers";
 import { initStream } from "./jstest_util.ts";
-import { assertEquals, assertExists, assertRejects } from "jsr:@std/assert";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import {
   deadline,
   deferred,

--- a/jetstream/tests/jetstream409_test.ts
+++ b/jetstream/tests/jetstream409_test.ts
@@ -16,7 +16,7 @@
 import { nanos } from "@nats-io/nats-core";
 import { AckPolicy, jetstream, jetstreamManager } from "../src/mod.ts";
 
-import { assert, assertEquals, assertRejects, fail } from "jsr:@std/assert";
+import { assert, assertEquals, assertRejects, fail } from "@std/assert";
 import { initStream } from "./jstest_util.ts";
 import { cleanup, jetstreamServerConf, setup } from "test_helpers";
 

--- a/jetstream/tests/jetstream_pullconsumer_test.ts
+++ b/jetstream/tests/jetstream_pullconsumer_test.ts
@@ -29,7 +29,7 @@ import {
   type OverflowMinPendingAndMinAck,
   PriorityPolicy,
 } from "../src/jsapi_types.ts";
-import { assertEquals, assertExists } from "jsr:@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import {
   deferred,
   delay,

--- a/jetstream/tests/jetstream_pushconsumer_test.ts
+++ b/jetstream/tests/jetstream_pushconsumer_test.ts
@@ -34,12 +34,7 @@ import {
   syncIterator,
 } from "@nats-io/nats-core";
 import type { BoundPushConsumerOptions, PubAck } from "../src/types.ts";
-import {
-  assert,
-  assertEquals,
-  assertExists,
-  assertRejects,
-} from "jsr:@std/assert";
+import { assert, assertEquals, assertExists, assertRejects } from "@std/assert";
 import {
   AckPolicy,
   DeliverPolicy,

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -48,7 +48,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import { JetStreamClientImpl, JetStreamManagerImpl } from "../src/jsclient.ts";
 import {

--- a/jetstream/tests/jscluster_test.ts
+++ b/jetstream/tests/jscluster_test.ts
@@ -21,7 +21,7 @@ import {
   assertExists,
   assertRejects,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 Deno.test("jetstream - mirror alternates", async () => {
   const servers = await NatsServer.jetstreamCluster(3);

--- a/jetstream/tests/jsm_direct_test.ts
+++ b/jetstream/tests/jsm_direct_test.ts
@@ -20,7 +20,7 @@ import {
   assertIsError,
   assertRejects,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import { deferred, delay } from "@nats-io/nats-core";
 

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -20,7 +20,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 import { Feature } from "@nats-io/nats-core/internal";
@@ -66,11 +66,7 @@ import {
   setup,
 } from "test_helpers";
 import { validateName } from "../src/jsutil.ts";
-import {
-  encodeAccount,
-  encodeOperator,
-  encodeUser,
-} from "jsr:@nats-io/jwt@0.0.11";
+import { encodeAccount, encodeOperator, encodeUser } from "@nats-io/jwt";
 import { convertStreamSourceDomain } from "../src/jsmstream_api.ts";
 import type { ConsumerAPIImpl } from "../src/jsmconsumer_api.ts";
 import {

--- a/jetstream/tests/jsmsg_test.ts
+++ b/jetstream/tests/jsmsg_test.ts
@@ -19,7 +19,7 @@ import {
   assertNotEquals,
   assertRejects,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import {
   AckPolicy,
   jetstream,

--- a/jetstream/tests/next_test.ts
+++ b/jetstream/tests/next_test.ts
@@ -22,7 +22,7 @@ import {
   assertExists,
   assertRejects,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import { delay, nanos } from "@nats-io/nats-core";
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 import { jetstream, JetStreamError, jetstreamManager } from "../src/mod.ts";

--- a/jetstream/tests/pushconsumers_ordered_test.ts
+++ b/jetstream/tests/pushconsumers_ordered_test.ts
@@ -18,7 +18,7 @@ import {
   assertExists,
   assertFalse,
   assertRejects,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import { DeliverPolicy, jetstream, jetstreamManager } from "../src/mod.ts";
 import type { JsMsg } from "../src/mod.ts";
 

--- a/jetstream/tests/status_test.ts
+++ b/jetstream/tests/status_test.ts
@@ -16,11 +16,7 @@
 import { isMessageNotFound, JetStreamStatus } from "../src/jserrors.ts";
 import type { StreamAPIImpl } from "../src/jsmstream_api.ts";
 import { Empty, type Msg, type Payload } from "@nats-io/nats-core/internal";
-import {
-  assert,
-  assertEquals,
-  assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assert, assertEquals, assertRejects } from "@std/assert";
 import { MsgHdrsImpl } from "../../core/src/headers.ts";
 import { cleanup, setup } from "test_helpers";
 import { jetstreamServerConf } from "../../test_helpers/mod.ts";

--- a/jetstream/tests/streams_test.ts
+++ b/jetstream/tests/streams_test.ts
@@ -21,11 +21,7 @@ import {
 } from "test_helpers";
 import { AckPolicy, jetstream, jetstreamManager } from "../src/mod.ts";
 
-import {
-  assertEquals,
-  assertExists,
-  assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { initStream } from "./jstest_util.ts";
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 

--- a/jetstream/tests/util.ts
+++ b/jetstream/tests/util.ts
@@ -15,7 +15,7 @@
 
 import { delay } from "@nats-io/nats-core";
 import type { Consumer, Stream } from "../src/types.ts";
-import { fail } from "jsr:@std/assert";
+import { fail } from "@std/assert";
 import { StreamImpl } from "../src/jsmstream_api.ts";
 import { ConsumerNotFoundError, StreamNotFoundError } from "../src/jserrors.ts";
 

--- a/kv/package.json
+++ b/kv/package.json
@@ -37,8 +37,8 @@
     "@nats-io/nats-core": "3.1.0"
   },
   "devDependencies": {
-    "@types/node": "^24.0.11",
+    "@types/node": "^24.3.1",
     "shx": "^0.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -52,7 +52,7 @@ import {
   assertIsError,
   assertRejects,
   assertThrows,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import type { KV, KvEntry, KvOptions, KvWatchEntry } from "../src/types.ts";
 

--- a/obj/package.json
+++ b/obj/package.json
@@ -38,8 +38,8 @@
     "js-sha256": "^0.11.1"
   },
   "devDependencies": {
-    "@types/node": "^24.0.11",
+    "@types/node": "^24.3.1",
     "shx": "^0.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/obj/tests/b64_test.ts
+++ b/obj/tests/b64_test.ts
@@ -18,7 +18,7 @@ import {
   Base64UrlCodec,
   Base64UrlPaddedCodec,
 } from "../src/base64.ts";
-import { assert, assertEquals, assertFalse } from "jsr:@std/assert";
+import { assert, assertEquals, assertFalse } from "@std/assert";
 
 Deno.test("b64 - Base64Codec", () => {
   // should match btoa

--- a/obj/tests/objectstore_test.ts
+++ b/obj/tests/objectstore_test.ts
@@ -27,7 +27,7 @@ import {
   assertExists,
   assertRejects,
   equal,
-} from "jsr:@std/assert";
+} from "@std/assert";
 import {
   DataBuffer,
   Empty,
@@ -38,7 +38,7 @@ import {
 import type { NatsConnectionImpl } from "@nats-io/nats-core/internal";
 import type { ObjectInfo, ObjectStoreMeta } from "../src/types.ts";
 import { jetstreamManager, StorageType } from "@nats-io/jetstream";
-import { equals } from "https://deno.land/std@0.221.0/bytes/mod.ts";
+import { equals } from "@std/bytes";
 import { digestType, Objm } from "../src/objectstore.ts";
 import { Base64UrlPaddedCodec } from "../src/base64.ts";
 import { sha256 } from "js-sha256";

--- a/services/examples/01_services.ts
+++ b/services/examples/01_services.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect, type QueuedIterator } from "jsr:@nats-io/transport-deno";
+import { connect, type QueuedIterator } from "@nats-io/transport-deno";
 
 import {
   ServiceError,
@@ -22,7 +22,7 @@ import {
   Svcm,
 } from "../src/mod.ts";
 import type { ServiceMsg, ServiceStats } from "../src/mod.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 // connect to NATS on demo.nats.io
 const nc = await connect({ servers: ["demo.nats.io"] });

--- a/services/examples/02_multiple_endpoints.ts
+++ b/services/examples/02_multiple_endpoints.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "jsr:@nats-io/transport-deno";
+import { connect } from "@nats-io/transport-deno";
 import { ServiceError, Svcm } from "../src/mod.ts";
 import type { ServiceMsg } from "../src/mod.ts";
 

--- a/services/examples/03_bigdata-client.ts
+++ b/services/examples/03_bigdata-client.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parse } from "jsr:@std/flags";
+import { parse } from "@std/flags";
 import { connect, type ConnectionOptions } from "@nats-io/transport-deno";
 
 import { humanizeBytes } from "./03_util.ts";

--- a/services/examples/03_bigdata.ts
+++ b/services/examples/03_bigdata.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { connect } from "jsr:@nats-io/transport-deno";
+import { connect } from "@nats-io/transport-deno";
 import { Svcm } from "../src/mod.ts";
 import { humanizeBytes } from "./03_util.ts";
 import type { DataRequest } from "./03_util.ts";

--- a/services/package.json
+++ b/services/package.json
@@ -36,8 +36,8 @@
     "@nats-io/nats-core": "3.1.0"
   },
   "devDependencies": {
-    "@types/node": "^24.0.11",
+    "@types/node": "^24.3.1",
     "shx": "^0.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/services/tests/service-check.ts
+++ b/services/tests/service-check.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { cli } from "jsr:@aricart/cobra";
+import { cli } from "@aricart/cobra";
 import { connect } from "@nats-io/transport-deno";
 import { collect, parseSemVer } from "@nats-io/nats-core/internal";
 
@@ -28,8 +28,8 @@ import {
 } from "../src/mod.ts";
 
 import type { ServiceClientImpl } from "../src/serviceclient.ts";
-import type { JSONSchemaType, ValidateFunction } from "npm:ajv";
-import { Ajv } from "npm:ajv";
+import type { JSONSchemaType, ValidateFunction } from "ajv";
+import { Ajv } from "ajv";
 
 const ajv = new Ajv();
 

--- a/services/tests/service_test.ts
+++ b/services/tests/service_test.ts
@@ -23,7 +23,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "jsr:@std/assert";
+} from "@std/assert";
 
 import {
   collect,

--- a/test_helpers/asserts.ts
+++ b/test_helpers/asserts.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertGreaterOrEqual, assertLessOrEqual } from "jsr:@std/assert";
+import { assertGreaterOrEqual, assertLessOrEqual } from "@std/assert";
 
 export function assertBetween(n: number, low: number, high: number) {
   assertGreaterOrEqual(n, low, `${n} >= ${low}`);

--- a/test_helpers/certs.ts
+++ b/test_helpers/certs.ts
@@ -1,5 +1,5 @@
 import { deferred } from "@nats-io/nats-core";
-import { join } from "jsr:@std/path";
+import { join } from "@std/path";
 
 export class Certs {
   #data!: Record<string, string>;

--- a/test_helpers/certs_tool.ts
+++ b/test_helpers/certs_tool.ts
@@ -1,4 +1,4 @@
-import { parseArgs } from "jsr:@std/cli/parse-args";
+import { parseArgs } from "@std/cli";
 import { Certs } from "./certs.ts";
 
 // this tool packs a bunch of certs into a JSON file keyed after its name

--- a/test_helpers/cluster.ts
+++ b/test_helpers/cluster.ts
@@ -14,8 +14,8 @@
  */
 
 import { NatsServer } from "./launcher.ts";
-import { parseArgs } from "jsr:@std/cli/parse-args";
-import { rgb24 } from "jsr:@std/fmt/colors";
+import { parseArgs } from "@std/cli";
+import { rgb24 } from "@std/fmt/colors";
 
 const defaults = {
   c: 3,

--- a/test_helpers/conf_test.ts
+++ b/test_helpers/conf_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { toConf } from "./launcher.ts";
-import { assertEquals } from "jsr:@std/assert";
+import { assertEquals } from "@std/assert";
 
 Deno.test("conf - serializing simple", () => {
   const x = {

--- a/test_helpers/launcher.ts
+++ b/test_helpers/launcher.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 // deno-lint-ignore-file no-explicit-any
-import { join, resolve } from "jsr:@std/path";
-import { rgb24 } from "jsr:@std/fmt/colors";
+import { join, resolve } from "@std/path";
+import { rgb24 } from "@std/fmt/colors";
 import { check, jsopts } from "./mod.ts";
 import {
   ConnectionOptions,

--- a/test_helpers/mod.ts
+++ b/test_helpers/mod.ts
@@ -17,7 +17,7 @@ import type { ConnectionOptions, NatsConnection } from "@nats-io/nats-core";
 import { compare, parseSemVer } from "@nats-io/nats-core/internal";
 
 import { NatsServer } from "./launcher.ts";
-import { red, yellow } from "jsr:@std/fmt/colors";
+import { red, yellow } from "@std/fmt/colors";
 export { connect } from "./connect.ts";
 export { check } from "./check.ts";
 export { Lock } from "./lock.ts";

--- a/test_helpers/util.ts
+++ b/test_helpers/util.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { deferred, timeout } from "@nats-io/nats-core/internal";
-import { assert } from "jsr:@std/assert";
+import { assert } from "@std/assert";
 
 export function consume<T>(iter: Iterable<T>, ms = 1000): Promise<T[]> {
   const to = timeout<T[]>(ms);

--- a/transport-deno/examples/bench.js
+++ b/transport-deno/examples/bench.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
-import { parse } from "jsr:@std/flags";
-import { Bench, connect, Metric, Nuid } from "jsr:@nats-io/transport-deno";
+import { parse } from "@std/flags";
+import { Bench, connect, Metric, Nuid } from "@nats-io/transport-deno";
 const defaults = {
   s: "127.0.0.1:4222",
   c: 100000,

--- a/transport-deno/examples/nats-events.ts
+++ b/transport-deno/examples/nats-events.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "jsr:@std/flags";
-import { connect, type ConnectionOptions } from "jsr:@nats-io/transport-deno";
+import { parse } from "@std/flags";
+import { connect, type ConnectionOptions } from "@nats-io/transport-deno";
 
 const argv = parse(
   Deno.args,

--- a/transport-deno/examples/nats-pub.ts
+++ b/transport-deno/examples/nats-pub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "jsr:@std/flags";
+import { parse } from "@std/flags";
 import {
   connect,
   type ConnectionOptions,
@@ -8,7 +8,7 @@ import {
   delay,
   headers,
   type MsgHdrs,
-} from "jsr:@nats-io/transport-deno";
+} from "@nats-io/transport-deno";
 
 const argv = parse(
   Deno.args,

--- a/transport-deno/examples/nats-rep.ts
+++ b/transport-deno/examples/nats-rep.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "jsr:@std/flags";
+import { parse } from "@std/flags";
 import {
   connect,
   type ConnectionOptions,
   credsAuthenticator,
   headers,
-} from "jsr:@nats-io/transport-deno";
+} from "@nats-io/transport-deno";
 
 const argv = parse(
   Deno.args,

--- a/transport-deno/examples/nats-req.ts
+++ b/transport-deno/examples/nats-req.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "jsr:@std/flags";
+import { parse } from "@std/flags";
 import {
   connect,
   type ConnectionOptions,
   credsAuthenticator,
   delay,
-} from "jsr:@nats-io/transport-deno";
+} from "@nats-io/transport-deno";
 
 const argv = parse(
   Deno.args,

--- a/transport-deno/examples/nats-sub.ts
+++ b/transport-deno/examples/nats-sub.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "jsr:@std/flags";
+import { parse } from "@std/flags";
 import {
   connect,
   type ConnectionOptions,
   credsAuthenticator,
-} from "jsr:@nats-io/transport-deno";
+} from "@nats-io/transport-deno";
 
 const argv = parse(
   Deno.args,

--- a/transport-deno/tests/basics_test.ts
+++ b/transport-deno/tests/basics_test.ts
@@ -1,5 +1,5 @@
 import { connect, createInbox, wsconnect } from "../src/mod.ts";
-import { assertEquals, assertRejects } from "jsr:@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 
 Deno.test("basics", () => {
   assertEquals(typeof connect, "function");

--- a/transport-node/package.json
+++ b/transport-node/package.json
@@ -63,9 +63,9 @@
     "@nats-io/jetstream": "3.1.0",
     "@nats-io/kv": "3.1.0",
     "@nats-io/obj": "3.1.0",
-    "@types/node": "^24.0.11",
+    "@types/node": "^24.3.1",
     "minimist": "^1.2.8",
     "shx": "^0.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
- Replaced `jsr:@std/*` imports with `@std/*` as per deno linter changes.
- Updated `@types/node` to `^24.3.1` and `typescript` to `^5.9.2`.
- Synchronized dependency versions across modules for alignment.
- Adjusted `deno.json` to reflect resolved import paths as per deno linter

Signed-off-by: Alberto Ricart <alberto@synadia.com>
