### PR TITLE
jsm-direct-pending

### DIFF
--- a/jetstream/src/jsm_direct.ts
+++ b/jetstream/src/jsm_direct.ts
@@ -268,11 +268,9 @@ export class DirectMsgImpl implements DirectMsg {
 
   get pending(): number {
     const v = this.header.last(DirectMsgHeaders.NumPending);
-    // if we have a pending - this pending will include the number of messages
-    // in the stream + the end of batch signal - better to remove the eob signal
-    // from the count so the client can estimate how many messages are
-    // in the stream. If a batch is 1 message, the pending is not included.
-    return typeof v === "string" ? parseInt(v) - 1 : -1;
+    // pre-2.12, we reduced the count by 1, as the server reported
+    // the eod message
+    return typeof v === "string" ? parseInt(v) : -1;
   }
 
   json<T = unknown>(reviver?: ReviverFn): T {

--- a/jetstream/tests/direct_consumer_test.ts
+++ b/jetstream/tests/direct_consumer_test.ts
@@ -29,7 +29,7 @@ import {
 
 Deno.test("direct consumer - next", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
-  if (await notCompatible(ns, nc, "2.11.0")) {
+  if (await notCompatible(ns, nc, "2.12.0")) {
     return;
   }
   const jsm = await jetstreamManager(nc);
@@ -59,7 +59,7 @@ Deno.test("direct consumer - next", async () => {
 
 Deno.test("direct consumer - batch", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
-  if (await notCompatible(ns, nc, "2.11.0")) {
+  if (await notCompatible(ns, nc, "2.12.0")) {
     return;
   }
   const jsm = await jetstreamManager(nc);
@@ -109,7 +109,7 @@ Deno.test("direct consumer - batch", async () => {
 
 Deno.test("direct consumer - consume", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
-  if (await notCompatible(ns, nc, "2.11.0")) {
+  if (await notCompatible(ns, nc, "2.12.0")) {
     return;
   }
   const jsm = await jetstreamManager(nc);

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2552,7 +2552,7 @@ Deno.test("jsm - consumer create paused", async () => {
   }
 
   const jsm = await jetstreamManager(nc);
-  jsm.streams.add({
+  await jsm.streams.add({
     name: "A",
     subjects: ["a.>"],
   });
@@ -2575,7 +2575,7 @@ Deno.test("jsm - pause/unpause", async () => {
   }
 
   const jsm = await jetstreamManager(nc);
-  jsm.streams.add({
+  await jsm.streams.add({
     name: "A",
     subjects: ["a.>"],
   });


### PR DESCRIPTION
2.12 corrects pending messages reported by the direct api - this is an internal change that is not visible to client code.