### PR TITLE
fix(jestream): fixed the Stream#deleteMessage() api to default erase

### DIFF
--- a/core/tests/basics_test.ts
+++ b/core/tests/basics_test.ts
@@ -72,6 +72,11 @@ Deno.test("basics - connect hostport", async () => {
   await nc.close();
 });
 
+Deno.test("basics - scott", async () => {
+  const nc = await connect({ servers: "demo.nats.io:4222", debug: true });
+  await nc.close();
+});
+
 Deno.test("basics - connect servers", async () => {
   const ns = await NatsServer.start();
   const nc = await connect({ servers: [`${ns.hostname}:${ns.port}`] });

--- a/jetstream/src/jsmstream_api.ts
+++ b/jetstream/src/jsmstream_api.ts
@@ -396,7 +396,7 @@ export class StreamImpl implements Stream {
     return this.api.getMessage(this.name, query);
   }
 
-  deleteMessage(seq: number, erase?: boolean): Promise<boolean> {
+  deleteMessage(seq: number, erase = true): Promise<boolean> {
     return this.api.deleteMessage(this.name, seq, erase);
   }
 }

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -1231,13 +1231,25 @@ export type AdvisoryKind = typeof AdvisoryKind[keyof typeof AdvisoryKind];
 export type Stream = {
   name: string;
 
+  /**
+   * Returns the info (optionally cached) on the stream.
+   * @param cached
+   * @param opts
+   */
   info(
     cached?: boolean,
     opts?: Partial<StreamInfoRequestOptions>,
   ): Promise<StreamInfo>;
 
+  /**
+   * Returns a list of streams that are equivalent alternates to this one.
+   */
   alternates(): Promise<StreamAlternate[]>;
 
+  /**
+   * Return the alternate (best RRT) for this stream. This is the
+   * first alternate returned by the server.
+   */
   best(): Promise<Stream>;
 
   /**
@@ -1250,6 +1262,11 @@ export type Stream = {
     name?: string | Partial<OrderedConsumerOptions>,
   ): Promise<Consumer>;
 
+  /**
+   * Returns the specified push consumer.
+   * @param stream
+   * @param name the name of the consumer, or an ordered consumer specification.
+   */
   getPushConsumer(
     stream: string,
     name?:
@@ -1264,8 +1281,17 @@ export type Stream = {
   //     | BoundPushConsumerOptions,
   // ): Promise<PushConsumer>;
 
+  /**
+   * Retrieves the specified message using the specified query.
+   * @param query
+   */
   getMessage(query: MsgRequest): Promise<StoredMsg | null>;
 
+  /**
+   * Deletes the specified message sequence
+   * @param seq
+   * @param erase - default is true
+   */
   deleteMessage(seq: number, erase?: boolean): Promise<boolean>;
 };
 


### PR DESCRIPTION
fix(jestream): fixed the `Stream#deleteMessage()` api to default erase to `true`, as the underlying optional erase from the `JetStreamManager#deleteMessage()` erase's is by default is `true`.

- added additional docs on the Stream apis.