### PR TITLE
feat(internal): api level internals

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -223,6 +223,13 @@ export interface ServerInfo {
    * The nats-server version
    */
   version: string;
+  /**
+   * JetStream API level advertised by the server. Present on servers that
+   * support API level negotiation (nats-server 2.11+). Use to gate features
+   * gated by API level (e.g. fast ingest requires `api_lvl >= 4`, available
+   * in nats-server 2.14+).
+   */
+  "api_lvl"?: number;
 }
 
 export interface Server {

--- a/core/tests/basics_test.ts
+++ b/core/tests/basics_test.ts
@@ -46,7 +46,7 @@ import type {
   PublishOptions,
   SubscriptionImpl,
 } from "../src/internal_mod.ts";
-import { cleanup, Lock, NatsServer, setup } from "nst";
+import { cleanup, jetstreamServerConf, Lock, NatsServer, setup } from "nst";
 import { connect } from "./connect.ts";
 import { errors } from "../src/errors.ts";
 
@@ -1229,6 +1229,17 @@ Deno.test("basics - server version", async () => {
 Deno.test("basics - info", async () => {
   const { ns, nc } = await setup();
   assertExists(nc.info);
+  await cleanup(ns, nc);
+});
+
+Deno.test("basics - info api_lvl", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  const nci = nc as NatsConnectionImpl;
+  assertExists(nc.info);
+  // server 2.11+ advertises api_lvl on INFO; older servers omit it
+  if (nci.protocol.features.require("2.11.0")) {
+    assertEquals(typeof nc.info!.api_lvl, "number");
+  }
   await cleanup(ns, nc);
 });
 

--- a/jetstream/src/jsapi_types.ts
+++ b/jetstream/src/jsapi_types.ts
@@ -169,34 +169,14 @@ export type StreamConfig = StreamUpdateConfig & {
   "first_seq": number;
 
   /**
-   * Enables allows header initiated per-message TTLs. If disabled, then the `NATS-TTL`
-   * header will be ignored.
-   */
-  "allow_msg_ttl": boolean;
-
-  /**
-   * Enables a NATS stream implementation of CRDT operations
+   * Enables a NATS stream implementation of CRDT operations.
+   * Cannot be changed once the stream is created.
    */
   "allow_msg_counter": boolean;
 
   /**
-   * Enables the scheduling of messages in a stream.
-   */
-  "allow_msg_schedules": boolean;
-
-  /**
-   * Enables the ability to send atomic batches to the stream
-   */
-  "allow_atomic": boolean;
-
-  /**
-   * Enables the ability to send batched messages to the stream
-   */
-  "allow_batched": boolean;
-
-  /**
    * Sets the persistence model for the stream - the default is PersistMode.Default.
-   * This is a 2.12 feature.
+   * This is a 2.12 feature. Cannot be changed once the stream is created.
    */
   "persist_mode": PersistMode;
 };
@@ -323,6 +303,27 @@ export type StreamUpdateConfig = {
    * When a mirror is configured subjects and sources must be empty.
    */
   mirror?: StreamSource; // same as a source
+
+  /**
+   * Enables allows header initiated per-message TTLs. If disabled, then the `NATS-TTL`
+   * header will be ignored.
+   */
+  "allow_msg_ttl"?: boolean;
+
+  /**
+   * Enables the scheduling of messages in a stream.
+   */
+  "allow_msg_schedules"?: boolean;
+
+  /**
+   * Enables the ability to send atomic batches to the stream.
+   */
+  "allow_atomic"?: boolean;
+
+  /**
+   * Enables the ability to send batched messages to the stream.
+   */
+  "allow_batched"?: boolean;
 };
 
 export type Republish = {

--- a/jetstream/src/jsbaseclient_api.ts
+++ b/jetstream/src/jsbaseclient_api.ts
@@ -20,6 +20,7 @@ import {
   Empty,
   errors,
   extend,
+  headers,
   RequestError,
 } from "@nats-io/nats-core/internal";
 import type {
@@ -28,8 +29,9 @@ import type {
   NatsConnectionImpl,
   RequestOptions,
 } from "@nats-io/nats-core/internal";
-import type { ApiResponse } from "./jsapi_types.ts";
-import type { JetStreamOptions } from "./types.ts";
+import type { ApiResponse, ConsumerApiOptions } from "./jsapi_types.ts";
+import { JsHeaders } from "./types.ts";
+import type { JetStreamManagerOptions, JetStreamOptions } from "./types.ts";
 import {
   ConsumerNotFoundError,
   JetStreamApiCodes,
@@ -78,6 +80,11 @@ export type StreamNameBySubject = {
   subject: string;
 };
 
+export type JetStreamApiRequestOptions = RequestOptions & ConsumerApiOptions & {
+  retries?: number;
+  minApiVersion?: number;
+};
+
 export class BaseApiClientImpl {
   nc: NatsConnectionImpl;
   opts: JetStreamOptions;
@@ -98,6 +105,10 @@ export class BaseApiClientImpl {
     return Object.assign({}, this.opts);
   }
 
+  protected sendRequiredApiLevel(): boolean {
+    return (this.opts as JetStreamManagerOptions).sendRequiredApiLevel === true;
+  }
+
   _parseOpts() {
     let prefix = this.opts.apiPrefix;
     if (!prefix || prefix.length === 0) {
@@ -116,31 +127,29 @@ export class BaseApiClientImpl {
   async _request(
     subj: string,
     data: unknown = null,
-    opts?: Partial<RequestOptions> & { retries?: number },
+    opts?: Partial<JetStreamApiRequestOptions>,
   ): Promise<unknown> {
-    opts = opts || {} as RequestOptions;
-    opts.timeout = this.timeout;
+    const { retries: r, minApiVersion, ...rest } = opts ?? {};
+    const reqOpts = { ...rest, timeout: this.timeout } as RequestOptions;
 
     let a: Uint8Array = Empty;
     if (data) {
       a = new TextEncoder().encode(JSON.stringify(data));
     }
 
-    let { retries } = opts as {
-      retries: number;
-    };
+    if (typeof minApiVersion === "number") {
+      const h = reqOpts.headers ?? headers();
+      h.set(JsHeaders.RequiredApiLevel, minApiVersion.toString());
+      reqOpts.headers = h;
+    }
 
-    retries = retries || 1;
+    let retries = r || 1;
     retries = retries === -1 ? Number.MAX_SAFE_INTEGER : retries;
     const bo = backoff();
 
     for (let i = 0; i < retries; i++) {
       try {
-        const m = await this.nc.request(
-          subj,
-          a,
-          opts as RequestOptions,
-        );
+        const m = await this.nc.request(subj, a, reqOpts);
         return this.parseJsResponse(m);
       } catch (err) {
         const re = err instanceof RequestError ? err as RequestError : null;

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -60,6 +60,7 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     stream: string,
     cfg: ConsumerConfig,
     opts: Partial<JetStreamApiRequestOptions>,
+    delta?: Partial<ConsumerConfig>,
   ): Promise<ConsumerInfo> {
     validateStreamName(stream);
     opts = opts || {};
@@ -162,10 +163,14 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
         : `${this.prefix}.CONSUMER.CREATE.${stream}`;
     }
 
+    // when called from update(), assert api level only on the partial delta
+    // so unrelated edits to a consumer that already has level-1 fields don't
+    // send a spurious Nats-Required-Api-Level header
+    const assertCfg = delta ?? cr.config;
     const r = await this._request(
       subj,
       cr,
-      { ...opts, ...this.requiredApiOpts(cr.config) },
+      { ...opts, ...this.requiredApiOpts(assertCfg) },
     );
     return r as ConsumerInfo;
   }
@@ -221,6 +226,7 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
       stream,
       Object.assign(ci.config, changable),
       { action: ConsumerApiAction.Update },
+      changable,
     );
   }
 

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -12,7 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BaseApiClientImpl } from "./jsbaseclient_api.ts";
+import {
+  BaseApiClientImpl,
+  type JetStreamApiRequestOptions,
+} from "./jsbaseclient_api.ts";
 import { ListerImpl } from "./jslister.ts";
 import {
   minValidation,
@@ -30,7 +33,6 @@ import {
   InvalidArgumentError,
 } from "@nats-io/nats-core/internal";
 import type {
-  ConsumerApiOptions,
   ConsumerConfig,
   ConsumerCreateOptions,
   ConsumerInfo,
@@ -57,7 +59,7 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
   async addUpdate(
     stream: string,
     cfg: ConsumerConfig,
-    opts: ConsumerApiOptions,
+    opts: Partial<JetStreamApiRequestOptions>,
   ): Promise<ConsumerInfo> {
     validateStreamName(stream);
     opts = opts || {};
@@ -160,8 +162,36 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
         : `${this.prefix}.CONSUMER.CREATE.${stream}`;
     }
 
-    const r = await this._request(subj, cr);
+    const r = await this._request(
+      subj,
+      cr,
+      { ...opts, ...this.requiredApiOpts(cr.config) },
+    );
     return r as ConsumerInfo;
+  }
+
+  // mirrors server/jetstream_versioning.go:setStaticConsumerMetadata
+  private minConsumerApi(c: Partial<ConsumerConfig>): number {
+    if (typeof c.pause_until === "string" && c.pause_until !== "") return 1;
+    if (
+      c.priority_policy !== undefined &&
+      c.priority_policy !== PriorityPolicy.None
+    ) return 1;
+    if (typeof c.priority_timeout === "number" && c.priority_timeout > 0) {
+      return 1;
+    }
+    if (Array.isArray(c.priority_groups) && c.priority_groups.length > 0) {
+      return 1;
+    }
+    return 0;
+  }
+
+  private requiredApiOpts(
+    c: Partial<ConsumerConfig>,
+  ): Partial<JetStreamApiRequestOptions> {
+    if (!this.sendRequiredApiLevel()) return {};
+    const minApiVersion = this.minConsumerApi(c);
+    return minApiVersion > 0 ? { minApiVersion } : {};
   }
 
   add(

--- a/jetstream/src/jsmstream_api.ts
+++ b/jetstream/src/jsmstream_api.ts
@@ -33,7 +33,10 @@ import {
   nuid,
   TD,
 } from "@nats-io/nats-core/internal";
-import type { StreamNames } from "./jsbaseclient_api.ts";
+import type {
+  JetStreamApiRequestOptions,
+  StreamNames,
+} from "./jsbaseclient_api.ts";
 import { BaseApiClientImpl } from "./jsbaseclient_api.ts";
 import { ListerImpl } from "./jslister.ts";
 import { minValidation, validateStreamName } from "./jsutil.ts";
@@ -78,7 +81,7 @@ import type {
   StreamUpdateConfig,
   SuccessResponse,
 } from "./jsapi_types.ts";
-import { AckPolicy, DeliverPolicy } from "./jsapi_types.ts";
+import { AckPolicy, DeliverPolicy, PersistMode } from "./jsapi_types.ts";
 import { PullConsumerImpl } from "./consumer.ts";
 import { ConsumerAPIImpl } from "./jsmconsumer_api.ts";
 import type { PushConsumerInternalOptions } from "./pushconsumer.ts";
@@ -466,6 +469,31 @@ export class StreamAPIImpl extends BaseApiClientImpl implements StreamAPI {
     }
   }
 
+  // mirrors server/jetstream_versioning.go:setStaticStreamMetadata
+  private minStreamApi(c: Partial<StreamConfig>): number {
+    if (c.allow_batched === true) return 4;
+    if (
+      c.allow_msg_counter === true ||
+      c.allow_atomic === true ||
+      c.allow_msg_schedules === true ||
+      c.persist_mode === PersistMode.Async
+    ) return 2;
+    if (
+      c.allow_msg_ttl === true ||
+      (typeof c.subject_delete_marker_ttl === "number" &&
+        c.subject_delete_marker_ttl > 0)
+    ) return 1;
+    return 0;
+  }
+
+  private requiredApiOpts(
+    c: Partial<StreamConfig>,
+  ): Partial<JetStreamApiRequestOptions> {
+    if (!this.sendRequiredApiLevel()) return {};
+    const minApiVersion = this.minStreamApi(c);
+    return minApiVersion > 0 ? { minApiVersion } : {};
+  }
+
   async add(
     cfg: WithRequired<Partial<StreamConfig>, "name">,
   ): Promise<StreamInfo> {
@@ -474,9 +502,11 @@ export class StreamAPIImpl extends BaseApiClientImpl implements StreamAPI {
     cfg.mirror = convertStreamSourceDomain(cfg.mirror);
     //@ts-ignore: the sources are either set or not - so no item should be undefined in the list
     cfg.sources = cfg.sources?.map(convertStreamSourceDomain);
+
     const r = await this._request(
       `${this.prefix}.STREAM.CREATE.${cfg.name}`,
       cfg,
+      this.requiredApiOpts(cfg),
     );
     const si = r as StreamInfo;
     this._fixInfo(si);
@@ -514,6 +544,7 @@ export class StreamAPIImpl extends BaseApiClientImpl implements StreamAPI {
     const r = await this._request(
       `${this.prefix}.STREAM.UPDATE.${name}`,
       update,
+      this.requiredApiOpts(cfg),
     );
     const si = r as StreamInfo;
     this._fixInfo(si);

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -82,6 +82,14 @@ export type JetStreamManagerOptions = JetStreamOptions & {
    * {@link JetStreamManager.getAccountInfo()}.
    */
   checkAPI?: boolean;
+  /**
+   * @ignore
+   * Send the `Nats-Required-Api-Level` header on stream/consumer create/update
+   * requests when the supplied config uses fields that require a minimum
+   * server API level (per ADR-44). Server rejects with `api level not supported`
+   * if its level is lower, instead of silently dropping unknown fields.
+   */
+  sendRequiredApiLevel?: boolean;
 };
 
 /**
@@ -1542,6 +1550,10 @@ export const JsHeaders = {
    * was not honored
    */
   PendingBytesHdr: "Nats-Pending-Bytes",
+  /**
+   * Asserts a minimum JetStream API level on a JS API request (ADR-44).
+   */
+  RequiredApiLevel: "Nats-Required-Api-Level",
 } as const;
 export type JsHeaders = typeof JsHeaders[keyof typeof JsHeaders];
 

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -40,11 +40,13 @@ import {
 import type {
   ConsumerConfig,
   ConsumerInfo,
+  ConsumerUpdateConfig,
   Lister,
   PubAck,
   StreamConfig,
   StreamInfo,
   StreamSource,
+  StreamUpdateConfig,
 } from "../src/mod.ts";
 import {
   AckPolicy,
@@ -2929,5 +2931,135 @@ Deno.test("jsm - sendRequiredApiLevel header on consumer create", async () => {
   });
 
   assertEquals(await captured, "1");
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel header on stream update", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc, { sendRequiredApiLevel: true });
+  await jsm.streams.add({ name: "FI", subjects: ["fi"] });
+
+  const captured = deferred<string | null>();
+  nc.subscribe("$JS.API.STREAM.UPDATE.>", {
+    callback: (_err, msg) => {
+      captured.resolve(msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null);
+    },
+    max: 1,
+  });
+
+  await jsm.streams.update(
+    "FI",
+    { allow_batched: true } as unknown as Partial<StreamUpdateConfig>,
+  );
+
+  assertEquals(await captured, "4");
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel stream update no header when delta plain", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc, { sendRequiredApiLevel: true });
+  // stream already has a level-4 field set
+  await jsm.streams.add({
+    name: "FI",
+    subjects: ["fi"],
+    allow_batched: true,
+  });
+
+  const captured = deferred<string | null>();
+  nc.subscribe("$JS.API.STREAM.UPDATE.>", {
+    callback: (_err, msg) => {
+      captured.resolve(msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null);
+    },
+    max: 1,
+  });
+
+  // delta touches an unrelated field — header must not be sent
+  await jsm.streams.update("FI", { description: "updated" });
+
+  assertEquals(await captured, null);
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel header on consumer update", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc, { sendRequiredApiLevel: true });
+  await jsm.streams.add({ name: "C", subjects: ["c"] });
+  await jsm.consumers.add("C", {
+    durable_name: "d",
+    ack_policy: AckPolicy.Explicit,
+  });
+
+  const captured = deferred<string | null>();
+  const sub = nc.subscribe("$JS.API.CONSUMER.>");
+  (async () => {
+    for await (const msg of sub) {
+      // ignore INFO lookups issued by update() before the actual CREATE
+      if (msg.subject.includes(".CREATE.")) {
+        captured.resolve(
+          msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null,
+        );
+        sub.unsubscribe();
+        return;
+      }
+    }
+  })();
+
+  await jsm.consumers.update("C", "d", {
+    description: "paused",
+    pause_until: new Date(Date.now() + 60_000).toISOString(),
+  } as unknown as Partial<ConsumerUpdateConfig>);
+
+  assertEquals(await captured, "1");
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel consumer update unrelated edit no header", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return;
+  }
+
+  const jsm = await jetstreamManager(nc, { sendRequiredApiLevel: true });
+  await jsm.streams.add({ name: "C", subjects: ["c"] });
+  // consumer already has a level-1 field set at creation
+  await jsm.consumers.add("C", {
+    durable_name: "d",
+    ack_policy: AckPolicy.Explicit,
+    priority_policy: PriorityPolicy.Overflow,
+    priority_groups: ["g1"],
+  });
+
+  const captured = deferred<string | null>();
+  const sub = nc.subscribe("$JS.API.CONSUMER.>");
+  (async () => {
+    for await (const msg of sub) {
+      // ignore INFO lookups issued by update() before the actual CREATE
+      if (msg.subject.includes(".CREATE.")) {
+        captured.resolve(
+          msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null,
+        );
+        sub.unsubscribe();
+        return;
+      }
+    }
+  })();
+
+  // delta touches an unrelated field — header must not be sent
+  await jsm.consumers.update("C", "d", { description: "edited" });
+
+  assertEquals(await captured, null);
   await cleanup(ns, nc);
 });

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -46,7 +46,6 @@ import type {
   StreamConfig,
   StreamInfo,
   StreamSource,
-  StreamUpdateConfig,
 } from "../src/mod.ts";
 import {
   AckPolicy,
@@ -2780,7 +2779,6 @@ Deno.test("jsm - stream message ttls", async () => {
 
   await assertRejects(
     () => {
-      //@ts-expect-error: this is a test
       return jsm.streams.update("A", { allow_msg_ttl: false });
     },
     Error,
@@ -2951,10 +2949,7 @@ Deno.test("jsm - sendRequiredApiLevel header on stream update", async () => {
     max: 1,
   });
 
-  await jsm.streams.update(
-    "FI",
-    { allow_batched: true } as unknown as Partial<StreamUpdateConfig>,
-  );
+  await jsm.streams.update("FI", { allow_batched: true });
 
   assertEquals(await captured, "4");
   await cleanup(ns, nc);

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -52,6 +52,7 @@ import {
   DiscardPolicy,
   jetstream,
   jetstreamManager,
+  JsHeaders,
   StorageType,
 } from "../src/mod.ts";
 import { initStream } from "./jstest_util.ts";
@@ -2852,5 +2853,81 @@ Deno.test("jsm - mirrors can be removed", async () => {
   si = await jsm.streams.update("B", { mirror: undefined });
   assertEquals(si.config.mirror, undefined);
 
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel sets header on stream create", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const captured = deferred<string | null>();
+  nc.subscribe("$JS.API.STREAM.CREATE.>", {
+    callback: (_err, msg) => {
+      captured.resolve(msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null);
+    },
+    max: 1,
+  });
+
+  const jsm = await jetstreamManager(nc, { sendRequiredApiLevel: true });
+  await jsm.streams.add({
+    name: "FI",
+    subjects: ["fi"],
+    allow_batched: true,
+  });
+
+  assertEquals(await captured, "4");
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel default omits header", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const captured = deferred<string | null>();
+  nc.subscribe("$JS.API.STREAM.CREATE.>", {
+    callback: (_err, msg) => {
+      captured.resolve(msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null);
+    },
+    max: 1,
+  });
+
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({
+    name: "FI",
+    subjects: ["fi"],
+    allow_batched: true,
+  });
+
+  assertEquals(await captured, null);
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - sendRequiredApiLevel header on consumer create", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return;
+  }
+
+  const captured = deferred<string | null>();
+  nc.subscribe("$JS.API.CONSUMER.CREATE.>", {
+    callback: (_err, msg) => {
+      captured.resolve(msg.headers?.get(JsHeaders.RequiredApiLevel) ?? null);
+    },
+    max: 1,
+  });
+
+  const jsm = await jetstreamManager(nc, { sendRequiredApiLevel: true });
+  await jsm.streams.add({ name: "C", subjects: ["c"] });
+  await jsm.consumers.add("C", {
+    ack_policy: AckPolicy.Explicit,
+    priority_policy: PriorityPolicy.Overflow,
+    priority_groups: ["g1"],
+  });
+
+  assertEquals(await captured, "1");
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
expose `api_level` on ServerInfo (server 2.11+)

ADR-44 header opt-in (requires server 2.12+)
- JetStreamManagerOptions.sendRequiredApiLevel?: boolean (hidden, default off)
- When on, stream/consumer create/update sends Nats-Required-Api-Level: <N> header
- Server (2.12+) rejects with api level not supported instead of silently dropping unknown fields
- On pre-2.12 server, header is ignored — flag is a no-op

Per-config level computation (when flag on)
- Stream: level 1 (TTL/marker), level 2 (counter/atomic/schedules/persist_mode=async), level 4 (allow_batched)
- Consumer: level 1 (pause_until/priority_*)