### PR TITLE
feat(kv): add getMany for consumer-less bulk reads

### DIFF
--- a/kv/README.md
+++ b/kv/README.md
@@ -144,16 +144,18 @@ await (async () => {
 })();
 console.log(`keys contains hello.world: ${buf[0] === "hello.world"}`);
 
-// getLastFor returns the last entry for each key matching a filter using a
-// single batch direct get - unlike keys()/history()/watch() it creates no
-// server-side consumer, so it is well-suited to frequent reads of a bucket's
-// current state. It requires a bucket created with `allow_direct` (the
-// default when the server supports it). Entries include "DEL"/"PURGE"
-// markers - filter on `e.operation` if you only want live values.
-const last = await kv.getLastFor("hello.>");
+// getMany is like get(), but returns the last entry for each key matching a
+// filter using a single batch direct get - unlike keys()/history()/watch() it
+// creates no server-side consumer, so it is well-suited to frequent reads of a
+// bucket's current state. It requires a bucket created with `allow_direct` (the
+// default when the server supports it). The server caps the result set at 1024
+// entries; matching more than that errors rather than truncating, so keep
+// filters scoped. Entries include "DEL"/"PURGE" markers - filter on
+// `e.operation` if you only want live values.
+const last = await kv.getMany("hello.>");
 await (async () => {
   for await (const e of last) {
-    console.log(`getLastFor: ${e.key}: ${e.operation} ${e.string()}`);
+    console.log(`getMany: ${e.key}: ${e.operation} ${e.string()}`);
   }
 })();
 

--- a/kv/README.md
+++ b/kv/README.md
@@ -144,6 +144,19 @@ await (async () => {
 })();
 console.log(`keys contains hello.world: ${buf[0] === "hello.world"}`);
 
+// getLastFor returns the last entry for each key matching a filter using a
+// single batch direct get - unlike keys()/history()/watch() it creates no
+// server-side consumer, so it is well-suited to frequent reads of a bucket's
+// current state. It requires a bucket created with `allow_direct` (the
+// default when the server supports it). Entries include "DEL"/"PURGE"
+// markers - filter on `e.operation` if you only want live values.
+const last = await kv.getLastFor("hello.>");
+await (async () => {
+  for await (const e of last) {
+    console.log(`getLastFor: ${e.key}: ${e.operation} ${e.string()}`);
+  }
+})();
+
 let h = await kv.history({ key: "hello.world" });
 await (async () => {
   for await (const e of h) {

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -1002,12 +1002,12 @@ export class Bucket implements KV {
     return keys;
   }
 
-  async getLastFor(
+  async getMany(
     filter: string | string[] = ">",
   ): Promise<QueuedIterator<KvEntry>> {
     if (!this.direct) {
       return Promise.reject(
-        new Error("getLastFor requires a bucket created with allow_direct"),
+        new Error("getMany requires a bucket created with allow_direct"),
       );
     }
 
@@ -1018,6 +1018,8 @@ export class Bucket implements KV {
       return this.fullKeyName(ek);
     });
 
+    // The server caps a batch direct get at 1024 results; matching more than
+    // that stops the iterator with a "too many results" error (no truncation).
     const direct = (this.jsm as unknown as { direct: DirectStreamAPI }).direct;
     const src = await direct.getLastMessagesFor(this.stream, { multi_last });
 

--- a/kv/src/kv.ts
+++ b/kv/src/kv.ts
@@ -1002,6 +1002,44 @@ export class Bucket implements KV {
     return keys;
   }
 
+  async getLastFor(
+    filter: string | string[] = ">",
+  ): Promise<QueuedIterator<KvEntry>> {
+    if (!this.direct) {
+      return Promise.reject(
+        new Error("getLastFor requires a bucket created with allow_direct"),
+      );
+    }
+
+    const a = !Array.isArray(filter) ? [filter] : filter;
+    const multi_last = a.map((k) => {
+      const ek = this.encodeKey(k);
+      this.validateSearchKey(k);
+      return this.fullKeyName(ek);
+    });
+
+    const direct = (this.jsm as unknown as { direct: DirectStreamAPI }).direct;
+    const src = await direct.getLastMessagesFor(this.stream, { multi_last });
+
+    const entries = new QueuedIteratorImpl<KvEntry>();
+    (async () => {
+      try {
+        for await (const sm of src) {
+          entries.push(this.smToEntry(sm));
+        }
+        entries.push(() => {
+          entries.stop();
+        });
+      } catch (err) {
+        entries.push(() => {
+          entries.stop(err as Error);
+        });
+      }
+    })().then();
+
+    return entries;
+  }
+
   purgeBucket(opts?: PurgeOpts): Promise<PurgeResponse> {
     return this.jsm.streams.purge(this.bucketName(), opts);
   }

--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -378,6 +378,25 @@ export type RoKV = {
    * @param filter - default is all keys
    */
   keys(filter?: string | string[]): Promise<QueuedIterator<string>>;
+
+  /**
+   * Returns an iterator yielding the last {@link KvEntry} for each key
+   * matching the specified filter, retrieved with a single batch direct get
+   * request. Unlike {@link history}, {@link watch} and {@link keys}, this
+   * creates no server-side consumer, making it well-suited to frequent reads
+   * of a bucket's current state.
+   *
+   * Entries are returned as-is, including those marked with a "DEL" or "PURGE"
+   * operation - filter on {@link KvEntry.operation} if only live values are
+   * wanted.
+   *
+   * Requires the bucket to have been created with `allow_direct` and a
+   * server that supports batch direct get (2.11.0 or better); the returned
+   * promise rejects otherwise. A filter matching no keys yields an empty
+   * iterator.
+   * @param filter - default is all keys
+   */
+  getLastFor(filter?: string | string[]): Promise<QueuedIterator<KvEntry>>;
 };
 
 export type KV = RoKV & {

--- a/kv/src/types.ts
+++ b/kv/src/types.ts
@@ -380,11 +380,17 @@ export type RoKV = {
   keys(filter?: string | string[]): Promise<QueuedIterator<string>>;
 
   /**
-   * Returns an iterator yielding the last {@link KvEntry} for each key
-   * matching the specified filter, retrieved with a single batch direct get
-   * request. Unlike {@link history}, {@link watch} and {@link keys}, this
-   * creates no server-side consumer, making it well-suited to frequent reads
-   * of a bucket's current state.
+   * Like {@link get}, but returns the last {@link KvEntry} for *each* key
+   * matching the specified filter(s) in a single batch direct get request.
+   * Unlike {@link history}, {@link watch} and {@link keys}, this creates no
+   * server-side consumer, making it well-suited to frequent reads of a
+   * bucket's current state.
+   *
+   * The server caps the result set at **1024 entries**. If more than 1024
+   * keys match the filter the returned iterator stops with a "too many
+   * results" error rather than truncating, so filters should be scoped to
+   * stay under that limit. A filter matching no keys yields an empty
+   * iterator.
    *
    * Entries are returned as-is, including those marked with a "DEL" or "PURGE"
    * operation - filter on {@link KvEntry.operation} if only live values are
@@ -392,11 +398,10 @@ export type RoKV = {
    *
    * Requires the bucket to have been created with `allow_direct` and a
    * server that supports batch direct get (2.11.0 or better); the returned
-   * promise rejects otherwise. A filter matching no keys yields an empty
-   * iterator.
+   * promise rejects otherwise.
    * @param filter - default is all keys
    */
-  getLastFor(filter?: string | string[]): Promise<QueuedIterator<KvEntry>>;
+  getMany(filter?: string | string[]): Promise<QueuedIterator<KvEntry>>;
 };
 
 export type KV = RoKV & {

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -2760,7 +2760,7 @@ Deno.test("kv - watcherPrefix", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("kv - getLastFor returns last value per key", async () => {
+Deno.test("kv - getMany returns last value per key", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.11.0")) {
     return await cleanup(ns, nc);
@@ -2773,7 +2773,7 @@ Deno.test("kv - getLastFor returns last value per key", async () => {
   await bucket.put("b", "1");
   await bucket.put("c", "1");
 
-  const entries = await collect(await bucket.getLastFor());
+  const entries = await collect(await bucket.getMany());
   const got = new Map(entries.map((e) => [e.key, e.string()]));
 
   assertEquals(got.size, 3);
@@ -2784,7 +2784,7 @@ Deno.test("kv - getLastFor returns last value per key", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("kv - getLastFor filters by key", async () => {
+Deno.test("kv - getMany filters by key", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.11.0")) {
     return await cleanup(ns, nc);
@@ -2796,16 +2796,16 @@ Deno.test("kv - getLastFor filters by key", async () => {
   await bucket.put("a.y", "2");
   await bucket.put("b.x", "3");
 
-  const wild = await collect(await bucket.getLastFor("a.>"));
+  const wild = await collect(await bucket.getMany("a.>"));
   assertEquals(wild.map((e) => e.key).sort(), ["a.x", "a.y"]);
 
-  const multi = await collect(await bucket.getLastFor(["a.x", "b.x"]));
+  const multi = await collect(await bucket.getMany(["a.x", "b.x"]));
   assertEquals(multi.map((e) => e.key).sort(), ["a.x", "b.x"]);
 
   await cleanup(ns, nc);
 });
 
-Deno.test("kv - getLastFor empty match yields empty iterator", async () => {
+Deno.test("kv - getMany empty match yields empty iterator", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.11.0")) {
     return await cleanup(ns, nc);
@@ -2813,13 +2813,13 @@ Deno.test("kv - getLastFor empty match yields empty iterator", async () => {
   const js = jetstream(nc);
   const bucket = await new Kvm(js).create(nuid.next());
 
-  const entries = await collect(await bucket.getLastFor("does.not.exist"));
+  const entries = await collect(await bucket.getMany("does.not.exist"));
   assertEquals(entries.length, 0);
 
   await cleanup(ns, nc);
 });
 
-Deno.test("kv - getLastFor includes tombstones", async () => {
+Deno.test("kv - getMany includes tombstones", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.11.0")) {
     return await cleanup(ns, nc);
@@ -2831,7 +2831,7 @@ Deno.test("kv - getLastFor includes tombstones", async () => {
   await bucket.put("gone", "1");
   await bucket.delete("gone");
 
-  const entries = await collect(await bucket.getLastFor());
+  const entries = await collect(await bucket.getMany());
   const ops = new Map(entries.map((e) => [e.key, e.operation]));
 
   assertEquals(ops.get("live"), "PUT");
@@ -2840,7 +2840,7 @@ Deno.test("kv - getLastFor includes tombstones", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("kv - getLastFor rejects when not direct", async () => {
+Deno.test("kv - getMany rejects when not direct", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}));
   if (await notCompatible(ns, nc, "2.11.0")) {
     return await cleanup(ns, nc);
@@ -2851,9 +2851,38 @@ Deno.test("kv - getLastFor rejects when not direct", async () => {
   await bucket.put("a", "1");
 
   await assertRejects(
-    () => bucket.getLastFor(),
+    () => bucket.getMany(),
     Error,
     "direct",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - getMany caps at 1024 results", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return await cleanup(ns, nc);
+  }
+  const js = jetstream(nc);
+  const bucket = await new Kvm(js).create(nuid.next());
+
+  // 1024 matching keys is the limit - all are returned
+  await Promise.all(
+    Array.from({ length: 1024 }, (_, i) => bucket.put(`k.${i}`, `${i}`)),
+  );
+  const ok = await collect(await bucket.getMany(">"));
+  assertEquals(ok.length, 1024);
+
+  // one more pushes past the cap - the iterator stops with an error rather
+  // than silently truncating
+  await bucket.put("k.1024", "x");
+  await assertRejects(
+    async () => {
+      await collect(await bucket.getMany(">"));
+    },
+    Error,
+    "too many results",
   );
 
   await cleanup(ns, nc);

--- a/kv/tests/kv_test.ts
+++ b/kv/tests/kv_test.ts
@@ -2759,3 +2759,102 @@ Deno.test("kv - watcherPrefix", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("kv - getLastFor returns last value per key", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return await cleanup(ns, nc);
+  }
+  const js = jetstream(nc);
+  const bucket = await new Kvm(js).create(nuid.next(), { history: 5 });
+
+  await bucket.put("a", "1");
+  await bucket.put("a", "2");
+  await bucket.put("b", "1");
+  await bucket.put("c", "1");
+
+  const entries = await collect(await bucket.getLastFor());
+  const got = new Map(entries.map((e) => [e.key, e.string()]));
+
+  assertEquals(got.size, 3);
+  assertEquals(got.get("a"), "2");
+  assertEquals(got.get("b"), "1");
+  assertEquals(got.get("c"), "1");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - getLastFor filters by key", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return await cleanup(ns, nc);
+  }
+  const js = jetstream(nc);
+  const bucket = await new Kvm(js).create(nuid.next());
+
+  await bucket.put("a.x", "1");
+  await bucket.put("a.y", "2");
+  await bucket.put("b.x", "3");
+
+  const wild = await collect(await bucket.getLastFor("a.>"));
+  assertEquals(wild.map((e) => e.key).sort(), ["a.x", "a.y"]);
+
+  const multi = await collect(await bucket.getLastFor(["a.x", "b.x"]));
+  assertEquals(multi.map((e) => e.key).sort(), ["a.x", "b.x"]);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - getLastFor empty match yields empty iterator", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return await cleanup(ns, nc);
+  }
+  const js = jetstream(nc);
+  const bucket = await new Kvm(js).create(nuid.next());
+
+  const entries = await collect(await bucket.getLastFor("does.not.exist"));
+  assertEquals(entries.length, 0);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - getLastFor includes tombstones", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return await cleanup(ns, nc);
+  }
+  const js = jetstream(nc);
+  const bucket = await new Kvm(js).create(nuid.next());
+
+  await bucket.put("live", "1");
+  await bucket.put("gone", "1");
+  await bucket.delete("gone");
+
+  const entries = await collect(await bucket.getLastFor());
+  const ops = new Map(entries.map((e) => [e.key, e.operation]));
+
+  assertEquals(ops.get("live"), "PUT");
+  assertEquals(ops.get("gone"), "DEL");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - getLastFor rejects when not direct", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}));
+  if (await notCompatible(ns, nc, "2.11.0")) {
+    return await cleanup(ns, nc);
+  }
+  const js = jetstream(nc);
+  const bucket = await new Kvm(js).create(nuid.next(), { allow_direct: false });
+
+  await bucket.put("a", "1");
+
+  await assertRejects(
+    () => bucket.getLastFor(),
+    Error,
+    "direct",
+  );
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
## What

Adds `RoKV.getMany(filter?)` — like `get()`, but returns the last `KvEntry` for **each key matching the filter(s)** in a single batch direct get (`$JS.API.DIRECT.GET`). It returns a `QueuedIterator<KvEntry>` and, unlike `keys()`, `history()` and `watch()`, creates **no server-side consumer**, making it well-suited to frequent reads of a bucket's current state.

- `kv/src/types.ts` — `getMany` added to the `RoKV` interface (available on both `RoKV` and `KV`).
- `kv/src/kv.ts` — implemented on `Bucket`: builds `multi_last` subjects the same way `_buildCC` does (`fullKeyName(encodeKey(k))` + `validateSearchKey`), calls `direct.getLastMessagesFor()`, and converts each `StoredMsg` via the existing `smToEntry()`.
- `kv/README.md` — usage example alongside `keys()`.

## Why

`keys()`, `history()` and `watch()` all stand up an ephemeral push consumer. For code paths that read a bucket's current state on every request, that's the "too many consumer creations" JetStream anti-pattern. The batch direct get API (`getLastMessagesFor`) already exists on the direct stream API; this surfaces it at the KV layer the same way `get()` already wraps `direct.getMessage`.

## Behavior notes

- **1024-result cap**: the server caps a batch direct get at **1024 entries**. If more than 1024 keys match, the iterator stops with a `too many results` error rather than truncating — so filters should be scoped to stay under the limit. Verified empirically: 1024 matches return cleanly, 1025 errors. This is documented in the TSDoc + README and covered by a boundary test.
- **Tombstones included**: entries are returned as-is, including `DEL`/`PURGE` markers — callers filter on `entry.operation` if they only want live values (mirrors how `history()` consumers already work). This is also strictly less code than skipping them.
- **Requires `allow_direct`**: rejects with a clear error if the bucket isn't direct-enabled, rather than silently falling back to a consumer-based scan (which would defeat the purpose). Also requires a server with batch direct get (2.11.0+).
- **Empty match** yields an empty iterator (the direct API's `isNoResults()` path), not an error.

## Tests

New cases in `kv/tests/kv_test.ts`, all gated on server 2.11.0:
- last value per key
- wildcard and multi-key filters
- empty match → empty iterator
- tombstones visible
- 1024 cap boundary (1024 ok, 1025 → "too many results")
- rejects when `allow_direct` is off

Full KV suite passes (91 passed, 0 failed); `deno lint` and `deno fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)