### PR TITLE
feat(obj): fast ingest + native sha256 backend

### DIFF
--- a/obj/bench/fast_ingest_bench.ts
+++ b/obj/bench/fast_ingest_bench.ts
@@ -1,0 +1,168 @@
+/*
+ * obj store fast-ingest benchmark.
+ *
+ * spawns a local nats-server with jetstream + memory storage, puts <size>
+ * bytes into two buckets — one with fast ingest disabled, one with it
+ * enabled — and prints throughput for each. not part of the test suite;
+ * run manually:
+ *
+ *   deno run -A obj/bench/fast_ingest_bench.ts [--size 1G] [--chunk 1M]
+ *
+ * requires nats-server 2.14+ on PATH (so api_lvl >= 4 → fast ingest path).
+ */
+
+import { jetstreamServerConf, NatsServer } from "nst";
+import { connect } from "../tests/connect.ts";
+import { Objm } from "../src/objectstore.ts";
+import { StorageType } from "../src/types.ts";
+import { setSha256Backend, type Sha256Backend } from "../src/sha256.ts";
+
+type Args = { size: number; chunk: number };
+
+function parseSize(s: string): number {
+  const m = s.trim().toUpperCase().match(/^(\d+)(B|K|KB|M|MB|G|GB)?$/);
+  if (!m) throw new Error(`bad size: ${s}`);
+  const n = parseInt(m[1], 10);
+  const u = (m[2] ?? "B").replace(/KB?/, "K").replace(/MB?/, "M").replace(
+    /GB?/,
+    "G",
+  );
+  switch (u) {
+    case "B":
+      return n;
+    case "K":
+      return n * 1024;
+    case "M":
+      return n * 1024 * 1024;
+    case "G":
+      return n * 1024 * 1024 * 1024;
+  }
+  throw new Error(`bad unit: ${u}`);
+}
+
+function parseArgs(): Args {
+  const args = Deno.args;
+  let size = 1024 * 1024 * 1024; // 1G default
+  let chunk = 1024 * 1024; // 1M default pull chunk
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--size") size = parseSize(args[++i]);
+    else if (args[i] === "--chunk") chunk = parseSize(args[++i]);
+  }
+  return { size, chunk };
+}
+
+function fmtBytes(n: number): string {
+  const u = ["B", "KiB", "MiB", "GiB"];
+  let i = 0;
+  while (n >= 1024 && i < u.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${n.toFixed(2)} ${u[i]}`;
+}
+
+// streams `total` bytes of pattern data in `chunk`-sized pieces. avoids a
+// single big allocation. one shared buffer, reused per pull.
+function patternStream(
+  total: number,
+  chunk: number,
+): ReadableStream<Uint8Array> {
+  let sent = 0;
+  const buf = new Uint8Array(chunk);
+  for (let i = 0; i < buf.length; i++) buf[i] = (i * 31) & 0xff;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (sent >= total) {
+        controller.close();
+        return;
+      }
+      const remaining = total - sent;
+      if (remaining >= chunk) {
+        // important: enqueue a copy or a fresh slice — re-enqueuing the
+        // same buffer would be detached after transfer in some runtimes.
+        controller.enqueue(buf.slice(0));
+        sent += chunk;
+      } else {
+        controller.enqueue(buf.slice(0, remaining));
+        sent += remaining;
+      }
+    },
+  });
+}
+
+async function runBench(
+  label: string,
+  bucket: string,
+  sha: Sha256Backend,
+  disableFastIngest: boolean,
+  args: Args,
+  port: number,
+): Promise<void> {
+  setSha256Backend(sha);
+  const nc = await connect({ port });
+  const objm = new Objm(nc);
+  const os = await objm.create(bucket, {
+    storage: StorageType.Memory,
+    max_bytes: args.size + 64 * 1024 * 1024,
+    disableFastIngest,
+  });
+
+  const stream = patternStream(args.size, args.chunk);
+  const start = performance.now();
+  const oi = await os.put({ name: "blob" }, stream);
+  const elapsed = (performance.now() - start) / 1000;
+  const throughput = args.size / elapsed;
+
+  console.log(
+    `${label.padEnd(36)} ${fmtBytes(args.size)} in ${elapsed.toFixed(2)}s ` +
+      `→ ${fmtBytes(throughput)}/s ` +
+      `chunks=${oi.chunks}`,
+  );
+
+  // free server memory before next bench
+  await os.destroy();
+  await nc.close();
+}
+
+async function main() {
+  const args = parseArgs();
+  console.log(
+    `bench: putting ${fmtBytes(args.size)} per bucket, ` +
+      `pull-chunk=${fmtBytes(args.chunk)}`,
+  );
+
+  const ns = await NatsServer.start(
+    jetstreamServerConf({
+      jetstream: {
+        max_mem_store: args.size * 4,
+        max_file_store: args.size * 4,
+      },
+    }),
+  );
+
+  // 2x2 matrix: {js | native sha} x {legacy publish | fast ingest}
+  try {
+    await runBench("js-sha + legacy publish", "b1", "js", true, args, ns.port);
+    await runBench("js-sha + fast ingest", "b2", "js", false, args, ns.port);
+    await runBench(
+      "native-sha + legacy publish",
+      "b3",
+      "native",
+      true,
+      args,
+      ns.port,
+    );
+    await runBench(
+      "native-sha + fast ingest",
+      "b4",
+      "native",
+      false,
+      args,
+      ns.port,
+    );
+  } finally {
+    await ns.stop();
+  }
+}
+
+await main();

--- a/obj/src/internal_mod.ts
+++ b/obj/src/internal_mod.ts
@@ -17,3 +17,7 @@ export { StorageType } from "./types.ts";
 export { Objm } from "./objectstore.ts";
 
 export { Base64Codec, Base64UrlCodec, Base64UrlPaddedCodec } from "./base64.ts";
+
+export type { Sha256Backend, StreamingSha256 } from "./sha256.ts";
+
+export { getSha256Backend, setSha256Backend } from "./sha256.ts";

--- a/obj/src/mod.ts
+++ b/obj/src/mod.ts
@@ -21,3 +21,7 @@ export {
   Base64UrlCodec,
   Base64UrlPaddedCodec,
 } from "./internal_mod.ts";
+
+export type { Sha256Backend } from "./internal_mod.ts";
+
+export { getSha256Backend, setSha256Backend } from "./internal_mod.ts";

--- a/obj/src/objectstore.ts
+++ b/obj/src/objectstore.ts
@@ -31,6 +31,7 @@ import {
 
 import type {
   ConsumerConfig,
+  FastIngest,
   JetStreamClient,
   JetStreamClientImpl,
   JetStreamManager,
@@ -55,6 +56,7 @@ import {
   JsHeaders,
   ListerImpl,
   PubHeaders,
+  startFastIngest,
   StoreCompression,
   toJetStreamClient,
 } from "@nats-io/jetstream/internal";
@@ -71,7 +73,7 @@ import type {
   ObjectWatchInfo,
 } from "./types.ts";
 import { Base64UrlPaddedCodec } from "./base64.ts";
-import { sha256 } from "js-sha256";
+import { createSha256 } from "./sha256.ts";
 import { checkSha256, parseSha256 } from "./sha_digest.parser.ts";
 
 export const osPrefix = "OBJ_";
@@ -128,9 +130,12 @@ export class Objm {
     const os = new ObjectStoreImpl(name, jsm, this.js);
     os.stream = objectStoreStreamName(name);
     if (check) {
-      await os.status();
+      const status = await os.status();
+      os.supportsFastIngest = status.streamInfo.config.allow_batched === true;
     }
-    return Promise.resolve(os);
+    // when check=false we skip the capability probe; supportsFastIngest stays
+    // at its default (false) — safer than assuming the server supports it
+    return os;
   }
 
   #maybeCreate(
@@ -332,11 +337,12 @@ function emptyReadableStream(): ReadableStream {
 
 export class ObjectStoreImpl implements ObjectStore {
   jsm: JetStreamManager;
-  js: JetStreamClient;
+  js: JetStreamClientImpl;
   stream!: string;
   name: string;
+  supportsFastIngest = false;
 
-  constructor(name: string, jsm: JetStreamManager, js: JetStreamClient) {
+  constructor(name: string, jsm: JetStreamManager, js: JetStreamClientImpl) {
     this.name = name;
     this.jsm = jsm;
     this.js = js;
@@ -442,8 +448,7 @@ export class ObjectStoreImpl implements ObjectStore {
     opts.timeout = opts.timeout || jsopts.timeout;
     opts.previousRevision = opts.previousRevision ?? undefined;
     const { timeout, previousRevision } = opts;
-    const si = (this.js as unknown as { nc: NatsConnection }).nc.info;
-    const maxPayload = si?.max_payload || 1024;
+    const maxPayload = this.js.nc.info?.max_payload || 1024;
     meta = meta || {} as ObjectStoreMeta;
     meta.options = meta.options || {};
     let maxChunk = meta.options?.max_chunk_size || 128 * 1024;
@@ -470,9 +475,27 @@ export class ObjectStoreImpl implements ObjectStore {
     const d = deferred<ObjectInfo>();
 
     const db = new DataBuffer();
+    // started lazily on the first chunk so a 0-byte object stays a single publish
+    let fi: FastIngest | null = null;
+
+    const publishChunk = async (payload: Uint8Array): Promise<void> => {
+      if (this.supportsFastIngest) {
+        if (!fi) {
+          fi = await startFastIngest(this.js.nc, chunkSubj, payload, {
+            allowGaps: false,
+            timeout,
+          });
+        } else {
+          await fi.add(chunkSubj, payload, { timeout });
+        }
+        return;
+      }
+      await this.js.publish(chunkSubj, payload, { timeout });
+    };
+
     try {
       const reader = rs ? rs.getReader() : null;
-      const sha = sha256.create();
+      const sha = await createSha256();
 
       while (true) {
         const { done, value } = reader
@@ -485,14 +508,12 @@ export class ObjectStoreImpl implements ObjectStore {
             sha.update(payload);
             info.chunks!++;
             info.size! += payload.length;
-            await this.js.publish(chunkSubj, payload, { timeout });
+            await publishChunk(payload);
           }
 
           // prepare the metadata
           info.mtime = new Date().toISOString();
-          const digest = Base64UrlPaddedCodec.encode(
-            Uint8Array.from(sha.digest()),
-          );
+          const digest = Base64UrlPaddedCodec.encode(sha.digest());
           info.digest = `${digestType}${digest}`;
 
           info.deleted = false;
@@ -507,13 +528,17 @@ export class ObjectStoreImpl implements ObjectStore {
           }
           h.set(JsHeaders.RollupHdr, JsHeaders.RollupValueSubject);
 
-          // try to update the metadata
-          const pa = await this.js.publish(metaSubj, JSON.stringify(info), {
-            headers: h,
-            timeout,
-          });
-          // update the revision to point to the sequence where we inserted
-          info.revision = pa.seq;
+          // cast: closure-captured `let` defeats TS narrowing.
+          const ack = fi
+            ? await (fi as FastIngest).last(metaSubj, JSON.stringify(info), {
+              headers: h,
+              timeout,
+            })
+            : await this.js.publish(metaSubj, JSON.stringify(info), {
+              headers: h,
+              timeout,
+            });
+          info.revision = ack.seq;
 
           // if we are here, the new entry is live
           if (old) {
@@ -539,12 +564,19 @@ export class ObjectStoreImpl implements ObjectStore {
             info.size! += maxChunk;
             const payload = db.drain(meta.options.max_chunk_size);
             sha.update(payload);
-            await this.js.publish(chunkSubj, payload, { timeout });
+            await publishChunk(payload);
           }
         }
       }
     } catch (err) {
-      // we failed, remove any partials
+      if (fi) {
+        // close the batch on the server side; ignore failure
+        try {
+          await (fi as FastIngest).end();
+        } catch (_e) { /* ignore */ }
+      }
+      // cleanup: purge any chunks that landed before the failure, otherwise
+      // we leak orphan chunks under chunkSubj
       await this.jsm.streams.purge(this.stream, { filter: chunkSubj });
       d.reject(err);
     }
@@ -660,7 +692,7 @@ export class ObjectStoreImpl implements ObjectStore {
       return Promise.resolve(r as ObjectResult);
     }
 
-    const sha = sha256.create();
+    const sha = await createSha256();
     let controller: ReadableStreamDefaultController;
 
     const cc: Partial<ConsumerConfig> = {};
@@ -677,7 +709,7 @@ export class ObjectStoreImpl implements ObjectStore {
           controller!.enqueue(jm.data);
         }
         if (jm.info.pending === 0) {
-          const computedDigest = Uint8Array.from(sha.digest());
+          const computedDigest = sha.digest();
           if (!checkSha256(digest, computedDigest)) {
             const hex = Array.from(computedDigest)
               .map((b) => b.toString(16).padStart(2, "0")).join("");
@@ -918,7 +950,7 @@ export class ObjectStoreImpl implements ObjectStore {
     return `$O.${this.name}.M.>`;
   }
 
-  async init(opts: Partial<ObjectStoreOptions> = {}): Promise<void> {
+  async init(opts: Partial<ObjectStoreOptions> = {}): Promise<StreamInfo> {
     try {
       this.stream = objectStoreStreamName(this.name);
     } catch (err) {
@@ -931,6 +963,9 @@ export class ObjectStoreImpl implements ObjectStore {
     // servers 2.12+ reject unknown properties
     const { replicas } = opts;
     delete opts.replicas;
+    // disableFastIngest is an objectstore concept; do not forward to stream config
+    const disableFastIngest = opts.disableFastIngest === true;
+    delete opts.disableFastIngest;
 
     // pacify the tsc compiler downstream
     const sc = Object.assign({ max_age }, opts) as unknown as StreamConfig;
@@ -940,6 +975,11 @@ export class ObjectStoreImpl implements ObjectStore {
     sc.num_replicas = replicas || 1;
     sc.discard = DiscardPolicy.New;
     sc.subjects = [`$O.${this.name}.C.>`, `$O.${this.name}.M.>`];
+    // api_lvl >= 4 ⇒ nats-server 2.14+ supports allow_batched (fast ingest)
+    const apiLvl = this.js.nc.info?.api_lvl ?? 0;
+    if (apiLvl >= 4 && !disableFastIngest) {
+      sc.allow_batched = true;
+    }
     if (opts.placement) {
       sc.placement = opts.placement;
     }
@@ -952,23 +992,35 @@ export class ObjectStoreImpl implements ObjectStore {
         : StoreCompression.None;
     }
 
+    let si: StreamInfo;
     try {
-      await this.jsm.streams.info(sc.name);
+      si = await this.jsm.streams.info(sc.name);
     } catch (err) {
       if ((err as Error).message === "stream not found") {
-        await this.jsm.streams.add(sc);
+        si = await this.jsm.streams.add(sc);
+      } else {
+        throw err;
       }
     }
+    return si;
   }
 
   static async create(
-    js: JetStreamClient,
+    js: JetStreamClientImpl,
     name: string,
     opts: Partial<ObjectStoreOptions> = {},
   ): Promise<ObjectStore> {
     const jsm = await js.jetstreamManager();
     const os = new ObjectStoreImpl(name, jsm, js);
-    await os.init(opts);
-    return Promise.resolve(os);
+    // snapshot before init() — init() deletes the flag from opts when it
+    // strips objectstore-only options out of the stream config
+    const disableFastIngest = opts.disableFastIngest === true;
+    const si = await os.init(opts);
+    // honor disableFastIngest at runtime even if an existing bucket already
+    // has allow_batched=true (init() returns the existing config when the
+    // stream is reused across calls)
+    os.supportsFastIngest = !disableFastIngest &&
+      si.config.allow_batched === true;
+    return os;
   }
 }

--- a/obj/src/sha256.ts
+++ b/obj/src/sha256.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sha256 } from "js-sha256";
+
+/**
+ * Incremental SHA-256 hasher. Same shape across both backends — output bytes
+ * are byte-for-byte identical (verified in `obj/tests/sha256_test.ts`).
+ */
+export type StreamingSha256 = {
+  update(data: Uint8Array): void;
+  digest(): Uint8Array;
+};
+
+/**
+ * SHA-256 backend selector.
+ *
+ * - `"js"` — pure-JS (`js-sha256`). Default. Works in every runtime including
+ *   the browser. Slow (~5-10× slower than native at MB+ payloads).
+ * - `"native"` — `node:crypto` `createHash`. Built into Node, Deno and Bun
+ *   (no extra dependency). Not available in browsers without a polyfill —
+ *   selecting `"native"` in a browser bundle will throw at first put/get.
+ */
+export type Sha256Backend = "js" | "native";
+
+type NodeHash = {
+  update(data: Uint8Array): void;
+  digest(): Uint8Array;
+};
+
+let backend: Sha256Backend = "js";
+let factory: (() => StreamingSha256) | null = null;
+let initPromise: Promise<void> | null = null;
+
+/**
+ * Selects the SHA-256 backend used by Object Store put/get operations.
+ * Default is `"js"` (pure-JS, browser-safe). Apps running on Node, Deno or
+ * Bun can flip to `"native"` for substantially higher throughput on large
+ * objects. The choice is process-wide — call once at startup, before any
+ * Object Store operation.
+ */
+export function setSha256Backend(b: Sha256Backend): void {
+  if (b !== "js" && b !== "native") {
+    throw new Error(`unknown sha256 backend: ${b}`);
+  }
+  if (b === backend) return;
+  backend = b;
+  factory = null;
+  initPromise = null;
+}
+
+/**
+ * Returns the currently selected backend.
+ */
+export function getSha256Backend(): Sha256Backend {
+  return backend;
+}
+
+function jsFactory(): StreamingSha256 {
+  const s = sha256.create();
+  return {
+    update(data: Uint8Array): void {
+      s.update(data);
+    },
+    digest(): Uint8Array {
+      return Uint8Array.from(s.digest());
+    },
+  };
+}
+
+async function init(): Promise<void> {
+  if (factory) return;
+  if (backend === "native") {
+    // indirect specifier — keeps static bundlers from trying to inline this
+    const spec = "node:crypto";
+    const m = await import(spec) as {
+      createHash?: (alg: string) => NodeHash;
+    };
+    if (typeof m?.createHash !== "function") {
+      throw new Error(
+        "sha256 backend 'native' selected but `node:crypto` is not available in this runtime",
+      );
+    }
+    const create = m.createHash;
+    factory = () => {
+      const h = create("sha256");
+      return {
+        update(data: Uint8Array): void {
+          h.update(data);
+        },
+        digest(): Uint8Array {
+          return new Uint8Array(h.digest());
+        },
+      };
+    };
+    return;
+  }
+  factory = jsFactory;
+}
+
+/**
+ * Returns a new streaming SHA-256 hasher using the currently selected backend.
+ * Resolves the backend lazily on first call after each `setSha256Backend()`.
+ */
+export async function createSha256(): Promise<StreamingSha256> {
+  if (!factory) {
+    initPromise = initPromise ?? init();
+    await initPromise;
+  }
+  const f = factory;
+  if (!f) {
+    // setSha256Backend() was called between await and here; rare race
+    throw new Error("sha256 backend reset during init");
+  }
+  return f();
+}

--- a/obj/src/types.ts
+++ b/obj/src/types.ts
@@ -199,6 +199,19 @@ export type ObjectStoreOptions = {
    * servers 2.10.x and better.
    */
   compression?: boolean;
+  /**
+   * Opt out of fast-ingest (batched publishes) for this bucket. By default, when
+   * the server supports it (api_lvl >= 4, nats-server 2.14+), the underlying
+   * stream is created with `allow_batched: true` and `put` operations pipeline
+   * chunks through a batch for higher throughput. Set to `true` to keep the
+   * legacy per-chunk synchronous publish path.
+   *
+   * Only honored on bucket create — `Objm.open()` enables fast ingest only when
+   * `check=true` (the default) and the underlying stream has
+   * `allow_batched: true`. When `check=false`, fast ingest is disabled because
+   * capability cannot be inferred without a probe.
+   */
+  disableFastIngest?: boolean;
 };
 /**
  * An object that allows reading the object stored under a specified name.

--- a/obj/tests/objectstore_test.ts
+++ b/obj/tests/objectstore_test.ts
@@ -43,6 +43,7 @@ import type {
   ObjectWatchInfo,
 } from "../src/types.ts";
 import {
+  DiscardPolicy,
   jetstream,
   jetstreamManager,
   type PushConsumer,
@@ -51,6 +52,7 @@ import {
 import { equals } from "@std/bytes";
 import { digestType, type ObjectStoreImpl, Objm } from "../src/objectstore.ts";
 import { Base64UrlPaddedCodec } from "../src/base64.ts";
+import { setSha256Backend } from "../src/sha256.ts";
 import { sha256 } from "js-sha256";
 
 function readableStreamFrom(data: Uint8Array): ReadableStream<Uint8Array> {
@@ -1365,6 +1367,230 @@ Deno.test("objectstore - watcherPrefix", async () => {
   const { config: { deliver_subject } } = await oc.info(true);
 
   assertEquals(deliver_subject?.split(".")[0], "hello");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - fast ingest enabled by default", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const objm = new Objm(nc);
+  const os = await objm.create("FI") as ObjectStoreImpl;
+  assertEquals(os.supportsFastIngest, true);
+
+  const jsm = await jetstreamManager(nc);
+  const si = await jsm.streams.info("OBJ_FI");
+  assertEquals(si.config.allow_batched, true);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - disableFastIngest opts out", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const objm = new Objm(nc);
+  const os = await objm.create("NOFI", {
+    disableFastIngest: true,
+  }) as ObjectStoreImpl;
+  assertEquals(os.supportsFastIngest, false);
+
+  const jsm = await jetstreamManager(nc);
+  const si = await jsm.streams.info("OBJ_NOFI");
+  assertEquals(si.config.allow_batched ?? false, false);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - disableFastIngest honored on existing FI bucket", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const objm = new Objm(nc);
+  // first create the bucket WITH fast ingest
+  const fiBucket = await objm.create("EXISTFI") as ObjectStoreImpl;
+  assertEquals(fiBucket.supportsFastIngest, true);
+
+  // re-open via create() with disableFastIngest — stream config still has
+  // allow_batched=true, but the caller opted out so this instance must
+  // not use fast ingest
+  const optOutBucket = await objm.create("EXISTFI", {
+    disableFastIngest: true,
+  }) as ObjectStoreImpl;
+  assertEquals(optOutBucket.supportsFastIngest, false);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - open(check=false) disables fast ingest", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const objm = new Objm(nc);
+  // bucket exists with allow_batched=true on the underlying stream
+  const created = await objm.create("PROBE") as ObjectStoreImpl;
+  assertEquals(created.supportsFastIngest, true);
+
+  // open with check=true picks up the stream's allow_batched flag
+  const probed = await objm.open("PROBE", true) as ObjectStoreImpl;
+  assertEquals(probed.supportsFastIngest, true);
+
+  // open with check=false skips the probe, so capability is unknown — fall
+  // back to the safe default (legacy publish path always works)
+  const noProbe = await objm.open("PROBE", false) as ObjectStoreImpl;
+  assertEquals(noProbe.supportsFastIngest, false);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - fast ingest multi-chunk roundtrip", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  // size that forces multiple chunks at the default 128 KiB chunk size
+  const blob = makeData(512 * 1024 + 31);
+
+  const objm = new Objm(nc);
+  const os = await objm.create("FIBLOB") as ObjectStoreImpl;
+  assertEquals(os.supportsFastIngest, true);
+
+  const oi = await os.put(
+    { name: "BLOB" },
+    readableStreamFrom(blob),
+  );
+  assert(oi.chunks > 1);
+  assertEquals(oi.size, blob.length);
+  assertEquals(oi.digest, digest(blob));
+
+  const or = await os.get("BLOB");
+  assertExists(or);
+  const read = await fromReadableStream(or!.data);
+  assert(equals(read, blob));
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - cross-read: writes with FI readable without FI", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const blob = makeData(300 * 1024);
+  const blobDigest = digest(blob);
+
+  // write with FI enabled (default)
+  const objm = new Objm(nc);
+  const fiBucket = await objm.create("XR_FI") as ObjectStoreImpl;
+  assertEquals(fiBucket.supportsFastIngest, true);
+  const fiOi = await fiBucket.put({ name: "data" }, readableStreamFrom(blob));
+
+  // write with FI disabled — same payload
+  const noFiBucket = await objm.create("XR_NOFI", {
+    disableFastIngest: true,
+  }) as ObjectStoreImpl;
+  assertEquals(noFiBucket.supportsFastIngest, false);
+  const noFiOi = await noFiBucket.put(
+    { name: "data" },
+    readableStreamFrom(blob),
+  );
+
+  // both writes must produce the same digest as the source data
+  assertEquals(fiOi.digest, blobDigest);
+  assertEquals(noFiOi.digest, blobDigest);
+
+  // round-trip both buckets — bytes must match the source byte-for-byte
+  for (const bucket of [fiBucket, noFiBucket]) {
+    const or = await bucket.get("data");
+    assertExists(or);
+    const read = await fromReadableStream(or!.data);
+    assert(equals(read, blob));
+  }
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - cross-read: native-sha write readable, js-sha read verifies digest", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  const blob = makeData(200 * 1024);
+
+  const objm = new Objm(nc);
+
+  try {
+    // write under native sha
+    setSha256Backend("native");
+    const os = await objm.create("XS") as ObjectStoreImpl;
+    const oi = await os.put({ name: "data" }, readableStreamFrom(blob));
+    assertEquals(oi.digest, digest(blob));
+
+    // read under js sha — digest verification on get() must still pass
+    setSha256Backend("js");
+    const or = await os.get("data");
+    assertExists(or);
+    const read = await fromReadableStream(or!.data);
+    assert(equals(read, blob));
+
+    // and the reverse: write js, read native
+    setSha256Backend("js");
+    const os2 = await objm.create("XS2") as ObjectStoreImpl;
+    const oi2 = await os2.put({ name: "data" }, readableStreamFrom(blob));
+    assertEquals(oi2.digest, digest(blob));
+
+    setSha256Backend("native");
+    const or2 = await os2.get("data");
+    assertExists(or2);
+    const read2 = await fromReadableStream(or2!.data);
+    assert(equals(read2, blob));
+  } finally {
+    setSha256Backend("js");
+  }
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - existing bucket without allow_batched uses legacy path", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.14.0")) {
+    return;
+  }
+
+  // pre-create the OBJ stream by hand without allow_batched
+  const jsm = await jetstreamManager(nc);
+  await jsm.streams.add({
+    name: "OBJ_LEGACY",
+    subjects: ["$O.LEGACY.C.>", "$O.LEGACY.M.>"],
+    allow_direct: true,
+    allow_rollup_hdrs: true,
+    discard: DiscardPolicy.New,
+  });
+
+  const objm = new Objm(nc);
+  const os = await objm.open("LEGACY") as ObjectStoreImpl;
+  assertEquals(os.supportsFastIngest, false);
+
+  const blob = makeData(300 * 1024);
+  const oi = await os.put({ name: "X" }, readableStreamFrom(blob));
+  assertEquals(oi.digest, digest(blob));
+
+  const or = await os.get("X");
+  assertExists(or);
+  const read = await fromReadableStream(or!.data);
+  assert(equals(read, blob));
 
   await cleanup(ns, nc);
 });

--- a/obj/tests/sha256_test.ts
+++ b/obj/tests/sha256_test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { sha256 } from "js-sha256";
+import {
+  createSha256,
+  getSha256Backend,
+  setSha256Backend,
+} from "../src/sha256.ts";
+
+function hex(b: Uint8Array): string {
+  return Array.from(b).map((x) => x.toString(16).padStart(2, "0")).join("");
+}
+
+Deno.test("sha256 - matches js-sha256 on single update", async () => {
+  const data = new TextEncoder().encode("hello world");
+  const expected =
+    "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
+
+  const h = await createSha256();
+  h.update(data);
+  assertEquals(hex(h.digest()), expected);
+});
+
+Deno.test("sha256 - chunked equivalent to single buffer", async () => {
+  const total = new Uint8Array(64 * 1024);
+  for (let i = 0; i < total.length; i++) total[i] = (i * 31) & 0xff;
+
+  // chunked through createSha256
+  const h = await createSha256();
+  for (let off = 0; off < total.length; off += 7919) {
+    h.update(total.subarray(off, Math.min(off + 7919, total.length)));
+  }
+  const got = h.digest();
+
+  // single-shot via js-sha256
+  const expected = Uint8Array.from(sha256.create().update(total).digest());
+
+  assertEquals(hex(got), hex(expected));
+});
+
+Deno.test("sha256 - matches js-sha256 across many random sizes", async () => {
+  for (const size of [0, 1, 31, 64, 128, 4096, 65537, 250_000]) {
+    const buf = new Uint8Array(size);
+    crypto.getRandomValues(buf.subarray(0, Math.min(size, 65536)));
+
+    const h = await createSha256();
+    h.update(buf);
+    const got = hex(h.digest());
+
+    const exp = hex(Uint8Array.from(sha256.create().update(buf).digest()));
+    assertEquals(got, exp, `mismatch at size ${size}`);
+  }
+});
+
+Deno.test("sha256 - returns 32 bytes", async () => {
+  const h = await createSha256();
+  h.update(new Uint8Array(0));
+  const out = h.digest();
+  assert(out instanceof Uint8Array);
+  assertEquals(out.length, 32);
+});
+
+Deno.test("sha256 - default backend is js", () => {
+  // since this test file imports a fresh module instance per Deno.test file,
+  // initial state should be the documented default.
+  setSha256Backend("js");
+  assertEquals(getSha256Backend(), "js");
+});
+
+Deno.test("sha256 - native backend matches js backend", async () => {
+  const data = new TextEncoder().encode(
+    "the quick brown fox jumps over the lazy dog",
+  );
+
+  setSha256Backend("js");
+  const j = await createSha256();
+  j.update(data);
+  const jOut = j.digest();
+
+  setSha256Backend("native");
+  const n = await createSha256();
+  n.update(data);
+  const nOut = n.digest();
+
+  assertEquals(jOut.length, 32);
+  assertEquals(nOut.length, 32);
+  assertEquals(hex(jOut), hex(nOut));
+
+  setSha256Backend("js");
+});
+
+Deno.test("sha256 - unknown backend rejected", () => {
+  assertThrows(
+    () => {
+      // deno-lint-ignore no-explicit-any
+      setSha256Backend("md5" as any);
+    },
+    Error,
+    "unknown sha256 backend",
+  );
+});


### PR DESCRIPTION
> ⚠️ **Stacked PR** — base is [#393](https://github.com/nats-io/nats.js/pull/393) (`add-api-lvl-info`), not `main`. PR #393 must merge first. Only review changes specific to this branch (`obj/` files); the diff against `main` will also include #393's content until that lands.

Resolves #362.

Two stacked wins for Object Store throughput on top of the api_lvl exposure from #393.

## 1. Fast ingest (batched publish)

Object Store buckets created on a server with `api_lvl >= 4` (nats-server 2.14+) get `allow_batched: true` on the underlying stream. `_put` pipelines chunks via `startFastIngest`, committing the meta message with `fi.last()` — atomic, chunks + meta land or none. On abort: `fi.end()` plus a defensive `chunkSubj` purge.

Caller can opt out via `ObjectStoreOptions.disableFastIngest: true`.

Pre-existing buckets without `allow_batched` continue on the legacy per-chunk publish path (auto-detected via `streams.info`, cached as `ObjectStoreImpl.supportsFastIngest`).

## 2. Native SHA-256 backend

New `setSha256Backend("js" | "native")` API on `@nats-io/obj`.

- `"js"` (default) — pure-JS `js-sha256`. Browser-safe, slow.
- `"native"` — `node:crypto` `createHash`. Built into Node, Deno, Bun (no new dependency). 5-10× faster on multi-MB payloads.

Backends produce byte-identical digests (verified in tests).

## Bench — 1 GiB into memory store

local nats-server 2.15.0-dev:

| sha    | ingest | throughput | vs baseline |
|--------|--------|-----------:|------------:|
| js     | legacy | 101 MiB/s  |        1.0× |
| js     | FI     | 122 MiB/s  |        1.2× |
| native | legacy | 526 MiB/s  |        5.2× |
| native | FI     | 1.16 GiB/s |       11.7× |

## Real-CLI smoke (aricart/obj, 1 GiB roundtrip, file storage, FI active)

| op  | sha    | rate       |
|-----|--------|-----------:|
| put | js     | 116 MiB/s  |
| put | native | 627 MiB/s  |
| get | js     | 117 MiB/s  |
| get | native | 941 MiB/s  |

## Tests

- 4 fast-ingest tests (default-on, opt-out, multi-chunk roundtrip, legacy-bucket fallback)
- 2 cross-read tests (FI on/off readable from each other; native/js sha digest equivalence)
- 7 sha256 tests (known-vector, chunked, random sizes, backend switch, error cases)
- 78 total obj tests pass

## Files

- `obj/src/objectstore.ts` — fast ingest wiring + native sha use
- `obj/src/sha256.ts` (new) — backend selector + dispatch
- `obj/src/types.ts` — `disableFastIngest?` opt-out
- `obj/src/internal_mod.ts`, `obj/src/mod.ts` — re-exports
- `obj/tests/objectstore_test.ts` — fast-ingest + cross-read tests
- `obj/tests/sha256_test.ts` (new) — equivalence + backend tests
- `obj/bench/fast_ingest_bench.ts` (new) — manual 2x2 throughput bench

No new dependencies.