### PR TITLE
Fix num parse

### DIFF
--- a/core/src/parser.ts
+++ b/core/src/parser.ts
@@ -81,6 +81,7 @@ function newMsgArg(): MsgArg {
 
 const ASCII_0 = 48;
 const ASCII_9 = 57;
+const MAX_64MB = 64 * 1024 * 1024;
 
 // This is an almost verbatim port of the Go NATS parser
 // https://github.com/nats-io/nats.go/blob/master/parser.go
@@ -579,13 +580,13 @@ export class Parser {
         this.ma.subject = args[0];
         this.ma.sid = this.protoParseInt(args[1]);
         this.ma.reply = undefined;
-        this.ma.size = this.protoParseInt(args[2]);
+        this.ma.size = this.protoParseInt(args[2], MAX_64MB);
         break;
       case 4:
         this.ma.subject = args[0];
         this.ma.sid = this.protoParseInt(args[1]);
         this.ma.reply = args[2];
-        this.ma.size = this.protoParseInt(args[3]);
+        this.ma.size = this.protoParseInt(args[3], MAX_64MB);
         break;
       default:
         throw this.fail(arg, "processMsgArgs Parse Error");
@@ -639,15 +640,15 @@ export class Parser {
         this.ma.subject = args[0];
         this.ma.sid = this.protoParseInt(args[1]);
         this.ma.reply = undefined;
-        this.ma.hdr = this.protoParseInt(args[2]);
-        this.ma.size = this.protoParseInt(args[3]);
+        this.ma.hdr = this.protoParseInt(args[2], MAX_64MB);
+        this.ma.size = this.protoParseInt(args[3], MAX_64MB);
         break;
       case 5:
         this.ma.subject = args[0];
         this.ma.sid = this.protoParseInt(args[1]);
         this.ma.reply = args[2];
-        this.ma.hdr = this.protoParseInt(args[3]);
-        this.ma.size = this.protoParseInt(args[4]);
+        this.ma.hdr = this.protoParseInt(args[3], MAX_64MB);
+        this.ma.size = this.protoParseInt(args[4], MAX_64MB);
         break;
       default:
         throw this.fail(arg, "processHeaderMsgArgs Parse Error");
@@ -667,9 +668,9 @@ export class Parser {
     }
   }
 
-  protoParseInt(a: Uint8Array): number {
-    // max 99_999_999
-    if (a.length === 0 || a.length > 8) {
+  protoParseInt(a: Uint8Array, max?: number): number {
+    // max 999_999_999_999_999 - one digit below MAX_SAFE_INTEGER
+    if (a.length === 0 || a.length > 15) {
       return -1;
     }
     let n = 0;
@@ -679,7 +680,7 @@ export class Parser {
       }
       n = n * 10 + (a[i] - ASCII_0);
     }
-    return n;
+    return max !== undefined && n > max ? -1 : n;
   }
 }
 

--- a/core/src/parser.ts
+++ b/core/src/parser.ts
@@ -668,7 +668,8 @@ export class Parser {
   }
 
   protoParseInt(a: Uint8Array): number {
-    if (a.length === 0) {
+    // max 99_999_999
+    if (a.length === 0 || a.length > 8) {
       return -1;
     }
     let n = 0;

--- a/core/tests/parser_test.ts
+++ b/core/tests/parser_test.ts
@@ -538,6 +538,39 @@ function parserClobberTest(hdrs = false): void {
   }
 }
 
+Deno.test("parser - protoParseInt", () => {
+  const d = new TestDispatcher();
+  const p = new Parser(d);
+
+  // valid ints
+  assertEquals(p.protoParseInt(te.encode("0")), 0);
+  assertEquals(p.protoParseInt(te.encode("1")), 1);
+  assertEquals(p.protoParseInt(te.encode("12345678")), 12345678);
+  assertEquals(p.protoParseInt(te.encode("99999999")), 99999999);
+
+  // empty
+  assertEquals(p.protoParseInt(te.encode("")), -1);
+  assertEquals(p.protoParseInt(new Uint8Array(0)), -1);
+
+  // non-digit chars
+  assertEquals(p.protoParseInt(te.encode("abc")), -1);
+  assertEquals(p.protoParseInt(te.encode("12a")), -1);
+  assertEquals(p.protoParseInt(te.encode("-1")), -1);
+
+  // overflow: > 8 digits rejected
+  assertEquals(p.protoParseInt(te.encode("123456789")), -1);
+  assertEquals(p.protoParseInt(te.encode("9999999999999999")), -1);
+});
+
+Deno.test("parser - oversized msg size rejects", () => {
+  const d = new TestDispatcher();
+  const p = new Parser(d);
+  // 9-digit size triggers protoParseInt to return -1, which fails the < 0 check
+  assertThrows(() => {
+    p.parse(te.encode("MSG foo 1 123456789\r\n"));
+  });
+});
+
 Deno.test("parser - describe", () => {
   assertEquals(describe({ kind: Kind.MSG }), "MSG: ");
   assertEquals(describe({ kind: Kind.OK }), "OK: ");

--- a/core/tests/parser_test.ts
+++ b/core/tests/parser_test.ts
@@ -546,7 +546,7 @@ Deno.test("parser - protoParseInt", () => {
   assertEquals(p.protoParseInt(te.encode("0")), 0);
   assertEquals(p.protoParseInt(te.encode("1")), 1);
   assertEquals(p.protoParseInt(te.encode("12345678")), 12345678);
-  assertEquals(p.protoParseInt(te.encode("99999999")), 99999999);
+  assertEquals(p.protoParseInt(te.encode("999999999999999")), 999999999999999);
 
   // empty
   assertEquals(p.protoParseInt(te.encode("")), -1);
@@ -557,17 +557,23 @@ Deno.test("parser - protoParseInt", () => {
   assertEquals(p.protoParseInt(te.encode("12a")), -1);
   assertEquals(p.protoParseInt(te.encode("-1")), -1);
 
-  // overflow: > 8 digits rejected
-  assertEquals(p.protoParseInt(te.encode("123456789")), -1);
+  // overflow: > 15 digits rejected
+  assertEquals(p.protoParseInt(te.encode("1234567890123456")), -1);
   assertEquals(p.protoParseInt(te.encode("9999999999999999")), -1);
+
+  // max parameter
+  assertEquals(p.protoParseInt(te.encode("100"), 100), 100);
+  assertEquals(p.protoParseInt(te.encode("101"), 100), -1);
+  assertEquals(p.protoParseInt(te.encode("1024"), 1024), 1024);
+  assertEquals(p.protoParseInt(te.encode("1025"), 1024), -1);
 });
 
 Deno.test("parser - oversized msg size rejects", () => {
   const d = new TestDispatcher();
   const p = new Parser(d);
-  // 9-digit size triggers protoParseInt to return -1, which fails the < 0 check
+  // 16-digit size triggers protoParseInt to return -1, which fails the < 0 check
   assertThrows(() => {
-    p.parse(te.encode("MSG foo 1 123456789\r\n"));
+    p.parse(te.encode("MSG foo 1 1234567890123456\r\n"));
   });
 });
 


### PR DESCRIPTION
the clamp is for some payloads that exceed standard sizes by future proofing. Some other limits are clamped to practical values (as over a long time, sub identifiers could grow very large).