### PR TITLE
feat(jetstream): add `ConsumerResetResponse` and reset() functionality

### DIFF
--- a/core/src/semver.ts
+++ b/core/src/semver.ts
@@ -54,6 +54,7 @@ export const Feature = {
   JS_DEFAULT_CONSUMER_LIMITS: "js_default_consumer_limits",
   JS_BATCH_DIRECT_GET: "js_batch_direct_get",
   JS_PRIORITY_GROUPS: "js_priority_groups",
+  JS_CONSUMER_RESET: "js_consumer_reset",
 } as const;
 
 export type Feature = typeof Feature[keyof typeof Feature];
@@ -115,6 +116,7 @@ export class Features {
     this.set(Feature.JS_DEFAULT_CONSUMER_LIMITS, "2.10.0");
     this.set(Feature.JS_BATCH_DIRECT_GET, "2.11.0");
     this.set(Feature.JS_PRIORITY_GROUPS, "2.11.0");
+    this.set(Feature.JS_CONSUMER_RESET, "2.14.0");
 
     this.disabled.forEach((f) => {
       this.features.delete(f);

--- a/jetstream/src/internal_mod.ts
+++ b/jetstream/src/internal_mod.ts
@@ -129,6 +129,7 @@ export type {
   ConsumerConfig,
   ConsumerCreateOptions,
   ConsumerInfo,
+  ConsumerResetResponse,
   ConsumerUpdateConfig,
   DirectBatch,
   DirectBatchLimits,

--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -916,6 +916,20 @@ export type ConsumerListResponse = ApiResponse & ApiPaged & {
   consumers: ConsumerInfo[];
 };
 
+/**
+ * Response from `$JS.API.CONSUMER.RESET` containing the reset
+ * ConsumerInfo plus the stream sequence the consumer was reset to.
+ *
+ * Requires server v2.14.0+. See ADR-60.
+ */
+export type ConsumerResetResponse = ConsumerInfo & {
+  /**
+   * The stream sequence the consumer was reset to. The next
+   * message delivered will have sequence >= reset_seq.
+   */
+  reset_seq: number;
+};
+
 export type StreamListResponse = ApiResponse & ApiPaged & {
   streams: StreamInfo[];
 };

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -270,6 +270,8 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     if (!ok) {
       throw new Error(`consumer reset requires server ${min}`);
     }
+    // seq === 0 is intentionally allowed: server treats it the same as an
+    // empty body and resets the consumer to ack_floor + 1 (ADR-60).
     if (typeof seq === "number" && (!Number.isInteger(seq) || seq < 0)) {
       throw InvalidArgumentError.format(
         "seq",

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -35,6 +35,7 @@ import type {
   ConsumerCreateOptions,
   ConsumerInfo,
   ConsumerListResponse,
+  ConsumerResetResponse,
   ConsumerUpdateConfig,
   CreateConsumerRequest,
   PriorityGroups,
@@ -255,6 +256,30 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
   unpin(stream: string, name: string, group: string): Promise<void> {
     const subj = `${this.prefix}.CONSUMER.UNPIN.${stream}.${name}`;
     return this._request(subj, { group }) as Promise<void>;
+  }
+
+  async reset(
+    stream: string,
+    name: string,
+    seq?: number,
+  ): Promise<ConsumerResetResponse> {
+    validateStreamName(stream);
+    validateDurableName(name);
+    const nci = this.nc as NatsConnectionImpl;
+    const { min, ok } = nci.features.get(Feature.JS_CONSUMER_RESET);
+    if (!ok) {
+      throw new Error(`consumer reset requires server ${min}`);
+    }
+    if (typeof seq === "number" && (!Number.isInteger(seq) || seq < 0)) {
+      throw InvalidArgumentError.format(
+        "seq",
+        "must be a non-negative integer",
+      );
+    }
+    const subj = `${this.prefix}.CONSUMER.RESET.${stream}.${name}`;
+    const body = typeof seq === "number" ? { seq } : undefined;
+    const r = await this._request(subj, body);
+    return r as ConsumerResetResponse;
   }
 }
 

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -265,7 +265,7 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
   ): Promise<ConsumerResetResponse> {
     validateStreamName(stream);
     validateDurableName(name);
-    const nci = this.nc as NatsConnectionImpl;
+    const nci = this.nc as unknown as NatsConnectionImpl;
     const { min, ok } = nci.features.get(Feature.JS_CONSUMER_RESET);
     if (!ok) {
       throw new Error(`consumer reset requires server ${min}`);

--- a/jetstream/src/jsmstream_api.ts
+++ b/jetstream/src/jsmstream_api.ts
@@ -61,6 +61,7 @@ import type {
   ApiPagedRequest,
   ConsumerConfig,
   ConsumerInfo,
+  ConsumerResetResponse,
   ExternalStream,
   MsgDeleteRequest,
   MsgRequest,
@@ -397,6 +398,14 @@ export class StreamImpl implements Stream {
 
   deleteMessage(seq: number, erase = true): Promise<boolean> {
     return this.api.deleteMessage(this.name, seq, erase);
+  }
+
+  resetConsumer(
+    name: string,
+    seq?: number,
+  ): Promise<ConsumerResetResponse> {
+    return new ConsumerAPIImpl(this.api.nc, this.api.opts)
+      .reset(this.name, name, seq);
   }
 }
 

--- a/jetstream/src/mod.ts
+++ b/jetstream/src/mod.ts
@@ -69,6 +69,7 @@ export type {
   ConsumerNotFound,
   ConsumerNotification,
   ConsumerPinned,
+  ConsumerResetResponse,
   Consumers,
   ConsumerUnpinned,
   ConsumerUpdateConfig,

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -35,6 +35,7 @@ import type {
 import type {
   ConsumerConfig,
   ConsumerInfo,
+  ConsumerResetResponse,
   ConsumerUpdateConfig,
   DirectBatchOptions,
   DirectMsgRequest,
@@ -491,6 +492,26 @@ export type ConsumerAPI = {
    * @param group
    */
   unpin(stream: string, name: string, group: string): Promise<void>;
+
+  /**
+   * Resets the consumer's delivery state without deleting and recreating
+   * it. If `seq` is provided, the next message delivered will have a
+   * stream sequence >= seq. If omitted, state is reset but the ack floor
+   * stream sequence is preserved.
+   *
+   * Requires server v2.14.0+. Only allowed on consumers configured with
+   * `DeliverPolicy=all`, `by_start_sequence`, or `by_start_time`. See
+   * ADR-60.
+   *
+   * @param stream
+   * @param name
+   * @param seq optional stream sequence to reset to
+   */
+  reset(
+    stream: string,
+    name: string,
+    seq?: number,
+  ): Promise<ConsumerResetResponse>;
 };
 
 /**
@@ -1502,6 +1523,27 @@ export type Stream = {
    * @param erase - default is true
    */
   deleteMessage(seq: number, erase?: boolean): Promise<boolean>;
+
+  /**
+   * Resets the named consumer's delivery state. See {@link ConsumerAPI.reset}
+   * for the underlying behavior, version requirements, and policy
+   * constraints.
+   *
+   * IMPORTANT: this is an admin operation. In-flight `consume()`,
+   * `fetch()`, `next()`, or push subscriptions on the consumer are NOT
+   * coordinated by this call. Buffered messages from the prior delivery
+   * may still be yielded, and re-delivered messages will have a delivery
+   * sequence restarting from 1 — looking like a gap. Ordered consumers
+   * detect the gap and recreate themselves; non-ordered consumers should
+   * be stopped and restarted by the caller after a reset.
+   *
+   * @param name consumer name or durable
+   * @param seq optional stream sequence to reset to
+   */
+  resetConsumer(
+    name: string,
+    seq?: number,
+  ): Promise<ConsumerResetResponse>;
 };
 
 export const JsHeaders = {

--- a/jetstream/tests/consumer_reset_test.ts
+++ b/jetstream/tests/consumer_reset_test.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cleanup, jetstreamServerConf, notCompatible, setup } from "nst";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  jetstream,
+  jetstreamManager,
+} from "../src/mod.ts";
+import { Feature, type NatsConnectionImpl } from "@nats-io/nats-core/internal";
+import { fill } from "./jstest_util.ts";
+
+Deno.test("consumer reset - basic (no seq)", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    await cleanup(ns, nc);
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.All,
+  });
+
+  await fill(nc, "s", 5);
+  const js = jetstream(nc);
+
+  const c = await js.consumers.get("s", "c");
+  const iter = await c.fetch({ max_messages: 3, expires: 1000 });
+  for await (const m of iter) {
+    m.ack();
+  }
+
+  const s = await js.streams.get("s");
+  const r = await s.resetConsumer("c");
+  assertEquals(r.name, "c");
+  assertEquals(r.stream_name, "s");
+  assert(typeof r.reset_seq === "number");
+  assertEquals(r.delivered.consumer_seq, 0);
+  assertEquals(r.num_redelivered, 0);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("consumer reset - with seq", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    await cleanup(ns, nc);
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.All,
+  });
+
+  await fill(nc, "s", 5);
+  const js = jetstream(nc);
+
+  const stream = await js.streams.get("s");
+  const r = await stream.resetConsumer("c", 3);
+  assertEquals(r.reset_seq, 3);
+
+  // next delivered message should be stream seq >= 3
+  const c = await js.consumers.get("s", "c");
+  const iter = await c.fetch({ max_messages: 1, expires: 1000 });
+  for await (const m of iter) {
+    assert(m.seq >= 3, `expected seq >= 3, got ${m.seq}`);
+    m.ack();
+  }
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("consumer reset - invalid seq", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    await cleanup(ns, nc);
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.All,
+  });
+
+  const js = jetstream(nc);
+  const stream = await js.streams.get("s");
+
+  await assertRejects(
+    () => stream.resetConsumer("c", -1),
+    Error,
+    "non-negative integer",
+  );
+  await assertRejects(
+    () => stream.resetConsumer("c", 1.5),
+    Error,
+    "non-negative integer",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("consumer reset - version gate", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  const nci = nc as NatsConnectionImpl;
+  nci.features.disable(Feature.JS_CONSUMER_RESET);
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.All,
+  });
+
+  const js = jetstream(nc);
+  const stream = await js.streams.get("s");
+
+  await assertRejects(
+    () => stream.resetConsumer("c"),
+    Error,
+    "consumer reset requires server",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("consumer reset - by_start_sequence allowed at/above", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    await cleanup(ns, nc);
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.StartSequence,
+    opt_start_seq: 3,
+  });
+
+  await fill(nc, "s", 5);
+  const js = jetstream(nc);
+  const stream = await js.streams.get("s");
+
+  // at the boundary: equals opt_start_seq is allowed
+  const r = await stream.resetConsumer("c", 3);
+  assertEquals(r.reset_seq, 3);
+
+  // above the boundary is allowed
+  const r2 = await stream.resetConsumer("c", 4);
+  assertEquals(r2.reset_seq, 4);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("consumer reset - by_start_sequence rejects below", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    await cleanup(ns, nc);
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.StartSequence,
+    opt_start_seq: 5,
+  });
+
+  await fill(nc, "s", 10);
+  const js = jetstream(nc);
+  const stream = await js.streams.get("s");
+
+  await assertRejects(
+    () => stream.resetConsumer("c", 2),
+    Error,
+    "below start seq",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("consumer reset - rejects last policy server-side", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    await cleanup(ns, nc);
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({ name: "s", subjects: ["s.*"] });
+  await jsm.consumers.add("s", {
+    durable_name: "c",
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.Last,
+  });
+
+  const js = jetstream(nc);
+  const stream = await js.streams.get("s");
+
+  // server should reject reset with seq for non-allowed policies
+  await assertRejects(
+    () => stream.resetConsumer("c", 1),
+    Error,
+  );
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
Added 
-  `reset()` and `resetConsumer()` methods for resetting to stream/consumer api