### PR TITLE
feat(jetstream,kv): handle additional JetStream API error for stream seq

### DIFF
--- a/jetstream/src/jserrors.ts
+++ b/jetstream/src/jserrors.ts
@@ -195,6 +195,7 @@ export const JetStreamApiCodes = {
   StreamNotFound: 10059,
   JetStreamNotEnabledForAccount: 10039,
   StreamWrongLastSequence: 10071,
+  StreamWrongLastSequenceUnknown: 10164,
   NoMessageFound: 10037,
 } as const;
 

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -595,7 +595,10 @@ export class Bucket implements KV {
       firstErr = err;
       if (err instanceof JetStreamApiError) {
         const jserr = err as JetStreamApiError;
-        if (jserr.code !== JetStreamApiCodes.StreamWrongLastSequence) {
+        if (
+          jserr.code !== JetStreamApiCodes.StreamWrongLastSequence &&
+          jserr.code !== JetStreamApiCodes.StreamWrongLastSequenceUnknown
+        ) {
           return Promise.reject(err);
         }
       }


### PR DESCRIPTION


- Added `StreamWrongLastSequenceUnknown` to JetStream error codes and updated KV logic to account for this scenario.