### PR TITLE
feat(core): normalize non-array values in `MsgHdrs.fromRecord`

### DIFF
--- a/core/src/headers.ts
+++ b/core/src/headers.ts
@@ -305,7 +305,8 @@ export class MsgHdrsImpl implements MsgHdrs {
   static fromRecord(r: Record<string, string[]>): MsgHdrs {
     const h = new MsgHdrsImpl();
     for (const k in r) {
-      h.headers.set(k, r[k]);
+      const v = r[k];
+      h.headers.set(k, Array.isArray(v) ? v : [`${v}`]);
     }
     return h;
   }

--- a/core/tests/headers_test.ts
+++ b/core/tests/headers_test.ts
@@ -493,6 +493,20 @@ Deno.test("headers - record", () => {
   assert(hr.equals(h as MsgHdrsImpl));
 });
 
+Deno.test("headers - fromRecord normalizes non-array values", () => {
+  const hr = MsgHdrsImpl.fromRecord(
+    { a: "x", d: 1 } as unknown as Record<string, string[]>,
+  ) as MsgHdrsImpl;
+  assertEquals(hr.get("a"), "x");
+  assertEquals(hr.get("d"), "1");
+
+  const r = hr.toRecord();
+  assertEquals(r, {
+    a: ["x"],
+    d: ["1"],
+  });
+});
+
 Deno.test("headers - not equals", () => {
   const h = headers() as MsgHdrsImpl;
   h.set("a", "aa");


### PR DESCRIPTION
- Updated `MsgHdrs.fromRecord` to convert non-array header values to arrays.
- Added tests to ensure proper normalization of such values.

interesting use of building headers from the map outside of the internals.

Fix #344 