### PR TITLE
feat(jsapi): add `PrioritizedOptions` and support for prioritized pull consumers

### DIFF
--- a/jetstream/src/consumer.ts
+++ b/jetstream/src/consumer.ts
@@ -146,7 +146,6 @@ export class PullConsumerMessagesImpl extends QueuedIteratorImpl<JsMsg>
   closeListener: ConnectionClosedListener;
   isPinned: boolean;
   isPriority: boolean;
-  override noIterator: boolean;
   natsPinId: string;
 
   // callback: ConsumerCallbackFn;

--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -1140,6 +1140,7 @@ export const PriorityPolicy = {
   None: "none",
   Overflow: "overflow",
   PinnedClient: "pinned_client",
+  Prioritized: "prioritized",
 } as const;
 export type PriorityPolicy = typeof PriorityPolicy[keyof typeof PriorityPolicy];
 
@@ -1213,36 +1214,44 @@ export type PinnedOptions = {
   min_ack_pending: never;
 };
 
+export type PrioritizedOptions = {
+  group: string;
+  priority: number;
+};
+
 /**
  * Options for a JetStream pull subscription which define how long
  * the pull request will remain open and limits the amount of data
  * that the server could return.
  */
-export type PullOptions = Partial<OverflowMinPendingAndMinAck> & {
-  /**
-   * Max number of messages to retrieve in a pull.
-   */
-  batch: number;
-  /**
-   * If true, the request for messages will end when received by the server
-   */
-  "no_wait": boolean;
-  /**
-   * If set, the number of milliseconds to wait for the number of messages
-   * specified in {@link batch}
-   */
-  expires: number;
-  /**
-   * If set, the max number of bytes to receive. The server will limit the
-   * number of messages in the batch to fit within this setting.
-   */
-  "max_bytes": number;
+export type PullOptions =
+  & Partial<OverflowMinPendingAndMinAck>
+  & Partial<PrioritizedOptions>
+  & {
+    /**
+     * Max number of messages to retrieve in a pull.
+     */
+    batch: number;
+    /**
+     * If true, the request for messages will end when received by the server
+     */
+    "no_wait": boolean;
+    /**
+     * If set, the number of milliseconds to wait for the number of messages
+     * specified in {@link batch}
+     */
+    expires: number;
+    /**
+     * If set, the max number of bytes to receive. The server will limit the
+     * number of messages in the batch to fit within this setting.
+     */
+    "max_bytes": number;
 
-  /**
-   * Number of nanos between messages for the server to emit an idle_heartbeat
-   */
-  "idle_heartbeat": number;
-};
+    /**
+     * Number of nanos between messages for the server to emit an idle_heartbeat
+     */
+    "idle_heartbeat": number;
+  };
 
 export type DeliveryInfo = {
   /**

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -290,11 +290,12 @@ function validatePriorityGroups(pg: unknown): void {
     if (
       pg.priority_policy !== PriorityPolicy.None &&
       pg.priority_policy !== PriorityPolicy.Overflow &&
-      pg.priority_policy !== PriorityPolicy.PinnedClient
+      pg.priority_policy !== PriorityPolicy.PinnedClient &&
+      pg.priority_policy !== PriorityPolicy.Prioritized
     ) {
       throw InvalidArgumentError.format(
         ["priority_policy"],
-        "must be 'none', 'overflow', or 'pinned_client'",
+        "must be 'none', 'prioritized', 'overflow', or 'pinned_client'",
       );
     }
   }

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -27,6 +27,7 @@ import type {
   ConsumerCreateOptions,
   DeliverPolicy,
   DirectLastFor,
+  PrioritizedOptions,
   PullOptions,
   ReplayPolicy,
 } from "./jsapi_types.ts";
@@ -472,7 +473,8 @@ export type ConsumeBytes =
   & ConsumeCallback
   & AbortOnMissingResource
   & Bind
-  & Partial<OverflowOptions>;
+  & Partial<OverflowOptions>
+  & Partial<PrioritizedOptions>;
 
 export type ConsumeMessages =
   & Partial<MaxMessages>
@@ -482,7 +484,8 @@ export type ConsumeMessages =
   & ConsumeCallback
   & AbortOnMissingResource
   & Bind
-  & Partial<OverflowOptions>;
+  & Partial<OverflowOptions>
+  & Partial<PrioritizedOptions>;
 
 export type ConsumeOptions =
   | ConsumeBytes
@@ -496,7 +499,8 @@ export type FetchBytes =
   & Expires
   & IdleHeartbeat
   & Bind
-  & Partial<OverflowOptions>;
+  & Partial<OverflowOptions>
+  & Partial<PrioritizedOptions>;
 /**
  * Options for fetching messages
  */
@@ -505,7 +509,8 @@ export type FetchMessages =
   & Expires
   & IdleHeartbeat
   & Bind
-  & Partial<OverflowOptions>;
+  & Partial<OverflowOptions>
+  & Partial<PrioritizedOptions>;
 
 export type FetchOptions = FetchBytes | FetchMessages;
 export type PullConsumerOptions = FetchOptions | ConsumeOptions;

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2711,7 +2711,7 @@ Deno.test("jsm - pull consumer priority groups", async (t) => {
         });
       },
       Error,
-      "'priority_policy' must be 'none', 'overflow', or 'pinned_client'",
+      "'priority_policy' must be 'none', 'prioritized', 'overflow', or 'pinned_client'",
     );
   });
 
@@ -2727,7 +2727,7 @@ Deno.test("jsm - pull consumer priority groups", async (t) => {
         });
       },
       Error,
-      "'priority_policy' must be 'none', 'overflow', or 'pinned_client'",
+      "'priority_policy' must be 'none', 'prioritized', 'overflow', or 'pinned_client'",
     );
   });
 


### PR DESCRIPTION

- Introduced `PrioritizedOptions` type to define priority options for pull consumers.
- Updated `PullOptions`, `ConsumeOptions`, and related types to include `PrioritizedOptions`.
- Added support for `prioritized` policy to `PriorityPolicy`.
- Implemented validation for priority group settings and pull options.
- Enhanced tests to verify functionality with prioritized groups.