### PR TITLE
feat(tests): added jetstream/jetstreamManager context property 

### DIFF
--- a/jetstream/src/jsbaseclient_api.ts
+++ b/jetstream/src/jsbaseclient_api.ts
@@ -15,6 +15,7 @@
 
 import {
   backoff,
+  createInbox,
   delay,
   Empty,
   errors,
@@ -65,6 +66,8 @@ export class BaseApiClientImpl {
 
   constructor(nc: NatsConnection, opts?: JetStreamOptions) {
     this.nc = nc as NatsConnectionImpl;
+    opts = opts || {} as JetStreamOptions;
+    opts.watcherPrefix = opts.watcherPrefix || this.nc.options.inboxPrefix;
     this.opts = defaultJsOptions(opts);
     this._parseOpts();
     this.prefix = this.opts.apiPrefix!;
@@ -85,6 +88,9 @@ export class BaseApiClientImpl {
       prefix = prefix.substr(0, prefix.length - 1);
     }
     this.opts.apiPrefix = prefix;
+
+    // verify that watcherPrefix is valid
+    createInbox(this.opts.watcherPrefix);
   }
 
   async _request(

--- a/jetstream/src/jsclient.ts
+++ b/jetstream/src/jsclient.ts
@@ -18,6 +18,7 @@ import { ConsumerAPIImpl } from "./jsmconsumer_api.ts";
 
 import {
   backoff,
+  createInbox,
   deferred,
   delay,
   Empty,
@@ -174,6 +175,14 @@ export class JetStreamClientImpl extends BaseApiClientImpl
       this.opts,
       { checkAPI },
     ) as JetStreamManagerOptions;
+
+    // fail early if watcherPrefix is bad
+    try {
+      createInbox(opts.watcherPrefix);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+
     return jetstreamManager(this.nc, opts);
   }
 

--- a/jetstream/src/jsmstream_api.ts
+++ b/jetstream/src/jsmstream_api.ts
@@ -177,8 +177,7 @@ export class ConsumersImpl implements Consumers {
     name_prefix = name_prefix || `oc_${nuid.next()}`;
     minValidation("name_prefix", name_prefix);
     deliver_prefix = deliver_prefix ||
-      createInbox((this.api as ConsumerAPIImpl).nc.options.inboxPrefix);
-    minValidation("deliver_prefix", name_prefix);
+      createInbox((this.api as ConsumerAPIImpl).getOptions().watcherPrefix);
 
     const cc = Object.assign({}, opts) as ConsumerConfig;
     cc.ack_policy = AckPolicy.None;

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -68,6 +68,12 @@ export type JetStreamOptions = {
    * the default JetStream apiPrefix.
    */
   domain?: string;
+
+  /**
+   * Watcher prefix for inbox subscriptions - these are used for watchers
+   * and push consumers. If not set, it uses ConnectionOptions#inboxPrefix
+   */
+  watcherPrefix?: string;
 };
 
 export type JetStreamManagerOptions = JetStreamOptions & {

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -2671,3 +2671,21 @@ Deno.test("kv - encoder", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("kv - watcherPrefix", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+
+  const js = jetstream(nc, { watcherPrefix: "hello" });
+  const kv = await new Kvm(js).create("A");
+
+  const iter = await kv.watch({ key: "a.>" }) as QueuedIteratorImpl<
+    KvWatchEntry
+  >;
+  const pci = iter._data as PushConsumer;
+  const { config: { deliver_subject } } = await pci.info(true);
+  assertEquals(deliver_subject?.split(".")[0], "hello");
+
+  iter.stop();
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
`watcherPrefix` which is used for the creation of watchers and ordered push consumers internally. It is used as the prefix for the subject that will deliver to the push consumer that services a watcher.

`jetstream(nc, {watcherPrefix: "hello"});` or `await jetstreamManager(nc, {watcherPrefix: "hello"});`