### PR TITLE
feat(jetstream): add consumers.addOrUpdate

### DIFF
--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -96,7 +96,7 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     const cr = {} as CreateConsumerRequest;
     cr.config = cfg;
     cr.stream_name = stream;
-    cr.action = opts.action || ConsumerApiAction.Create;
+    cr.action = opts.action ?? ConsumerApiAction.Create;
     cr.pedantic = opts.pedantic || false;
 
     if (cr.config.durable_name) {
@@ -215,6 +215,17 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     }
     const cco = Object.assign({}, { action }, opts);
     return this.addUpdate(stream, cfg, cco);
+  }
+
+  createOrUpdate(
+    stream: string,
+    cfg: ConsumerConfig,
+    opts?: ConsumerCreateOptions,
+  ): Promise<ConsumerInfo> {
+    return this.addUpdate(stream, cfg, {
+      ...(opts ?? {}),
+      action: ConsumerApiAction.CreateOrUpdate,
+    });
   }
 
   async update(

--- a/jetstream/src/jsmconsumer_api.ts
+++ b/jetstream/src/jsmconsumer_api.ts
@@ -217,7 +217,7 @@ export class ConsumerAPIImpl extends BaseApiClientImpl implements ConsumerAPI {
     return this.addUpdate(stream, cfg, cco);
   }
 
-  createOrUpdate(
+  addOrUpdate(
     stream: string,
     cfg: ConsumerConfig,
     opts?: ConsumerCreateOptions,

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -445,6 +445,20 @@ export type ConsumerAPI = {
   ): Promise<ConsumerInfo>;
 
   /**
+   * Creates the consumer if it does not exist, or updates it in place if it
+   * does. The full configuration provided is sent to the server, which decides
+   * whether to create or update.
+   * @param stream
+   * @param cfg
+   * @param opts
+   */
+  createOrUpdate(
+    stream: string,
+    cfg: Partial<ConsumerConfig>,
+    opts?: ConsumerCreateOptions,
+  ): Promise<ConsumerInfo>;
+
+  /**
    * Updates the consumer configuration for the specified consumer on the specified
    * stream that has the specified durable name.
    * @param stream

--- a/jetstream/src/types.ts
+++ b/jetstream/src/types.ts
@@ -445,14 +445,14 @@ export type ConsumerAPI = {
   ): Promise<ConsumerInfo>;
 
   /**
-   * Creates the consumer if it does not exist, or updates it in place if it
+   * Adds the consumer if it does not exist, or updates it in place if it
    * does. The full configuration provided is sent to the server, which decides
    * whether to create or update.
    * @param stream
    * @param cfg
    * @param opts
    */
-  createOrUpdate(
+  addOrUpdate(
     stream: string,
     cfg: Partial<ConsumerConfig>,
     opts?: ConsumerCreateOptions,

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2060,12 +2060,12 @@ Deno.test("jsm - consumer api action", async () => {
     "consumer already exists",
   );
 
-  // createOrUpdate must accept the modified config and apply it
-  const ci = await jsm.consumers.createOrUpdate("stream", config);
+  // addOrUpdate must accept the modified config and apply it
+  const ci = await jsm.consumers.addOrUpdate("stream", config);
   assertEquals(ci.config.inactive_threshold, nanos(60 * 1000));
 
-  // createOrUpdate must also create when the consumer doesn't exist
-  const fresh = await jsm.consumers.createOrUpdate("stream", {
+  // addOrUpdate must also create when the consumer doesn't exist
+  const fresh = await jsm.consumers.addOrUpdate("stream", {
     ack_policy: AckPolicy.Explicit,
     durable_name: "fresh",
   } as ConsumerConfig);

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2064,6 +2064,13 @@ Deno.test("jsm - consumer api action", async () => {
   const ci = await jsm.consumers.createOrUpdate("stream", config);
   assertEquals(ci.config.inactive_threshold, nanos(60 * 1000));
 
+  // createOrUpdate must also create when the consumer doesn't exist
+  const fresh = await jsm.consumers.createOrUpdate("stream", {
+    ack_policy: AckPolicy.Explicit,
+    durable_name: "fresh",
+  } as ConsumerConfig);
+  assertEquals(fresh.config.durable_name, "fresh");
+
   await cleanup(ns, nc);
 });
 

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2060,6 +2060,10 @@ Deno.test("jsm - consumer api action", async () => {
     "consumer already exists",
   );
 
+  // createOrUpdate must accept the modified config and apply it
+  const ci = await jsm.consumers.createOrUpdate("stream", config);
+  assertEquals(ci.config.inactive_threshold, nanos(60 * 1000));
+
   await cleanup(ns, nc);
 });
 


### PR DESCRIPTION
Mirrors `CreateOrUpdateConsumer` in the Go client — useful for KV/object-store init paths and any caller that wants idempotent setup without doing the info-then-decide dance themselves.

Also a small fix in `addUpdate`: the action default used `||`, which coerced the empty-string `CreateOrUpdate` value back to `"create"`. Changed to `??` so the action survives. Today this only matters for the new `createOrUpdate` path (the existing `add`/`update` callers always pass a truthy action), but worth fixing in the same PR since the new method depends on it.