### PR TITLE
feat(jetstream): refactor types and enhance batch publishing options

### DIFF
--- a/jetstream/src/internal_mod.ts
+++ b/jetstream/src/internal_mod.ts
@@ -97,6 +97,7 @@ export type {
   StoredMsg,
   Stream,
   StreamAPI,
+  StreamExpectations,
   StreamNotFound,
   Streams,
   ThresholdBytes,

--- a/jetstream/src/jsclient.ts
+++ b/jetstream/src/jsclient.ts
@@ -359,7 +359,7 @@ export class BatchPublisherImpl implements Batch {
   add(
     subj: string,
     payload?: Payload,
-    opts: BatchMessageOptions | BatchMessageOptionsWithReply = {},
+    opts: BatchMessageOptions | BatchMessageOptionsWithReply = { ack: false },
   ): void | Promise<void> {
     if (this.done) {
       throw new Error("batch publisher is done");

--- a/jetstream/src/mod.ts
+++ b/jetstream/src/mod.ts
@@ -147,6 +147,7 @@ export type {
   StreamAPI,
   StreamConfig,
   StreamConsumerLimits,
+  StreamExpectations,
   StreamInfo,
   StreamInfoRequestOptions,
   StreamNames,


### PR DESCRIPTION
- Introduced `StreamExpectations` for better assertion handling in message publishing.
- Updated `JetStreamPublishOptions` to utilize `StreamExpectations`.
- Refactored `BatchMessageOptions` and `BatchMessageOptionsWithReply` with `Partial` types for improved flexibility.
- Adjusted `add` method in batch publishing to accept refined option types.