### PR TITLE
chore(workflows): add parallel support and Coveralls completion step

### DIFF
--- a/.github/workflows/deno_checks.yml
+++ b/.github/workflows/deno_checks.yml
@@ -43,6 +43,7 @@ jobs:
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
           flag-name: ${{ matrix.module }}
           file: ./coverage/out.lcov
 

--- a/.github/workflows/node_checks.yml
+++ b/.github/workflows/node_checks.yml
@@ -49,6 +49,7 @@ jobs:
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
           flag-name: transport-node
           file: ./transport-node/out.lcov
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,3 +17,11 @@ jobs:
     uses: ./.github/workflows/deno_checks.yml
   test-node:
     uses: ./.github/workflows/node_checks.yml
+  coveralls-finish:
+    needs: [test-deno, test-node]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true


### PR DESCRIPTION
- Enabled `parallel` mode in `node_checks.yml` and `deno_checks.yml` for Coveralls.
- Added `coveralls-finish` step in `test.yml` to finalize parallel coverage reports.