### PR TITLE
feat(jsm): allow removal of stream mirrors via update API

### DIFF
--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -155,11 +155,6 @@ export type StreamConfig = StreamUpdateConfig & {
    */
   "max_consumers": number;
   /**
-   * Maintains a 1:1 mirror of another stream with name matching this property.
-   * When a mirror is configured subjects and sources must be empty.
-   */
-  mirror?: StreamSource; // same as a source
-  /**
    * Sealed streams do not allow messages to be deleted via limits or API,
    * sealed streams can not be unsealed via configuration update.
    * Can only be set on already created streams via the Update API
@@ -301,6 +296,12 @@ export type StreamUpdateConfig = {
    * Sets a duration for adding server markers for delete, purge and max age limits.
    */
   "subject_delete_marker_ttl"?: Nanos;
+
+  /**
+   * Maintains a 1:1 mirror of another stream with name matching this property.
+   * When a mirror is configured subjects and sources must be empty.
+   */
+  mirror?: StreamSource; // same as a source
 };
 
 export type Republish = {

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2825,3 +2825,31 @@ Deno.test("jsm - message ttls", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("jsm - mirrors can be removed", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  if (await notCompatible(ns, nc, "2.12.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({
+    name: "A",
+    subjects: ["a"],
+  });
+
+  let si = await jsm.streams.add({
+    name: "B",
+    mirror: {
+      name: "A",
+      subject_transforms: [{ src: "a", dest: "b" }],
+    },
+  });
+
+  assertExists(si.config.mirror);
+
+  si = await jsm.streams.update("B", { mirror: undefined });
+  assertEquals(si.config.mirror, undefined);
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
Added a test to verify that mirrors can be removed by setting the `mirror` property to `undefined` during stream updates.

This functionality requires server 2.12 or better, older servers will reject this operation