### PR TITLE
feat(core): setServers/getServers

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -233,23 +233,59 @@ export interface ServerInfo {
 }
 
 export interface Server {
-  hostname: string;
-  port: number;
-  listen: string;
-  src: string;
-  tlsName: string;
-
-  resolve(
-    opts: Partial<
-      {
-        fn: DnsResolveFn;
-        randomize: boolean;
-        debug?: boolean;
-        resolve?: boolean;
-      }
-    >,
-  ): Promise<Server[]>;
+  readonly hostname: string;
+  readonly port: number;
+  readonly listen: string;
+  readonly src: string;
+  readonly tlsName: string;
+  readonly reconnects: number;
+  readonly lastConnect: number;
+  readonly gossiped: boolean;
+  readonly didConnect: boolean;
 }
+
+/**
+ * @hidden
+ */
+export interface ServerSelectionContext {
+  setServers(servers: string[]): ReadonlyArray<Server>;
+}
+
+/**
+ * @hidden
+ *
+ * ReconnectToServerHandler is invoked on every connection attempt (initial
+ * connect and reconnects). It receives a snapshot of the current server pool,
+ * with the server the client would have selected at index 0, the most recent
+ * ServerInfo (null on initial connect, before any INFO has been received),
+ * and a ServerSelectionContext for optionally replacing the pool.
+ *
+ * Return one of:
+ *   - a `Server` from the (possibly mutated) pool: the client will dial it
+ *     immediately.
+ *   - `{ server, delay }`: the client will wait `delay` milliseconds (on top
+ *     of any reconnect backoff already applied) before dialing `server`.
+ *     Useful for application-level pacing — not for reconnect backoff
+ *     (configure that via {@link ConnectionOptions.reconnectDelayHandler}).
+ *     The delay is interruptible by `nc.close()`.
+ *   - `null`: defer to default selection (pool[0]).
+ *
+ * The handler must be synchronous and must not throw. If it throws or
+ * returns a Server that is not in the pool, the connection is rejected on
+ * initial connect or closed on reconnect with a ConnectionError wrapping
+ * the underlying cause.
+ *
+ * Reconnect backoff (reconnectTimeWait, reconnectJitter,
+ * reconnectDelayHandler) is applied by the client before invoking this
+ * handler — the handler only selects which server to dial, and may
+ * optionally request additional pre-dial delay via the `{server, delay}`
+ * return shape.
+ */
+export type ReconnectToServerHandler = (
+  pool: ReadonlyArray<Server>,
+  info: ServerInfo | null,
+  ctl: ServerSelectionContext,
+) => Server | { server: Server; delay: number } | null;
 
 /**
  * ServerChanged records servers in the cluster that were added or deleted.
@@ -514,6 +550,27 @@ export interface NatsConnection {
    * this API has no effect, as the client is already attempting to reconnect.
    */
   reconnect(): Promise<void>;
+
+  /**
+   * Replace the client's server pool with the provided list of `host:port`
+   * entries. The new pool is used for subsequent reconnect attempts. The
+   * live connection is not dropped — call {@link reconnect} afterwards to
+   * force the client to switch onto the new pool immediately.
+   *
+   * Throws if `servers` is empty or contains invalid entries. Removing all
+   * reachable servers from the pool can leave the client unable to reconnect.
+   */
+  setServers(servers: string[]): void;
+
+  /**
+   * Returns the current server pool, including gossiped entries received
+   * from the cluster. Each entry exposes `gossiped`, `reconnects`,
+   * `lastConnect`, and `didConnect` for filtering and diagnostics.
+   *
+   * To round-trip with {@link setServers}, map to listens:
+   * `nc.getServers().map(s => s.listen)`.
+   */
+  getServers(): ReadonlyArray<Server>;
 }
 
 /**
@@ -994,6 +1051,14 @@ export interface ConnectionOptions {
    * option to true, will throw an exception as this option is not available.
    */
   resolve?: boolean;
+
+  /**
+   * @hidden
+   *
+   * Optional handler invoked on every connection attempt to choose which
+   * server the client should dial next. See {@link ReconnectToServerHandler}.
+   */
+  reconnectToServer?: ReconnectToServerHandler;
 }
 
 /**

--- a/core/src/nats.ts
+++ b/core/src/nats.ts
@@ -37,6 +37,7 @@ import type {
   QueuedIterator,
   RequestManyOptions,
   RequestOptions,
+  Server,
   ServerInfo,
   Stats,
   Status,
@@ -509,6 +510,14 @@ export class NatsConnectionImpl implements NatsConnection {
   getServer(): string {
     const srv = this.protocol.getServer();
     return srv ? srv.listen : "";
+  }
+
+  setServers(servers: string[]): void {
+    this.protocol.servers.setServers(servers);
+  }
+
+  getServers(): ReadonlyArray<Server> {
+    return this.protocol.servers.snapshot();
   }
 
   status(): AsyncIterable<Status> {

--- a/core/src/protocol.ts
+++ b/core/src/protocol.ts
@@ -69,6 +69,15 @@ const ERR_RECONNECT_HANDLER_FAILED =
   "client option reconnectToServer handler failed";
 const ERR_RECONNECT_HANDLER_NOT_IN_POOL = "returned server is not in the pool";
 
+function isDelayedServer(
+  x: unknown,
+): x is { server: Server; delay: number } {
+  return (
+    x !== null && typeof x === "object" &&
+    "server" in x && "delay" in x
+  );
+}
+
 export class Connect {
   echo?: boolean;
   no_responders?: boolean;
@@ -681,13 +690,9 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
               ctl,
             );
             let picked: Server | null;
-            if (
-              r !== null && typeof r === "object" &&
-              "server" in r && "delay" in r
-            ) {
+            if (isDelayedServer(r)) {
               picked = r.server;
-              extraDelay = typeof r.delay === "number" &&
-                  Number.isFinite(r.delay) && r.delay > 0
+              extraDelay = Number.isFinite(r.delay) && r.delay > 0
                 ? Math.floor(r.delay)
                 : 0;
             } else {

--- a/core/src/protocol.ts
+++ b/core/src/protocol.ts
@@ -708,6 +708,16 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
                 this.servers.setCurrent(target);
                 this.server = target;
               }
+            } else {
+              // picked === null = "use default selection". If the handler
+              // also called ctl.setServers(), srv may not be in the new
+              // pool; fall back to whatever the pool currently considers
+              // the default (the head it advanced to on replacement).
+              const cur = this.servers.getCurrentServer();
+              if (cur !== srv) {
+                target = cur;
+                this.server = target;
+              }
             }
           } catch (cause) {
             const c = cause instanceof Error ? cause : new Error(String(cause));

--- a/core/src/protocol.ts
+++ b/core/src/protocol.ts
@@ -39,6 +39,7 @@ import type {
   Request,
   Server,
   ServerInfo,
+  ServerSelectionContext,
   Status,
   Subscription,
   SubscriptionOptions,
@@ -63,6 +64,10 @@ export const INFO = /^INFO\s+([^\r\n]+)\r\n/i;
 
 const PONG_CMD = encode("PONG\r\n");
 const PING_CMD = encode("PING\r\n");
+
+const ERR_RECONNECT_HANDLER_FAILED =
+  "client option reconnectToServer handler failed";
+const ERR_RECONNECT_HANDLER_NOT_IN_POOL = "returned server is not in the pool";
 
 export class Connect {
   echo?: boolean;
@@ -441,9 +446,10 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       ? [options.servers]
       : options.servers;
 
-    this.servers = new Servers(servers, {
+    this.servers = new Servers({
       randomize: !options.noRandomize,
     });
+    this.servers.setServers(servers as string[]);
     this.closed = deferred<Error | void>();
     this.parser = new Parser(this);
 
@@ -592,7 +598,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
   }
 
-  async _doDial(srv: Server): Promise<void> {
+  async _doDial(srv: ServerImpl): Promise<void> {
     const { resolve } = this.options;
     const alts = await srv.resolve({
       fn: getResolveFn(),
@@ -658,9 +664,61 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       }
       const now = Date.now();
       if (srv.lastConnect === 0 || srv.lastConnect + wait <= now) {
-        srv.lastConnect = Date.now();
+        let target = srv;
+        let extraDelay = 0;
+        if (this.options.reconnectToServer) {
+          const ctl: ServerSelectionContext = {
+            setServers: (servers: string[]): ReadonlyArray<Server> => {
+              this.servers.setServers(servers);
+              return this.servers.snapshotForHandler();
+            },
+          };
+          try {
+            const snap = this.servers.snapshotForHandler();
+            const r = this.options.reconnectToServer(
+              snap,
+              this.info ?? null,
+              ctl,
+            );
+            let picked: Server | null;
+            if (
+              r !== null && typeof r === "object" &&
+              "server" in r && "delay" in r
+            ) {
+              picked = r.server;
+              extraDelay = typeof r.delay === "number" &&
+                  Number.isFinite(r.delay) && r.delay > 0
+                ? Math.floor(r.delay)
+                : 0;
+            } else {
+              picked = r;
+            }
+            if (picked !== null) {
+              const found = this.servers.find(picked);
+              if (!found) {
+                throw new Error(ERR_RECONNECT_HANDLER_NOT_IN_POOL);
+              }
+              if (found !== srv) {
+                target = found;
+                this.servers.setCurrent(target);
+                this.server = target;
+              }
+            }
+          } catch (cause) {
+            const c = cause instanceof Error ? cause : new Error(String(cause));
+            throw new errors.ConnectionError(
+              `${ERR_RECONNECT_HANDLER_FAILED}: ${c.message}`,
+              { cause: c },
+            );
+          }
+        }
+        if (extraDelay > 0) {
+          this.dialDelay = delay(extraDelay);
+          await this.dialDelay;
+        }
+        target.lastConnect = Date.now();
         try {
-          await this._doDial(srv);
+          await this._doDial(target);
           break;
         } catch (err) {
           lastError = err as Error;
@@ -670,9 +728,9 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
             }
             this.servers.removeCurrentServer();
           }
-          srv.reconnects++;
+          target.reconnects++;
           const mra = this.options.maxReconnectAttempts || 0;
-          if (mra !== -1 && srv.reconnects >= mra) {
+          if (mra !== -1 && target.reconnects >= mra) {
             this.servers.removeCurrentServer();
           }
         }

--- a/core/src/servers.ts
+++ b/core/src/servers.ts
@@ -223,7 +223,14 @@ export class Servers {
       hp = urlParseFn ? urlParseFn(hp) : hp;
       const { listen } = hostPort(hp);
       const surviving = existing.get(listen);
-      merged.push(surviving ?? new ServerImpl(hp));
+      if (surviving) {
+        // user-supplied = not gossiped. otherwise a later cluster update()
+        // could remove an entry the user explicitly asked for.
+        surviving.gossiped = false;
+        merged.push(surviving);
+      } else {
+        merged.push(new ServerImpl(hp));
+      }
     }
     if (this.randomize) shuffle(merged);
 

--- a/core/src/servers.ts
+++ b/core/src/servers.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { defaultPort, getUrlParseFn } from "./transport.ts";
+import { getUrlParseFn } from "./transport.ts";
 import { shuffle } from "./util.ts";
 import { isIP } from "./ipparser.ts";
 import type {
@@ -21,7 +21,8 @@ import type {
   ServerInfo,
   ServersChanged,
 } from "./core.ts";
-import { DEFAULT_HOST, DEFAULT_PORT } from "./core.ts";
+import { DEFAULT_PORT } from "./core.ts";
+import { InvalidArgumentError } from "./errors.ts";
 
 export function isIPV4OrHostname(hp: string): boolean {
   // in the wild seeing IPv4s as IPv6s
@@ -188,34 +189,52 @@ export class ServerImpl implements Server {
  */
 export class Servers {
   private firstSelect: boolean;
-  private readonly servers: ServerImpl[];
-  private currentServer: ServerImpl;
+  private servers: ServerImpl[];
+  private currentServer!: ServerImpl;
   private tlsName: string;
   private randomize: boolean;
 
-  constructor(
-    listens: string[] = [],
-    opts: Partial<{ randomize: boolean }> = {},
-  ) {
+  constructor(opts: Partial<{ randomize: boolean }> = {}) {
     this.firstSelect = true;
-    this.servers = [] as ServerImpl[];
+    this.servers = [];
     this.tlsName = "";
     this.randomize = opts.randomize || false;
+  }
 
+  /**
+   * Replace the server pool with the provided list of `host:port` entries.
+   *
+   * Throws `InvalidArgumentError` if `listens` is empty or not an array.
+   *
+   * Note: reconnect attempts continue to follow the configured reconnect
+   * policy, but if every entry in the new pool is unreachable the
+   * connection may be left unable to recover.
+   */
+  setServers(listens: string[]): void {
+    if (!Array.isArray(listens) || listens.length === 0) {
+      throw InvalidArgumentError.format("servers", "cannot be empty");
+    }
     const urlParseFn = getUrlParseFn();
-    if (listens) {
-      listens.forEach((hp) => {
-        hp = urlParseFn ? urlParseFn(hp) : hp;
-        this.servers.push(new ServerImpl(hp));
-      });
-      if (this.randomize) {
-        this.servers = shuffle(this.servers);
-      }
+    const existing = new Map<string, ServerImpl>();
+    for (const s of this.servers) existing.set(s.listen, s);
+
+    const merged: ServerImpl[] = [];
+    for (let hp of listens) {
+      hp = urlParseFn ? urlParseFn(hp) : hp;
+      const { listen } = hostPort(hp);
+      const surviving = existing.get(listen);
+      merged.push(surviving ?? new ServerImpl(hp));
     }
-    if (this.servers.length === 0) {
-      this.addServer(`${DEFAULT_HOST}:${defaultPort()}`, false);
+    if (this.randomize) shuffle(merged);
+
+    this.servers = merged;
+    if (
+      this.currentServer === undefined ||
+      !merged.includes(this.currentServer)
+    ) {
+      this.currentServer = merged[0];
+      this.firstSelect = true;
     }
-    this.currentServer = this.servers[0];
   }
 
   clear(): void {
@@ -273,6 +292,53 @@ export class Servers {
     }
   }
 
+  /**
+   * Returns a frozen snapshot of the server pool in natural order.
+   * Each entry is a defensive copy — callers cannot mutate pool state.
+   */
+  snapshot(): ReadonlyArray<Server> {
+    return Servers.freezeAll(this.servers);
+  }
+
+  /**
+   * Returns a frozen snapshot of the server pool with the current server
+   * (= next dial candidate) at index 0. Used to present the handler with
+   * the server the library would have selected.
+   */
+  snapshotForHandler(): ReadonlyArray<Server> {
+    const cur = this.currentServer;
+    if (!cur) return this.snapshot();
+    const idx = this.servers.indexOf(cur);
+    if (idx <= 0) return this.snapshot();
+    return Servers.freezeAll(
+      [cur, ...this.servers.slice(0, idx), ...this.servers.slice(idx + 1)],
+    );
+  }
+
+  private static freezeAll(arr: ServerImpl[]): ReadonlyArray<Server> {
+    return arr.map((s) =>
+      Object.freeze<Server>({
+        hostname: s.hostname,
+        port: s.port,
+        listen: s.listen,
+        src: s.src,
+        tlsName: s.tlsName,
+        reconnects: s.reconnects,
+        lastConnect: s.lastConnect,
+        gossiped: s.gossiped,
+        didConnect: s.didConnect,
+      })
+    );
+  }
+
+  find(server: Server): ServerImpl | undefined {
+    return this.servers.find((s) => s.listen === server.listen);
+  }
+
+  setCurrent(server: ServerImpl): void {
+    this.currentServer = server;
+  }
+
   length(): number {
     return this.servers.length;
   }
@@ -325,6 +391,16 @@ export class Servers {
       this.servers.push(v);
       added.push(k);
     });
+
+    // shuffle the pool so reconnect picks distribute across the cluster.
+    // currentServer is held at the head — the live connection isn't
+    // disturbed, but rotation order through the rest is randomized.
+    if (this.randomize && added.length > 0) {
+      const cur = this.currentServer;
+      const others = this.servers.filter((s) => s !== cur);
+      shuffle(others);
+      this.servers = cur ? [cur, ...others] : others;
+    }
 
     return { added, deleted };
   }

--- a/core/tests/properties_test.ts
+++ b/core/tests/properties_test.ts
@@ -151,7 +151,8 @@ Deno.test("properties - port is only honored if no servers provided", () => {
 
   buf.forEach((t) => {
     const opts = parseOptions(t.opts);
-    const servers = new Servers(opts.servers as string[], {});
+    const servers = new Servers();
+    servers.setServers(opts.servers as string[]);
     const cs = servers.getCurrentServer();
     assertEquals(cs.listen, t.expected);
   });

--- a/core/tests/reconnect_test.ts
+++ b/core/tests/reconnect_test.ts
@@ -12,7 +12,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assert, assertEquals, assertInstanceOf, fail } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+  fail,
+} from "@std/assert";
 import { connect } from "./connect.ts";
 import { Lock, NatsServer } from "nst";
 import {
@@ -23,6 +30,7 @@ import {
   delay,
   tokenAuthenticator,
 } from "../src/internal_mod.ts";
+import type { Server } from "../src/internal_mod.ts";
 import type { NatsConnectionImpl } from "../src/nats.ts";
 
 import { cleanup, setup } from "nst";
@@ -468,4 +476,185 @@ Deno.test("reconnect - authentication timeout reconnects", async () => {
   assert(!nc.isClosed());
 
   await cleanup(ns, nc);
+});
+
+Deno.test("reconnectToServer - handler invoked on initial connect", async () => {
+  let calls = 0;
+  let lastPoolLen = -1;
+  await using ctx = await setup({}, {
+    reconnectToServer: (pool) => {
+      calls++;
+      lastPoolLen = pool.length;
+      return pool[0];
+    },
+  });
+  assertEquals(calls, 1);
+  assertEquals(lastPoolLen, 1);
+  assert(!ctx.nc.isClosed());
+  assertEquals(ctx.nc.getServer(), `127.0.0.1:${ctx.ns.port}`);
+});
+
+Deno.test("reconnectToServer - returning null uses default", async () => {
+  await using ctx = await setup({}, {
+    reconnectToServer: () => null,
+  });
+  assertEquals(ctx.nc.getServer(), `127.0.0.1:${ctx.ns.port}`);
+});
+
+Deno.test("reconnectToServer - handler throws rejects connect()", async () => {
+  await using ns = await NatsServer.start();
+  await assertRejects(
+    () =>
+      ns.connect({
+        reconnectToServer: () => {
+          throw new Error("boom");
+        },
+      }),
+    ConnectionError,
+    "client option reconnectToServer handler failed: boom",
+  );
+});
+
+Deno.test("reconnectToServer - out-of-pool rejects connect()", async () => {
+  await using ns = await NatsServer.start();
+  const fake: Server = {
+    hostname: "9.9.9.9",
+    port: 9999,
+    listen: "9.9.9.9:9999",
+    src: "9.9.9.9:9999",
+    tlsName: "",
+    reconnects: 0,
+    lastConnect: 0,
+    gossiped: false,
+    didConnect: false,
+  };
+  await assertRejects(
+    () => ns.connect({ reconnectToServer: () => fake }),
+    ConnectionError,
+    "client option reconnectToServer handler failed: returned server is not in the pool",
+  );
+});
+
+Deno.test("reconnectToServer - throws on reconnect closes connection", async () => {
+  await using ns = await NatsServer.start();
+  let calls = 0;
+  const nc = await ns.connect({
+    reconnectTimeWait: 100,
+    maxReconnectAttempts: -1,
+    reconnectToServer: (pool) => {
+      calls++;
+      if (calls === 1) return pool[0];
+      throw new Error("boom-reconnect");
+    },
+  });
+  await ns.stop();
+  const err = await nc.closed();
+  assertInstanceOf(err, ConnectionError);
+  assertStringIncludes((err as Error).message, "boom-reconnect");
+});
+
+Deno.test("reconnectToServer - ctl.setServers routes initial connect to new pool", async () => {
+  await using target = await NatsServer.start();
+  await using bogus = await NatsServer.start();
+  await bogus.stop();
+  let replaced = false;
+  const nc = await connect({
+    port: bogus.port,
+    waitOnFirstConnect: true,
+    reconnectTimeWait: 100,
+    maxReconnectAttempts: -1,
+    reconnectToServer: (pool, _info, ctl) => {
+      if (!replaced) {
+        replaced = true;
+        const fresh = ctl.setServers([`127.0.0.1:${target.port}`]);
+        return fresh[0];
+      }
+      return pool[0];
+    },
+  });
+  assertEquals(nc.getServer(), `127.0.0.1:${target.port}`);
+  await nc.close();
+});
+
+Deno.test("reconnectToServer - picks chosen server on reconnect", async () => {
+  await using ns0 = await NatsServer.start();
+  await using ns1 = await NatsServer.start();
+  let firstAttempt = true;
+  const nc = await connect({
+    servers: [`127.0.0.1:${ns0.port}`, `127.0.0.1:${ns1.port}`],
+    noRandomize: true,
+    reconnectTimeWait: 100,
+    maxReconnectAttempts: -1,
+    reconnectToServer: (pool) => {
+      if (firstAttempt) {
+        firstAttempt = false;
+        return pool[0];
+      }
+      return pool.find((s) => s.port === ns1.port) ?? pool[0];
+    },
+  });
+  assertEquals(nc.getServer(), `127.0.0.1:${ns0.port}`);
+
+  const reconnected = deferred<void>();
+  (async () => {
+    for await (const s of nc.status()) {
+      if (s.type === "reconnect") {
+        reconnected.resolve();
+        break;
+      }
+    }
+  })().then();
+
+  await ns0.stop();
+  await reconnected;
+  assertEquals(nc.getServer(), `127.0.0.1:${ns1.port}`);
+  await nc.close();
+});
+
+Deno.test("reconnectToServer - {server, delay} return waits before dial", async () => {
+  await using ns = await NatsServer.start();
+  const t0 = Date.now();
+  let elapsedAtDial = -1;
+  const nc = await ns.connect({
+    reconnectToServer: (pool) => {
+      elapsedAtDial = Date.now() - t0;
+      return { server: pool[0], delay: 500 };
+    },
+  });
+  const elapsed = Date.now() - t0;
+  assert(elapsed >= 500, `connect elapsed ${elapsed} < 500ms expected delay`);
+  assert(
+    elapsedAtDial < 500,
+    `handler invoked at ${elapsedAtDial}, expected < 500ms`,
+  );
+  assertEquals(nc.getServer(), `127.0.0.1:${ns.port}`);
+  await nc.close();
+});
+
+Deno.test("setServers - replaces pool and reconnect dials new pool", async () => {
+  await using ns0 = await NatsServer.start();
+  await using ns1 = await NatsServer.start();
+  const nc = await connect({
+    port: ns0.port,
+    reconnectTimeWait: 100,
+    maxReconnectAttempts: -1,
+  });
+  assertEquals(nc.getServer(), `127.0.0.1:${ns0.port}`);
+
+  const reconnected = deferred<void>();
+  (async () => {
+    for await (const s of nc.status()) {
+      if (s.type === "reconnect") {
+        reconnected.resolve();
+        break;
+      }
+    }
+  })().then();
+
+  nc.setServers([`127.0.0.1:${ns1.port}`]);
+  await nc.reconnect();
+  await reconnected;
+
+  assertEquals(nc.getServer(), `127.0.0.1:${ns1.port}`);
+  await nc.close();
 });

--- a/core/tests/servers_test.ts
+++ b/core/tests/servers_test.ts
@@ -18,10 +18,11 @@ import {
   setTransportFactory,
 } from "../src/internal_mod.ts";
 import type { ServerInfo } from "../src/internal_mod.ts";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 
 Deno.test("servers - single", () => {
-  const servers = new Servers(["127.0.0.1:4222"], { randomize: false });
+  const servers = new Servers({ randomize: false });
+  servers.setServers(["127.0.0.1:4222"]);
   assertEquals(servers.length(), 1);
   assertEquals(servers.getServers().length, 1);
   assertEquals(servers.getCurrentServer().listen, "127.0.0.1:4222");
@@ -35,7 +36,8 @@ Deno.test("servers - single", () => {
 });
 
 Deno.test("servers - multiples", () => {
-  const servers = new Servers(["h:1", "h:2"], { randomize: false });
+  const servers = new Servers({ randomize: false });
+  servers.setServers(["h:1", "h:2"]);
   assertEquals(servers.length(), 2);
   assertEquals(servers.getServers().length, 2);
   assertEquals(servers.getCurrentServer().listen, "h:1");
@@ -58,7 +60,8 @@ function servInfo(): ServerInfo {
 }
 
 Deno.test("servers - add/delete", () => {
-  const servers = new Servers(["127.0.0.1:4222"], { randomize: false });
+  const servers = new Servers({ randomize: false });
+  servers.setServers(["127.0.0.1:4222"]);
   assertEquals(servers.length(), 1);
   let ce = servers.update(Object.assign(servInfo(), { connect_urls: ["h:1"] }));
   assertEquals(ce.added.length, 1);
@@ -85,7 +88,8 @@ Deno.test("servers - url parse fn", () => {
     return `x://${s}`;
   };
   setTransportFactory({ urlParseFn: fn });
-  const s = new Servers(["127.0.0.1:4222"], { randomize: false });
+  const s = new Servers({ randomize: false });
+  s.setServers(["127.0.0.1:4222"]);
   s.update(Object.assign(servInfo(), { connect_urls: ["h:1", "j:2/path"] }));
 
   const servers = s.getServers();
@@ -96,7 +100,8 @@ Deno.test("servers - url parse fn", () => {
 });
 
 Deno.test("servers - save tls name", () => {
-  const servers = new Servers(["h:1", "h:2"], { randomize: false });
+  const servers = new Servers({ randomize: false });
+  servers.setServers(["h:1", "h:2"]);
   servers.addServer("127.1.0.0", true);
   servers.addServer("127.1.2.0", true);
   servers.updateTLSName();
@@ -115,7 +120,8 @@ Deno.test("servers - save tls name", () => {
 
 Deno.test("servers - port 80", () => {
   function t(hp: string, port: number) {
-    const servers = new Servers([hp]);
+    const servers = new Servers();
+    servers.setServers([hp]);
     const s = servers.getCurrentServer();
     assertEquals(s.port, port);
   }
@@ -133,4 +139,57 @@ Deno.test("servers - hostname only", () => {
   assertEquals(isIPV4OrHostname("hostname"), true);
   assertEquals(isIPV4OrHostname("hostname:40"), true);
   assertEquals(isIPV4OrHostname("::ffff:35.234.43.228"), false);
+});
+
+Deno.test("servers - randomize shuffles initial pool", () => {
+  const listens = ["a:1", "b:2", "c:3", "d:4", "e:5", "f:6", "g:7", "h:8"];
+  const orders = new Set<string>();
+  for (let i = 0; i < 20; i++) {
+    const s = new Servers({ randomize: true });
+    s.setServers(listens);
+    orders.add(s.getServers().map((x) => x.listen).join(","));
+  }
+  assert(
+    orders.size > 1,
+    `expected shuffle to produce multiple orders, got ${orders.size}`,
+  );
+});
+
+Deno.test("servers - randomize=false preserves order", () => {
+  const listens = ["a:1", "b:2", "c:3", "d:4"];
+  for (let i = 0; i < 5; i++) {
+    const s = new Servers({ randomize: false });
+    s.setServers(listens);
+    assertEquals(
+      s.getServers().map((x) => x.listen),
+      listens,
+    );
+  }
+});
+
+Deno.test("servers - gossip update shuffles new servers", () => {
+  // pool starts with seed; gossip arrives with multiple new servers.
+  // currentServer (seed) must remain at index 0; the rest must be shuffled.
+  const orders = new Set<string>();
+  const seed = "seed:1";
+  const gossipUrls = ["a:2", "b:3", "c:4", "d:5", "e:6", "f:7", "g:8", "h:9"];
+  for (let i = 0; i < 20; i++) {
+    const s = new Servers({ randomize: true });
+    s.setServers([seed]);
+    const info = {
+      max_payload: 1,
+      client_id: 1,
+      proto: 1,
+      version: "1",
+      connect_urls: gossipUrls,
+    } as ServerInfo;
+    s.update(info);
+    const listed = s.getServers().map((x) => x.listen);
+    assertEquals(listed[0], seed, "seed must stay at head");
+    orders.add(listed.slice(1).join(","));
+  }
+  assert(
+    orders.size > 1,
+    `expected gossip-shuffle to produce multiple orders, got ${orders.size}`,
+  );
 });

--- a/core/tests/ws_test.ts
+++ b/core/tests/ws_test.ts
@@ -23,6 +23,7 @@ import {
 
 import {
   createInbox,
+  deferred,
   errors,
   wsconnect,
   wsUrlParseFn,
@@ -202,4 +203,69 @@ Deno.test("ws - wsURLParseFn", () => {
   assertEquals(wsUrlParseFn("localhost", false), "ws://localhost:80/");
   assertEquals(wsUrlParseFn("http://localhost"), "ws://localhost:80/");
   assertEquals(wsUrlParseFn("https://localhost"), "wss://localhost:443/");
+});
+
+Deno.test("ws - reconnectToServer invoked on initial connect", async () => {
+  const ns = await NatsServer.start(wsServerConf());
+  let calls = 0;
+  let lastPoolLen = -1;
+  const nc = await wsconnect({
+    servers: `ws://127.0.0.1:${ns.websocket}`,
+    reconnectToServer: (pool) => {
+      calls++;
+      lastPoolLen = pool.length;
+      return pool[0];
+    },
+  });
+  assertEquals(calls, 1);
+  assertEquals(lastPoolLen, 1);
+  await cleanup(ns, nc);
+});
+
+Deno.test("ws - getServers returns ws listens", async () => {
+  const ns = await NatsServer.start(wsServerConf());
+  const nc = await wsconnect({
+    servers: `ws://127.0.0.1:${ns.websocket}`,
+  });
+  const servers = nc.getServers();
+  assert(servers.length >= 1);
+  const listens = servers.map((s) => s.listen);
+  assert(
+    listens.some((l) => l.includes(`${ns.websocket}`)),
+    `expected ws port in listens: ${listens.join(",")}`,
+  );
+  await cleanup(ns, nc);
+});
+
+Deno.test("ws - setServers replaces pool and reconnect dials new", async () => {
+  const ns0 = await NatsServer.start(wsServerConf());
+  const ns1 = await NatsServer.start(wsServerConf());
+  const nc = await wsconnect({
+    servers: `ws://127.0.0.1:${ns0.websocket}`,
+    reconnectTimeWait: 100,
+    maxReconnectAttempts: -1,
+  }) as NatsConnectionImpl;
+  assert(nc.getServer().includes(`${ns0.websocket}`));
+
+  const reconnected = deferred<void>();
+  (async () => {
+    for await (const s of nc.status()) {
+      if (s.type === "reconnect") {
+        reconnected.resolve();
+        break;
+      }
+    }
+  })().then();
+
+  nc.setServers([`ws://127.0.0.1:${ns1.websocket}`]);
+  await nc.reconnect();
+  await reconnected;
+
+  assert(
+    nc.getServer().includes(`${ns1.websocket}`),
+    `expected ${ns1.websocket}, got ${nc.getServer()}`,
+  );
+  await nc.close();
+  await ns0.stop();
+  await ns1.stop();
 });

--- a/nst/bin/cluster.ts
+++ b/nst/bin/cluster.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The NATS Authors
+ * Copyright 2020-2026 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,7 +15,15 @@
 
 import { NatsServer } from "../src/launcher.ts";
 import { parseArgs } from "@std/cli";
-import { rgb24 } from "@std/fmt/colors";
+import { gray, green, red, yellow } from "@std/fmt/colors";
+import {
+  clearScreen,
+  coalescingScheduler,
+  fmtDuration,
+  MAX_WIDTH,
+  palette,
+  writeFrame,
+} from "./_tui.ts";
 
 const defaults = {
   c: 3,
@@ -26,20 +34,17 @@ const defaults = {
   key: "",
 };
 
-const argv = parseArgs(
-  Deno.args,
-  {
-    alias: {
-      "p": ["port"],
-      "c": ["count"],
-      "d": ["debug"],
-      "j": ["jetstream"],
-      "w": ["websocket"],
-    },
-    default: defaults,
-    boolean: ["debug", "jetstream", "server-debug", "chaos"],
+const argv = parseArgs(Deno.args, {
+  alias: {
+    "p": ["port"],
+    "c": ["count"],
+    "d": ["debug"],
+    "j": ["jetstream"],
+    "w": ["websocket"],
   },
-);
+  default: defaults,
+  boolean: ["debug", "jetstream", "server-debug", "chaos"],
+});
 
 if (argv.h || argv.help) {
   console.log(
@@ -70,7 +75,133 @@ if (wsport === 80 && cert?.length) {
   wsport = 443;
 }
 
+const isTty = Deno.stdout.isTerminal();
+
+type ServerState = "running" | "restarting" | "failed";
+
+type ServerMeta = {
+  idx: number;
+  label: string;
+  color: (s: string) => string;
+  state: ServerState;
+  pid: number;
+  port: number;
+  websocket?: number;
+  cluster: number;
+  monitoring?: number;
+  configFile: string;
+  restarts: number;
+  ns: NatsServer | null;
+};
+
+const meta: ServerMeta[] = [];
+const events: string[] = [];
+const startedAt = Date.now();
 let chaosTimer: number | undefined;
+
+function pushEvent(line: string) {
+  const ts = new Date().toISOString().substring(11, 19);
+  if (!isTty) {
+    console.log(`${ts}  ${line}`);
+  }
+  events.unshift(`${gray(ts)}  ${line}`);
+  if (events.length > 8) events.pop();
+  scheduleRender();
+}
+
+const scheduleRender = coalescingScheduler(() => render());
+
+function stateLabel(s: ServerState): string {
+  switch (s) {
+    case "running":
+      return green("● running   ");
+    case "restarting":
+      return yellow("⟳ restarting");
+    case "failed":
+      return red("✗ failed    ");
+  }
+}
+
+function render(): void {
+  if (!isTty) return;
+  const out: string[] = [];
+  const chaosState = chaosTimer === undefined
+    ? gray("chaos: OFF")
+    : red("chaos: ON ");
+  out.push(
+    `NATS Cluster (${meta.length} servers)   ${chaosState}   up=${
+      fmtDuration(Date.now() - startedAt)
+    }`,
+  );
+  out.push("─".repeat(MAX_WIDTH));
+  const W = {
+    s: 4,
+    state: 12,
+    pid: 6,
+    nats: 6,
+    ws: 6,
+    cluster: 7,
+    http: 6,
+    restarts: 4,
+  };
+  out.push(
+    [
+      "S".padEnd(W.s),
+      "state".padEnd(W.state),
+      "pid".padEnd(W.pid),
+      "nats".padEnd(W.nats),
+      "ws".padEnd(W.ws),
+      "cluster".padEnd(W.cluster),
+      "http".padEnd(W.http),
+      "restarts".padEnd(W.restarts),
+    ].join("  "),
+  );
+  for (const m of meta) {
+    const lbl = m.color(`[${m.label}]`.padEnd(W.s));
+    out.push(
+      [
+        lbl,
+        stateLabel(m.state),
+        String(m.pid).padEnd(W.pid),
+        String(m.port).padEnd(W.nats),
+        String(m.websocket || "-").padEnd(W.ws),
+        String(m.cluster).padEnd(W.cluster),
+        String(m.monitoring || "-").padEnd(W.http),
+        String(m.restarts).padEnd(W.restarts),
+      ].join("  "),
+    );
+  }
+  if (events.length > 0) {
+    out.push("");
+    out.push("recent:");
+    for (const e of events) out.push(`  ${e}`);
+  }
+  out.push("");
+  out.push(
+    `${gray("ctrl+c")} terminate   ${gray("ctrl+t")} toggle chaos`,
+  );
+  writeFrame(out.join("\n"));
+}
+
+function addServer(idx: number, ns: NatsServer): ServerMeta {
+  const m: ServerMeta = {
+    idx,
+    label: `S${idx + 1}`,
+    color: palette[idx % palette.length],
+    state: "running",
+    pid: ns.pid(),
+    port: ns.port,
+    websocket: ns.websocket,
+    cluster: ns.cluster!,
+    monitoring: ns.monitoring,
+    configFile: ns.configFile,
+    restarts: 0,
+    ns,
+  };
+  meta.push(m);
+  return m;
+}
+
 let cluster: NatsServer[];
 
 try {
@@ -92,18 +223,12 @@ try {
 
   if (cert) {
     base = Object.assign(base, {
-      tls: {
-        cert_file: cert,
-        key_file: key,
-      },
+      tls: { cert_file: cert, key_file: key },
       websocket: {
         port: wsport,
         no_tls: false,
         compression: true,
-        tls: {
-          cert_file: cert,
-          key_file: key,
-        },
+        tls: { cert_file: cert, key_file: key },
       },
     });
   }
@@ -111,38 +236,33 @@ try {
   cluster = argv.jetstream
     ? await NatsServer.jetstreamCluster(
       count,
-      Object.assign(
-        base,
-        Object.assign(base, {
-          jetstream: {
-            max_file_store: -1,
-            max_mem_store: -1,
-          },
-        }),
-      ),
+      Object.assign(base, {
+        jetstream: { max_file_store: -1, max_mem_store: -1 },
+      }),
     )
-    : await NatsServer.cluster(
-      count,
-      Object.assign(base),
-      serverDebug,
-    );
+    : await NatsServer.cluster(count, base, serverDebug);
 
-  cluster.forEach((s) => {
-    const pid = rgb24(`[${s.process.pid}]`, s.rgb);
-    console.log(`${pid} config ${s.configFile}
-\tnats://${s.hostname}:${s.port}
-\tws${cert ? "s" : ""}://${s.hostname}:${s.websocket}
-\tcluster://${s.hostname}:${s.cluster}
-\thttp://127.0.0.1:${s.monitoring}
-${argv.jetstream ? `\tstore: ${s.config?.jetstream?.store_dir}` : ""}`);
-  });
+  cluster.forEach((s, i) => addServer(i, s));
+  pushEvent(`cluster started (${cluster.length} servers)`);
+  if (!isTty) {
+    for (const m of meta) {
+      console.log(
+        `[${m.label}] pid=${m.pid} nats=${m.port} ws=${
+          m.websocket ?? "-"
+        } cluster=${m.cluster} http=${m.monitoring ?? "-"}`,
+      );
+    }
+  }
 
+  render();
   if (argv.chaos === true && confirm("start chaos?")) {
     chaos(cluster, 0);
   }
-  waitForStop();
+  setInterval(render, 1000);
+  installSignals();
 } catch (err) {
   console.error(err);
+  Deno.exit(1);
 }
 
 function randomBetween(min: number, max: number): number {
@@ -151,9 +271,8 @@ function randomBetween(min: number, max: number): number {
 
 function chaos(cluster: NatsServer[], delay: number) {
   setTimeout(() => {
-    chaosTimer = setInterval(() => {
-      restart(cluster);
-    }, 3000);
+    chaosTimer = setInterval(() => restart(cluster), 3000);
+    scheduleRender();
   }, delay);
 }
 
@@ -161,58 +280,57 @@ function restart(cluster: NatsServer[]) {
   const millis = randomBetween(0, 10000);
   const idx = randomBetween(0, cluster.length);
   if (cluster[idx] === null) {
-    // try again
-    setTimeout(() => {
-      restart(cluster);
-    });
+    setTimeout(() => restart(cluster), 100);
     return;
   }
   const old = cluster[idx];
   // @ts-ignore: test
   cluster[idx] = null;
+  const m = meta[idx];
+  m.state = "restarting";
+  scheduleRender();
   setTimeout(() => {
     const oldPid = old.pid();
-    console.log(
-      rgb24(
-        `[${oldPid}] chaos is restarting server at port ${old.port}`,
-        old.rgb,
-      ),
+    pushEvent(
+      `${m.color(m.label)} restarting (pid ${oldPid}, port ${old.port})`,
     );
     old.restart()
       .then((s) => {
         s.rgb = old.rgb;
         cluster[idx] = s;
-        console.log(rgb24(`[${s.pid()}] replaces PID ${oldPid}`, s.rgb));
-      }).catch((err) => {
-        console.log(`failed to replace ${oldPid}: ${err.message}`);
-        console.log(`to manually restart: nats-server -c ${old.configFile}`);
+        m.ns = s;
+        m.pid = s.pid();
+        m.state = "running";
+        m.restarts++;
+        pushEvent(
+          `${m.color(m.label)} replaced pid ${oldPid} → ${s.pid()}`,
+        );
+      })
+      .catch((err) => {
+        m.state = "failed";
+        pushEvent(`${m.color(m.label)} failed to restart: ${err.message}`);
       });
   }, millis);
 }
 
-function waitForStop(): void {
-  console.log("control+c to terminate");
+function installSignals(): void {
   Deno.addSignalListener("SIGTERM", () => {
     Deno.exit();
   });
-
-  console.log("control+t to stop/restart chaos");
+  Deno.addSignalListener("SIGINT", () => {
+    if (isTty) {
+      clearScreen();
+    }
+    Deno.exit();
+  });
   Deno.addSignalListener("SIGINFO", () => {
     if (chaosTimer === undefined) {
-      console.log("restarting chaos...");
-      console.log("control+t to stop chaos");
-      console.log("control+c to terminate");
-
+      pushEvent("chaos: ON");
       chaos(cluster, 0);
       return;
     }
     clearInterval(chaosTimer);
     chaosTimer = undefined;
-    console.log("control+t to restart chaos");
-    console.log("control+c to terminate");
-    console.log("monitoring can be accessed:");
-    for (const s of cluster) {
-      console.log(`http://127.0.0.1:${s?.monitoring}`);
-    }
+    pushEvent("chaos: OFF");
   });
 }


### PR DESCRIPTION
This PR adds the ability to set and replace the server list. This enables setting a server list, and issuing a reconnect() to migrate to the new servers. Setting the server list to empty will throw an exception.

In addition there are some internal changes to support reconnectToServer, this is an advanced feature that enables a client at the time of a reconnect to select the server to connect to (and if to delay the dial) from the list of provided servers. This feature is fully implemented but stealthy. Must specify the `reconnectToServer` option

Also updated the cluster to use a TUI and added the chaos_client tool (these are internal tools that are very useful for exercising flapping clusters and reconnect)

Fixes #307 