### PR TITLE
feat(jetstream): handle "no results" status in direct APIs

### DIFF
--- a/jetstream/src/jserrors.ts
+++ b/jetstream/src/jserrors.ts
@@ -176,6 +176,10 @@ export class JetStreamStatus {
     return this.code === 404 && this.description === "message not found";
   }
 
+  isNoResults(): boolean {
+    return this.code === 404 && this.description === "no results";
+  }
+
   isMessageSizeExceedsMaxBytes(): boolean {
     return this.code === 409 &&
       this.description === "message size exceeds maxbytes";

--- a/jetstream/src/jsm_direct.ts
+++ b/jetstream/src/jsm_direct.ts
@@ -183,6 +183,11 @@ export class DirectStreamAPIImpl extends BaseApiClientImpl
         }
         const status = JetStreamStatus.maybeParseStatus(msg);
         if (status) {
+          if (status.isNoResults()) {
+            push({}, () => {
+              iter.stop();
+            });
+          }
           if (status.isEndOfBatch()) {
             push({}, () => {
               iter.stop();


### PR DESCRIPTION
Previously, an error was thrown, but this is inconsistent on how the client handles this conditions for fetch and other similar user-initiated operations.

- Added `isNoResults` method to identify "no results" error in JetStream errors.
- Updated logic in `jsm_direct.ts` to stop iterators on "no results" status.
- Enhanced tests with scenarios for handling batches and direct message retrieval when no messages are available.

Fix #335 