### PR TITLE
fix(typescript): fixes to the exports so QueuedIterator exports correctly to JetStream

### DIFF
--- a/core/src/mod.ts
+++ b/core/src/mod.ts
@@ -105,6 +105,7 @@ export type {
   TlsOptions,
   TokenAuth,
   UserPass,
+  WithRequired,
   WsConnectionOptions,
   WsSocketFactory,
 } from "./internal_mod.ts";

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -21,7 +21,7 @@ import type {
   RequestOptions,
   ReviverFn,
   WithRequired,
-} from "@nats-io/nats-core/internal";
+} from "@nats-io/nats-core";
 
 import type {
   ConsumerCreateOptions,


### PR DESCRIPTION
export WithRequired from core to the public module so types.ts in jetstream can import everything from @nats-io/nats-core directly

Fix #345