### PR TITLE
feat: add `Symbol.asyncDispose` support for connections and subscriptions

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -447,6 +447,13 @@ export interface NatsConnection {
   drain(): Promise<void>;
 
   /**
+   * Implements the `AsyncDisposable` protocol so the connection can be used
+   * with `await using`. Equivalent to calling {@link drain}; if the connection
+   * is already closed or draining, resolves without error.
+   */
+  [Symbol.asyncDispose](): Promise<void>;
+
+  /**
    * Returns true if the client is closed.
    */
   isClosed(): boolean;
@@ -607,6 +614,13 @@ export interface Subscription extends AsyncIterable<Msg> {
    * when the subscription finished draining.
    */
   drain(): Promise<void>;
+
+  /**
+   * Implements the `AsyncDisposable` protocol so the subscription can be used
+   * with `await using`. Equivalent to calling {@link drain}; if the
+   * subscription is already closed or draining, resolves without error.
+   */
+  [Symbol.asyncDispose](): Promise<void>;
 
   /**
    * Returns true if the subscription is draining.

--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -487,6 +487,17 @@ export class NatsConnectionImpl implements NatsConnection {
     return this.protocol.drain();
   }
 
+  async [Symbol.asyncDispose](): Promise<void> {
+    if (this.isClosed()) {
+      return;
+    }
+    if (this.isDraining()) {
+      await this.closed();
+      return;
+    }
+    await this.drain();
+  }
+
   isClosed(): boolean {
     return this.protocol.isClosed();
   }

--- a/core/src/protocol.ts
+++ b/core/src/protocol.ts
@@ -260,6 +260,17 @@ export class SubscriptionImpl extends QueuedIteratorImpl<Msg>
     return this.drained;
   }
 
+  async [Symbol.asyncDispose](): Promise<void> {
+    if (this.protocol.isClosed() || this.isClosed()) {
+      return;
+    }
+    if (this.drained) {
+      await this.drained;
+      return;
+    }
+    await this.drain();
+  }
+
   isDraining(): boolean {
     return this.draining;
   }

--- a/core/tests/dispose_test.ts
+++ b/core/tests/dispose_test.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { assert, assertEquals } from "@std/assert";
+import { cleanup, NatsServer, setup } from "nst";
+import { connect } from "./connect.ts";
+import { createInbox } from "../src/internal_mod.ts";
+import type { NatsConnection, Subscription } from "../src/mod.ts";
+
+Deno.test("dispose - connection await using calls drain", async () => {
+  const ns = await NatsServer.start();
+  let captured: NatsConnection;
+  {
+    await using nc = await connect({ port: ns.port });
+    captured = nc;
+    assertEquals(nc.isClosed(), false);
+  }
+  assert(captured!.isClosed(), "connection should be closed after scope exit");
+  assertEquals(await captured!.closed(), undefined);
+  await ns.stop();
+});
+
+Deno.test("dispose - connection async dispose is idempotent when closed", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  await nc.close();
+  assert(nc.isClosed());
+  // should resolve, not reject
+  await nc[Symbol.asyncDispose]();
+  await ns.stop();
+});
+
+Deno.test("dispose - connection async dispose awaits in-flight drain", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const draining = nc.drain();
+  await nc[Symbol.asyncDispose]();
+  await draining;
+  assert(nc.isClosed());
+  await ns.stop();
+});
+
+Deno.test("dispose - subscription await using drains", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const subj = createInbox();
+  let count = 0;
+  let captured: Subscription;
+  {
+    await using sub = nc.subscribe(subj, {
+      callback: () => {
+        count++;
+      },
+    });
+    captured = sub;
+    nc.publish(subj);
+    nc.publish(subj);
+    await nc.flush();
+  }
+  assert(
+    captured!.isClosed(),
+    "subscription should be closed after scope exit",
+  );
+  assertEquals(await captured!.closed, undefined);
+  assertEquals(count, 2);
+  await nc.close();
+  await ns.stop();
+});
+
+Deno.test("dispose - iterator subscription await using drains", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const subj = createInbox();
+  let count = 0;
+  let captured: Subscription;
+  {
+    await using sub = nc.subscribe(subj, { max: 2 });
+    captured = sub;
+    const iter = (async () => {
+      for await (const _ of sub) {
+        count++;
+      }
+    })();
+    nc.publish(subj);
+    nc.publish(subj);
+    await iter;
+  }
+  assert(captured!.isClosed());
+  assertEquals(await captured!.closed, undefined);
+  assertEquals(count, 2);
+  await nc.close();
+  await ns.stop();
+});
+
+Deno.test("dispose - iterator subscription closed promise resolves on dispose", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const subj = createInbox();
+  const sub = nc.subscribe(subj);
+  const iter = (async () => {
+    for await (const _ of sub) {
+      // drain msgs
+    }
+  })();
+  await sub[Symbol.asyncDispose]();
+  await iter;
+  assert(sub.isClosed());
+  assertEquals(await sub.closed, undefined);
+  await nc.close();
+  await ns.stop();
+});
+
+Deno.test("dispose - subscription async dispose is idempotent when closed", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const sub = nc.subscribe(createInbox(), { callback: () => {} });
+  await sub.drain();
+  assert(sub.isClosed());
+  assertEquals(await sub.closed, undefined);
+  await sub[Symbol.asyncDispose]();
+  await nc.close();
+  await ns.stop();
+});
+
+Deno.test("dispose - subscription async dispose awaits in-flight drain", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const sub = nc.subscribe(createInbox(), { callback: () => {} });
+  const draining = sub.drain();
+  await sub[Symbol.asyncDispose]();
+  await draining;
+  assert(sub.isClosed());
+  assertEquals(await sub.closed, undefined);
+  await nc.close();
+  await ns.stop();
+});
+
+Deno.test("dispose - subscription async dispose when connection closed", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const sub = nc.subscribe(createInbox());
+  await nc.close();
+  // should resolve, not throw
+  await sub[Symbol.asyncDispose]();
+  await ns.stop();
+});
+
+Deno.test("dispose - script use", async () => {
+  const { ns, nc } = await setup();
+  nc.subscribe("q", {
+    callback: (_, msg) => {
+      msg.respond();
+    },
+  });
+
+  let counter = 0;
+
+  const oneShot = async function (): Promise<void> {
+    counter++;
+    await using c = await connect({ port: ns.port });
+    c.closed().then(() => {
+      console.log("connection", counter, "closed");
+    });
+
+    await using sub = c.subscribe("q");
+    (async () => {
+      for await (const _ of sub) {
+        console.log("sub", counter, "got message");
+      }
+    })().catch();
+
+    sub.closed.then(() => {
+      console.log("sub", counter, "closed");
+    });
+    await c.request("q");
+  };
+
+  await oneShot();
+  await oneShot();
+
+  await cleanup(ns, nc);
+});

--- a/core/tests/dispose_test.ts
+++ b/core/tests/dispose_test.ts
@@ -178,7 +178,7 @@ Deno.test("dispose - script use", async () => {
       for await (const _ of sub) {
         console.log("sub", counter, "got message");
       }
-    })().catch();
+    })().catch((_) => {});
 
     sub.closed.then(() => {
       console.log("sub", counter, "closed");

--- a/nst/src/launcher.ts
+++ b/nst/src/launcher.ts
@@ -303,6 +303,10 @@ export class NatsServer implements PortInfo {
     await Promise.all(cleanups);
   }
 
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.stop(true);
+  }
+
   signal(signal: string): Promise<void> {
     if (signal === ServerSignals.KILL) {
       return this.stop();

--- a/nst/src/mod.ts
+++ b/nst/src/mod.ts
@@ -103,15 +103,27 @@ export function wsServerConf(opts: unknown = {}): Record<string, unknown> {
   return Object.assign(wsopts(), opts);
 }
 
+export type SetupContext = {
+  ns: NatsServer;
+  nc: NatsConnection;
+  [Symbol.asyncDispose](): Promise<void>;
+};
+
 export async function setup(
   serverConf?: Record<string, unknown>,
   clientOpts?: Partial<ConnectionOptions>,
-): Promise<{ ns: NatsServer; nc: NatsConnection }> {
+): Promise<SetupContext> {
   const dt = serverConf as { debug?: boolean; trace?: boolean };
   const debug = !!(dt && (dt.debug || dt.trace));
   const ns = await NatsServer.start(serverConf, debug);
   const nc = await ns.connect(clientOpts);
-  return { ns, nc };
+  return {
+    ns,
+    nc,
+    [Symbol.asyncDispose]() {
+      return cleanup(ns, nc);
+    },
+  };
 }
 
 export async function cleanup(


### PR DESCRIPTION
- `AsyncDisposable` protocol for `NatsConnection` and `Subscription`, enabling scoped resource management with `await using`.

Fixes #357