### PR TITLE
Add docs.nats.io examples to main with typecheck CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,17 @@ jobs:
     uses: ./.github/workflows/node_checks.yml
   test-unsafe:
     uses: ./.github/workflows/unsafe_checks.yml
+  docs-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: 2.7.x
+      - name: Typecheck docs examples
+        run: deno check docs-io-nats-examples/*.ts
   coveralls-finish:
     needs: [test-deno, test-node, test-unsafe]
     runs-on: ubuntu-latest

--- a/docs-io-nats-examples/basics-publish.ts
+++ b/docs-io-nats-examples/basics-publish.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect();
+
+// NATS-DOC-START
+// Publish a message to the "weather.updates" subject
+nc.publish("weather.updates", "Temperature: 72°F");
+// NATS-DOC-END
+console.log("Message published to weather.updates");
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/basics-subscribe.ts
+++ b/docs-io-nats-examples/basics-subscribe.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, delay} from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect();
+
+delay(1000).then(() => {
+  nc.publish("weather.updates", "Weather: Sunny in NYC");
+})
+
+// NATS-DOC-START
+// Subscribe to the "weather.updates" subject; auto-close after 1 message
+const sub = nc.subscribe("weather.updates");
+
+// iterate over messages received (sub will end after the first message)
+for await (const msg of sub) {
+  console.log(`Received: ${msg.string()}`);
+  break;
+}
+
+// NATS-DOC-END
+
+// drain will close the connection after processing pending messages
+await nc.drain();

--- a/docs-io-nats-examples/getting-started-publish.ts
+++ b/docs-io-nats-examples/getting-started-publish.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect();
+
+// publish a message to the 'hello' subject
+nc.publish("hello", "Hello NATS!");
+console.log("Message published to hello");
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/getting-started-subscribe.ts
+++ b/docs-io-nats-examples/getting-started-subscribe.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, delay} from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect();
+
+delay(1000).then(() => {
+  nc.publish("weather.updates", "Weather: Sunny in NYC");
+})
+
+// NATS-DOC-START
+// Subscribe to the "weather.updates" subject; auto-close after 1 message
+const sub = nc.subscribe("weather.updates");
+
+// iterate over messages received (sub will end after the first message)
+for await (const msg of sub) {
+  console.log(`Received: ${msg.string()}`);
+  break;
+}
+
+// NATS-DOC-END
+
+// drain will close the connection after processing pending messages
+await nc.drain();

--- a/docs-io-nats-examples/jetstream-basic.ts
+++ b/docs-io-nats-examples/jetstream-basic.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  AckPolicy,
+  jetstream,
+  jetstreamManager,
+  StorageType,
+} from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Create a stream that captures any subject under `orders.`
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "ORDERS",
+  subjects: ["orders.>"],
+  storage: StorageType.File,
+});
+
+// Publish a few orders
+const js = jetstream(nc);
+await js.publish("orders.new", "Order #1001");
+await js.publish("orders.new", "Order #1002");
+await js.publish("orders.shipped", "Order #1001 shipped");
+
+// Create a durable pull consumer that delivers from the beginning
+await jsm.consumers.add("ORDERS", {
+  durable_name: "order-processor",
+  ack_policy: AckPolicy.Explicit,
+});
+const consumer = await js.consumers.get("ORDERS", "order-processor");
+
+// Fetch a batch and acknowledge each message
+const messages = await consumer.fetch({ max_messages: 3, expires: 5000 });
+for await (const msg of messages) {
+  console.log(`Received on ${msg.subject}: ${msg.string()}`);
+  msg.ack();
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-core-nats-publish-subscribe-publish.ts
+++ b/docs-io-nats-examples/learn-core-nats-publish-subscribe-publish.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Publish one order to the orders.created subject. Publishing is
+// fire-and-forget: the call hands the message to the server and returns.
+const order =
+  '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}';
+nc.publish("orders.created", order);
+// NATS-DOC-END
+
+// drain flushes the buffered publish, then closes the connection
+await nc.drain();

--- a/docs-io-nats-examples/learn-core-nats-publish-subscribe-subscribe.ts
+++ b/docs-io-nats-examples/learn-core-nats-publish-subscribe-subscribe.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Subscribe as the warehouse service to orders.created. Each matching
+// message is delivered to this subscription as it is published.
+const sub = nc.subscribe("orders.created");
+for await (const msg of sub) {
+  console.log(`warehouse received: ${msg.string()}`);
+}
+// NATS-DOC-END

--- a/docs-io-nats-examples/learn-core-nats-queue-groups-queue-subscribe.ts
+++ b/docs-io-nats-examples/learn-core-nats-queue-groups-queue-subscribe.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Join the "packers" queue group on orders.created. Every subscriber that
+// names the same group shares the load: each order is delivered to exactly
+// one member. Run this in several processes to watch the load balance.
+const sub = nc.subscribe("orders.created", { queue: "packers" });
+for await (const msg of sub) {
+  console.log(`packer handling: ${msg.string()}`);
+}
+// NATS-DOC-END

--- a/docs-io-nats-examples/learn-core-nats-request-reply-replies.ts
+++ b/docs-io-nats-examples/learn-core-nats-request-reply-replies.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, createInbox } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Gather more than one reply to a single request. A plain request() returns
+// only the first reply, so when several services may answer, subscribe to your
+// own inbox, publish the request with that inbox as the reply subject, and
+// collect replies until they stop arriving.
+const order =
+  '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}';
+const inbox = createInbox();
+const sub = nc.subscribe(inbox);
+nc.publish("orders.inventory.check", order, { reply: inbox });
+
+const replies: string[] = [];
+const gather = (async () => {
+  for await (const msg of sub) {
+    replies.push(msg.string());
+  }
+})();
+
+// Stop once no further reply is expected.
+setTimeout(() => sub.unsubscribe(), 300);
+await gather;
+
+console.log(`gathered ${replies.length} replies`);
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-core-nats-request-reply-request.ts
+++ b/docs-io-nats-examples/learn-core-nats-request-reply-request.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, RequestError, TimeoutError } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Ask the inventory service whether an order's item is in stock. The client
+// creates a private inbox, sends the request, and waits up to the timeout for
+// one reply. A missing service surfaces immediately as NoRespondersError; a
+// slow one as TimeoutError.
+const order =
+  '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}';
+try {
+  const reply = await nc.request("orders.inventory.check", order, {
+    timeout: 2000,
+  });
+  console.log(`inventory replied: ${reply.string()}`);
+} catch (err) {
+  if (err instanceof RequestError && err.isNoResponders()) {
+    console.log("no inventory service is running");
+  } else if (err instanceof TimeoutError) {
+    console.log("inventory service did not answer in time");
+  } else {
+    throw err;
+  }
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-core-nats-request-reply-respond.ts
+++ b/docs-io-nats-examples/learn-core-nats-request-reply-respond.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// The inventory service: subscribe to orders.inventory.check and answer
+// every request by responding on the reply subject it carries.
+const sub = nc.subscribe("orders.inventory.check");
+for await (const msg of sub) {
+  msg.respond('{"in_stock":true,"warehouse":"us-east"}');
+}
+// NATS-DOC-END

--- a/docs-io-nats-examples/learn-core-nats-scatter-gather-gather.ts
+++ b/docs-io-nats-examples/learn-core-nats-scatter-gather-gather.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, createInbox } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Scatter one request to every shipping-quote provider and gather the replies.
+// Subscribe to a private inbox, publish the request with that inbox as the
+// reply subject, then collect quotes until they stop arriving and pick the
+// cheapest.
+const order =
+  '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}';
+const inbox = createInbox();
+const sub = nc.subscribe(inbox);
+nc.publish("shipping.quote", order, { reply: inbox });
+
+const quotes: string[] = [];
+const gather = (async () => {
+  for await (const msg of sub) {
+    quotes.push(msg.string());
+  }
+})();
+
+// Stop once no further reply is expected.
+setTimeout(() => sub.unsubscribe(), 300);
+await gather;
+
+console.log(`gathered ${quotes.length} quotes: ${JSON.stringify(quotes)}`);
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-core-nats-scatter-gather-provider.ts
+++ b/docs-io-nats-examples/learn-core-nats-scatter-gather-provider.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// A shipping-quote provider. Subscribe plainly to shipping.quote (NOT in a
+// queue group, so every provider sees each request) and reply with a price.
+// Run several copies, each quoting a different number.
+const sub = nc.subscribe("shipping.quote");
+for await (const msg of sub) {
+  msg.respond('{"carrier":"carrier-a","quote_cents":1500}');
+}
+// NATS-DOC-END

--- a/docs-io-nats-examples/learn-core-nats-subjects-and-wildcards-wildcard-multi.ts
+++ b/docs-io-nats-examples/learn-core-nats-subjects-and-wildcards-wildcard-multi.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Audit service: catch every order message at any depth. The multi-token
+// wildcard > matches one or more tokens and must be the last token, so
+// orders.> matches orders.created, orders.us.created, and
+// orders.us.west.created alike.
+const sub = nc.subscribe("orders.>");
+for await (const msg of sub) {
+  console.log(`audit: ${msg.subject}`);
+}
+// NATS-DOC-END

--- a/docs-io-nats-examples/learn-core-nats-subjects-and-wildcards-wildcard-single.ts
+++ b/docs-io-nats-examples/learn-core-nats-subjects-and-wildcards-wildcard-single.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Regional analytics: one subscription catches created orders from every
+// region. The single-token wildcard * matches exactly one token, so both
+// orders.us.created and orders.eu.created match, while orders.created and
+// orders.us.west.created do not.
+const sub = nc.subscribe("orders.*.created");
+for await (const msg of sub) {
+  console.log(`analytics: new order on ${msg.subject}`);
+}
+// NATS-DOC-END

--- a/docs-io-nats-examples/learn-jetstream-acknowledgment-nakWithDelay.ts
+++ b/docs-io-nats-examples/learn-jetstream-acknowledgment-nakWithDelay.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the existing durable and pull one message with next(). nak() tells the
+// server to redeliver instead of advancing. Passing a delay (in milliseconds)
+// holds the redelivery for that long, which backs off a downstream that isn't
+// ready yet.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+const m = await c.next();
+if (m) {
+  console.log(`${m.subject}: ${m.string()}`);
+  m.nak(10_000); // ask for redelivery after 10 seconds
+} else {
+  console.log("nothing to read");
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-acknowledgment-termPoison.ts
+++ b/docs-io-nats-examples/learn-jetstream-acknowledgment-termPoison.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the existing durable and pull one message with next(). term() stops
+// delivery for good: the server advances past the message and never redelivers
+// it. Use it for a poison message that will fail every time, so it doesn't loop
+// forever.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+const m = await c.next();
+if (m) {
+  console.log(`${m.subject}: ${m.string()}`);
+  m.term();
+} else {
+  console.log("nothing to read");
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-acknowledgment-watchMaxDeliveries.ts
+++ b/docs-io-nats-examples/learn-jetstream-acknowledgment-watchMaxDeliveries.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// The server publishes a max-deliveries advisory when a message on the shipping
+// consumer hits its delivery limit without an ack. It's a plain core subject, so
+// subscribe with the core client to watch for poison messages. Each advisory is
+// JSON describing the stream, consumer, and sequence that gave up.
+const sub = nc.subscribe(
+  "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.ORDERS.shipping",
+);
+for await (const m of sub) {
+  console.log(`max deliveries reached: ${m.string()}`);
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-advanced-publishing-async.ts
+++ b/docs-io-nats-examples/learn-jetstream-advanced-publishing-async.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream context; the ORDERS stream already captures `orders.>`
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// Async publish: call publish() for every order WITHOUT awaiting each one, so
+// the round trips overlap. Collect the promises, await them together, then
+// check each result -- a rejected promise is a failed publish you must retry.
+const orders = [
+  `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200}`,
+  `{"order_id":"ord_2zr9","customer":"globex","total_cents":7800}`,
+  `{"order_id":"ord_5t1m","customer":"initech","total_cents":1500}`,
+  `{"order_id":"ord_9p3x","customer":"hooli","total_cents":9900}`,
+];
+
+const pending = orders.map((order) => js.publish("orders.created", order));
+const results = await Promise.allSettled(pending);
+
+results.forEach((result, i) => {
+  if (result.status === "fulfilled") {
+    console.log(`order ${i + 1} stored at sequence ${result.value.seq}`);
+  } else {
+    console.log(`order ${i + 1} failed, re-publish it: ${result.reason}`);
+  }
+});
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-advanced-publishing-atomic.ts
+++ b/docs-io-nats-examples/learn-jetstream-advanced-publishing-atomic.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream, jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// create the ORDERS stream with atomic batches turned on, so a publish either
+// lands every staged message or none of them. add() is idempotent.
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "ORDERS",
+  subjects: ["orders.>"],
+  allow_atomic: true,
+});
+
+// get a JetStream context for publishing
+const js = jetstream(nc);
+
+// the three line items that make up one order
+const lineItems = [
+  `{"order_id":"ord_8w2k","sku":"NATS-MUG","qty":2}`,
+  `{"order_id":"ord_8w2k","sku":"NATS-TEE","qty":1}`,
+  `{"order_id":"ord_8w2k","sku":"NATS-CAP","qty":3}`,
+];
+
+// NATS-DOC-START
+// Atomic batch: all three line items of order ord_8w2k reach the stream
+// together, or none of them do. startBatch() opens the batch with the first
+// item, add() stages the next without its own round trip, and commit()
+// publishes the last item and seals the batch. The server stores every staged
+// message at once and answers with a single ack for the whole batch.
+const batch = await js.startBatch("orders.created", lineItems[0]);
+batch.add("orders.created", lineItems[1]);
+const ack = await batch.commit("orders.created", lineItems[2]);
+console.log(`batch ${ack.batch} stored ${ack.count} line items`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-filtering-createFiltered.ts
+++ b/docs-io-nats-examples/learn-jetstream-filtering-createFiltered.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { AckPolicy, jetstream, jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// ORDERS already holds orders.created and orders.shipped messages. Create a
+// durable pull consumer that only sees one of those subjects: filter_subject
+// "orders.shipped" tells the server to skip everything else. ack_policy Explicit
+// means a reader acks each delivered message. add() is idempotent.
+const jsm = await jetstreamManager(nc);
+await jsm.consumers.add("ORDERS", {
+  durable_name: "analytics",
+  ack_policy: AckPolicy.Explicit,
+  filter_subject: "orders.shipped",
+});
+console.log("Created filtered consumer: analytics (orders.shipped)");
+
+// Bind to it and pull a small batch. Only orders.shipped come back — the filter
+// drops orders.created before it ever reaches this consumer.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "analytics");
+const msgs = await c.fetch({ max_messages: 5, expires: 2000 });
+for await (const m of msgs) {
+  console.log(m.subject);
+  await m.ack();
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-filtering-filterMatchesNothing.ts
+++ b/docs-io-nats-examples/learn-jetstream-filtering-filterMatchesNothing.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { AckPolicy, jetstream, jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// The filter_subject here has a typo: "orders.shiped" matches no subject ORDERS
+// actually stores. The server still accepts the consumer — a filter that matches
+// nothing is valid, just empty.
+const jsm = await jetstreamManager(nc);
+await jsm.consumers.add("ORDERS", {
+  durable_name: "analytics-typo",
+  ack_policy: AckPolicy.Explicit,
+  filter_subject: "orders.shiped",
+});
+console.log("Created filtered consumer: analytics-typo (orders.shiped)");
+
+// Try to pull. The fetch waits out its short expiry and returns nothing — no
+// error, no message. A wrong filter fails silently: the pull just times out
+// empty because no stored subject matches.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "analytics-typo");
+const msgs = await c.fetch({ max_messages: 5, expires: 2000 });
+let count = 0;
+for await (const m of msgs) {
+  count++;
+  await m.ack();
+}
+if (count === 0) {
+  console.log("pull returned nothing: filter matched no stored subject");
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-get-direct-batch-get.ts
+++ b/docs-io-nats-examples/learn-jetstream-get-direct-batch-get.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager
+const jsm = await jetstreamManager(nc);
+
+// NATS-DOC-START
+// Fetch up to 3 messages starting at stream sequence 1 in a single Direct Get
+// request. This needs allow_direct on the stream and can be served by any
+// replica, not just the leader. getBatch returns an iterator of stored
+// messages in stream order.
+const iter = await jsm.direct.getBatch("ORDERS", { seq: 1, batch: 3 });
+for await (const m of iter) {
+  console.log(`seq ${m.seq} on ${m.subject}`);
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-get-direct-by-sequence.ts
+++ b/docs-io-nats-examples/learn-jetstream-get-direct-by-sequence.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager
+const jsm = await jetstreamManager(nc);
+
+// NATS-DOC-START
+// Read the message at stream sequence 2 through the regular get API, which is
+// served by the stream leader.
+const m = await jsm.streams.getMessage("ORDERS", { seq: 2 });
+console.log(`subject: ${m?.subject}`);
+console.log(`payload: ${m?.string()}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-get-direct-direct-read.ts
+++ b/docs-io-nats-examples/learn-jetstream-get-direct-direct-read.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager
+const jsm = await jetstreamManager(nc);
+
+// NATS-DOC-START
+// Read a single message at sequence 1 through the Direct Get API. This needs
+// allow_direct on the stream and can be served by any replica, not just the
+// leader.
+const m = await jsm.direct.getMessage("ORDERS", { seq: 1 });
+console.log(`subject: ${m?.subject}`);
+console.log(`payload: ${m?.string()}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-get-direct-enable.ts
+++ b/docs-io-nats-examples/learn-jetstream-get-direct-enable.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager and the current ORDERS configuration
+const jsm = await jetstreamManager(nc);
+const info = await jsm.streams.info("ORDERS");
+
+// NATS-DOC-START
+// Turn on direct access by setting allow_direct on the stream config and
+// applying the update.
+const config = info.config;
+config.allow_direct = true;
+const updated = await jsm.streams.update("ORDERS", config);
+console.log(`allow_direct: ${updated.config.allow_direct}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-get-direct-last-for-subject.ts
+++ b/docs-io-nats-examples/learn-jetstream-get-direct-last-for-subject.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager
+const jsm = await jetstreamManager(nc);
+
+// NATS-DOC-START
+// Read the last message stored on subject orders.shipped through the regular
+// get API, which is served by the stream leader.
+const m = await jsm.streams.getMessage("ORDERS", {
+  last_by_subj: "orders.shipped",
+});
+console.log(`subject: ${m?.subject}`);
+console.log(`payload: ${m?.string()}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-message-ttl-publishWithTtl.ts
+++ b/docs-io-nats-examples/learn-jetstream-message-ttl-publishWithTtl.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream, jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a manager and make sure ORDERS allows per-message TTLs. The stream must
+// enable `allow_msg_ttl` before any `Nats-TTL` header is honored.
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "ORDERS",
+  subjects: ["orders.>"],
+  allow_msg_ttl: true,
+});
+
+// get a JetStream context to publish with
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// Publish one order with a per-message TTL. The `ttl` option sets the
+// `Nats-TTL` header ("60s"), so the server deletes this message 60 seconds
+// after it is stored, even if the stream would otherwise keep it forever.
+const pa = await js.publish("orders.cancelled", "order ord_8w2k cancelled", {
+  ttl: "60s",
+});
+console.log(`Stored in ${pa.stream} at sequence ${pa.seq}`);
+console.log("This message is deleted 60s after it was stored");
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-message-ttl-publishWithTtl.ts
+++ b/docs-io-nats-examples/learn-jetstream-message-ttl-publishWithTtl.ts
@@ -36,7 +36,7 @@ const js = jetstream(nc);
 // Publish one order with a per-message TTL. The `ttl` option sets the
 // `Nats-TTL` header ("60s"), so the server deletes this message 60 seconds
 // after it is stored, even if the stream would otherwise keep it forever.
-const pa = await js.publish("orders.cancelled", "order ord_8w2k cancelled", {
+const pa = await js.publish("orders.canceled", "order ord_8w2k canceled", {
   ttl: "60s",
 });
 console.log(`Stored in ${pa.stream} at sequence ${pa.seq}`);

--- a/docs-io-nats-examples/learn-jetstream-message-ttl-ttl-on-disabled-stream.ts
+++ b/docs-io-nats-examples/learn-jetstream-message-ttl-ttl-on-disabled-stream.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  jetstream,
+  JetStreamApiError,
+  jetstreamManager,
+} from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a manager and create a stream that does NOT enable per-message TTLs
+// (no `allow_msg_ttl`), then get a JetStream context to publish with
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "ORDERS_NO_TTL",
+  subjects: ["no-ttl.>"],
+});
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// Publish with a TTL to a stream that has per-message TTLs disabled. The server
+// rejects the message with err 10166 ("per-message TTL is disabled") and stores
+// nothing. Enabling `allow_msg_ttl` on the stream is the fix.
+try {
+  await js.publish("no-ttl.msg", "order ord_8w2k cancelled", { ttl: "60s" });
+} catch (err) {
+  if (err instanceof JetStreamApiError) {
+    console.log(`Rejected (err ${err.code}): ${err.message}`);
+    console.log("Nothing was stored");
+  } else {
+    throw err;
+  }
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-message-ttl-ttl-on-disabled-stream.ts
+++ b/docs-io-nats-examples/learn-jetstream-message-ttl-ttl-on-disabled-stream.ts
@@ -38,7 +38,7 @@ const js = jetstream(nc);
 // rejects the message with err 10166 ("per-message TTL is disabled") and stores
 // nothing. Enabling `allow_msg_ttl` on the stream is the fix.
 try {
-  await js.publish("no-ttl.msg", "order ord_8w2k cancelled", { ttl: "60s" });
+  await js.publish("no-ttl.msg", "order ord_8w2k canceled", { ttl: "60s" });
 } catch (err) {
   if (err instanceof JetStreamApiError) {
     console.log(`Rejected (err ${err.code}): ${err.message}`);

--- a/docs-io-nats-examples/learn-jetstream-mirrors-and-sources-createMirror.ts
+++ b/docs-io-nats-examples/learn-jetstream-mirrors-and-sources-createMirror.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Create ORDERS-ARCHIVE as a read-only mirror of ORDERS. A mirror takes
+// no subjects of its own; it follows the upstream stream.
+const jsm = await jetstreamManager(nc);
+const info = await jsm.streams.add({
+  name: "ORDERS-ARCHIVE",
+  mirror: { name: "ORDERS" },
+});
+console.log(`Created mirror ${info.config.name} of ${info.config.mirror?.name}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-mirrors-and-sources-createSource.ts
+++ b/docs-io-nats-examples/learn-jetstream-mirrors-and-sources-createSource.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+const jsm = await jetstreamManager(nc);
+
+// Setup: the three regional streams ALL-ORDERS aggregates, each with its own subjects.
+await jsm.streams.add({ name: "ORDERS-US", subjects: ["us.orders.>"] });
+await jsm.streams.add({ name: "ORDERS-EU", subjects: ["eu.orders.>"] });
+await jsm.streams.add({ name: "ORDERS-APAC", subjects: ["apac.orders.>"] });
+
+// NATS-DOC-START
+// Create ALL-ORDERS as an aggregate that sources the three regional streams
+// into one. Unlike a mirror, a stream can list several sources.
+const info = await jsm.streams.add({
+  name: "ALL-ORDERS",
+  sources: [
+    { name: "ORDERS-US" },
+    { name: "ORDERS-EU" },
+    { name: "ORDERS-APAC" },
+  ],
+});
+console.log(`Created ${info.config.name} sourcing ${info.config.sources?.length} streams`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-mirrors-and-sources-mirrorLag.ts
+++ b/docs-io-nats-examples/learn-jetstream-mirrors-and-sources-mirrorLag.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// A mirror is eventually consistent. Read its lag before trusting it to
+// hold what the upstream just received: 0 means fully caught up.
+const jsm = await jetstreamManager(nc);
+const info = await jsm.streams.info("ORDERS-ARCHIVE");
+console.log(`Upstream:  ${info.mirror?.name}`);
+console.log(`Lag:       ${info.mirror?.lag}`);
+console.log(`Last seen: ${info.mirror?.active} ns ago`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-ordered-consumer-read.ts
+++ b/docs-io-nats-examples/learn-jetstream-ordered-consumer-read.ts
@@ -1,0 +1,26 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Ask for an ordered consumer over the stream: consumers.get() with no consumer
+// name returns one. There's no ack to send — the library runs the consumer for
+// you and recreates it if it ever misses a message, so you read every order in
+// stream order.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS");
+
+// Read the whole log once, in order, stopping when caught up (pending 0).
+const messages = await c.consume();
+for await (const m of messages) {
+  console.log(`order ${m.string()}`);
+  if (m.info.pending === 0) {
+    break;
+  }
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-publishing-confirmStored.ts
+++ b/docs-io-nats-examples/learn-jetstream-publishing-confirmStored.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream context; the ORDERS stream already captures `orders.>`
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// `publish` resolves only once the server has persisted the message. Awaiting
+// the PubAck and reading its stream and sequence confirms the order is stored
+const data =
+  `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`;
+const pa = await js.publish("orders.created", data);
+console.log(`Stored in ${pa.stream} at sequence ${pa.seq}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-publishing-dedup.ts
+++ b/docs-io-nats-examples/learn-jetstream-publishing-dedup.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream context; the ORDERS stream already captures `orders.>`
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// Publish the same order twice with a stable msgID. Within the stream's
+// duplicate window the server stores it once: the second PubAck reports the
+// same sequence and `duplicate: true`
+const data =
+  `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`;
+
+const first = await js.publish("orders.created", data, {
+  msgID: "ord_8w2k-created",
+});
+console.log(`First:  sequence ${first.seq}, duplicate ${first.duplicate}`);
+
+const second = await js.publish("orders.created", data, {
+  msgID: "ord_8w2k-created",
+});
+console.log(`Second: sequence ${second.seq}, duplicate ${second.duplicate}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-publishing-pubAck.ts
+++ b/docs-io-nats-examples/learn-jetstream-publishing-pubAck.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream context; the ORDERS stream already captures `orders.>`
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// Publish one order and read every field the PubAck carries: the stream that
+// stored it, the assigned sequence, and whether the server treated it as a
+// duplicate
+const data =
+  `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`;
+const pa = await js.publish("orders.created", data);
+console.log(`Stream:    ${pa.stream}`);
+console.log(`Sequence:  ${pa.seq}`);
+console.log(`Duplicate: ${pa.duplicate}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-publishing-sync.ts
+++ b/docs-io-nats-examples/learn-jetstream-publishing-sync.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream context; the ORDERS stream already captures `orders.>`
+const js = jetstream(nc);
+
+// NATS-DOC-START
+// Publish three orders and read each PubAck, which confirms the stream that
+// stored the message and the sequence it was assigned
+const orders = [
+  {
+    subject: "orders.created",
+    data:
+      `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}`,
+  },
+  {
+    subject: "orders.created",
+    data:
+      `{"order_id":"ord_2zr9","customer":"globex","total_cents":7800,"ts":"2026-05-22T10:14:25Z"}`,
+  },
+  {
+    subject: "orders.shipped",
+    data:
+      `{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:31Z"}`,
+  },
+];
+
+for (const order of orders) {
+  const pa = await js.publish(order.subject, order.data);
+  console.log(`Stored in ${pa.stream}, sequence ${pa.seq}`);
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-pull-consumers-consumeContinuous.ts
+++ b/docs-io-nats-examples/learn-jetstream-pull-consumers-consumeContinuous.ts
@@ -1,0 +1,23 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the durable "shipping" consumer.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+// consume() sets up a continuous flow: the library keeps pull requests open and
+// yields each order as soon as it lands in the stream. It runs until you stop
+// it, no fetch loop to write by hand.
+const messages = await c.consume();
+for await (const m of messages) {
+  console.log(`shipping ${m.string()}`);
+  m.ack();
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-pull-consumers-emptyFetch.ts
+++ b/docs-io-nats-examples/learn-jetstream-pull-consumers-emptyFetch.ts
@@ -1,0 +1,28 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the durable "shipping" consumer.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+// A fetch on a drained consumer ends empty once the wait elapses, not with an
+// error. Treat "nothing right now" as normal: if no orders came back, wait and
+// fetch again instead of failing.
+const msgs = await c.fetch({ max_messages: 10, expires: 2000 });
+let count = 0;
+for await (const m of msgs) {
+  console.log(`shipping ${m.string()}`);
+  m.ack();
+  count++;
+}
+if (count === 0) {
+  console.log("no orders waiting, will retry");
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-pull-consumers-fetchBatch.ts
+++ b/docs-io-nats-examples/learn-jetstream-pull-consumers-fetchBatch.ts
@@ -1,0 +1,23 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the durable "shipping" consumer.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+// Fetch a batch of up to 10 orders, waiting up to 2 seconds for them. The call
+// returns when the batch is full or the wait elapses, whichever comes first.
+// Process and ack each, then fetch again to keep going.
+const msgs = await c.fetch({ max_messages: 10, expires: 2000 });
+for await (const m of msgs) {
+  console.log(`shipping ${m.string()}`);
+  m.ack();
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-reading-back-create.ts
+++ b/docs-io-nats-examples/learn-jetstream-reading-back-create.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  jetstreamManager,
+} from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Create a durable consumer on the ORDERS stream. A durable keeps its position
+// under a fixed name, so a reader can come back later and pick up where it left
+// off. With explicit acks the server only advances that position once a reader
+// acks each message. add() is idempotent: calling it again with the same config
+// is a no-op.
+const jsm = await jetstreamManager(nc);
+await jsm.consumers.add("ORDERS", {
+  durable_name: "billing",
+  ack_policy: AckPolicy.Explicit,
+  deliver_policy: DeliverPolicy.All,
+});
+console.log("Created durable consumer: billing");
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-reading-back-read.ts
+++ b/docs-io-nats-examples/learn-jetstream-reading-back-read.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the existing durable and read every stored message in order. Ask the
+// consumer how many are waiting (num_pending) instead of guessing a count, then
+// fetch exactly that many. Ack each message after handling it so the server
+// advances the consumer past it and won't redeliver it.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "billing");
+const info = await c.info();
+const n = info.num_pending;
+
+if (n === 0) {
+  console.log("nothing to read");
+} else {
+  const msgs = await c.fetch({ max_messages: Number(n) });
+  for await (const m of msgs) {
+    console.log(
+      `stream seq ${m.info.streamSequence}, delivery seq ${m.info.deliverySequence}: ${m.string()}`,
+    );
+    await m.ack();
+  }
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-retention-policies-retentionSwitchRejected.ts
+++ b/docs-io-nats-examples/learn-jetstream-retention-policies-retentionSwitchRejected.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  jetstreamManager,
+  JetStreamApiError,
+  RetentionPolicy,
+} from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a manager and make sure the FULFILLMENT WorkQueue stream exists
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "FULFILLMENT",
+  subjects: ["fulfill.>"],
+  retention: RetentionPolicy.Workqueue,
+});
+
+// NATS-DOC-START
+// Retention is fixed at creation. Read the live config, flip it from WorkQueue
+// to Limits, and submit the update. The server rejects the change with err
+// 10052: it won't move a stream to or from workqueue retention. To change
+// retention, create a new stream instead.
+const fulfillment = await jsm.streams.info("FULFILLMENT");
+fulfillment.config.retention = RetentionPolicy.Limits;
+try {
+  await jsm.streams.update("FULFILLMENT", fulfillment.config);
+} catch (err) {
+  if (err instanceof JetStreamApiError) {
+    console.log(`Rejected (err ${err.code}): ${err.message}`);
+  } else {
+    throw err;
+  }
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-retention-policies-workQueueCreate.ts
+++ b/docs-io-nats-examples/learn-jetstream-retention-policies-workQueueCreate.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  AckPolicy,
+  jetstream,
+  jetstreamManager,
+  RetentionPolicy,
+} from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream context for publishing and consuming, and a manager for
+// creating streams and consumers
+const js = jetstream(nc);
+const jsm = await jetstreamManager(nc);
+
+// NATS-DOC-START
+// FULFILLMENT is the queue of paid orders waiting to ship. WorkQueue retention
+// means the stream holds each task only until a worker acks it, then drops it.
+// That is the opposite of a Limits stream like ORDERS, which keeps the record.
+const info = await jsm.streams.add({
+  name: "FULFILLMENT",
+  subjects: ["fulfill.>"],
+  retention: RetentionPolicy.Workqueue,
+});
+console.log(`Created stream FULFILLMENT, retention: ${info.config.retention}`);
+
+// Queue one order to ship in the US region.
+const order = `{"order_id":"ord_8w2k","customer":"acme-co"}`;
+const pa = await js.publish("fulfill.us", order);
+console.log(`Queued ${pa.stream} seq ${pa.seq}`);
+
+// A durable pull consumer drains the queue. WorkQueue streams require explicit
+// ack, so the worker acks each task it finishes.
+await jsm.consumers.add("FULFILLMENT", {
+  durable_name: "shippers",
+  ack_policy: AckPolicy.Explicit,
+});
+
+// Pull the order, ship it, and ack. ackAck waits for the server to confirm the
+// ack landed, so the next read sees the result.
+const c = await js.consumers.get("FULFILLMENT", "shippers");
+const msgs = await c.fetch({ max_messages: 1, expires: 5000 });
+for await (const m of msgs) {
+  console.log(`Shipping ${m.subject}: ${m.string()}`);
+  await m.ackAck();
+}
+
+// The ack removed the task, so the stream is now empty. A Limits stream would
+// still hold the message; a WorkQueue stream drains to zero.
+const after = await jsm.streams.info("FULFILLMENT");
+console.log(`Messages in FULFILLMENT after ack: ${after.state.messages}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-retention-policies-workqueueOverlap.ts
+++ b/docs-io-nats-examples/learn-jetstream-retention-policies-workqueueOverlap.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  AckPolicy,
+  jetstreamManager,
+  JetStreamApiError,
+  RetentionPolicy,
+} from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a manager and make sure the FULFILLMENT WorkQueue stream exists
+const jsm = await jetstreamManager(nc);
+await jsm.streams.add({
+  name: "FULFILLMENT",
+  subjects: ["fulfill.>"],
+  retention: RetentionPolicy.Workqueue,
+});
+
+// NATS-DOC-START
+// One unfiltered consumer reads every subject in the queue. On a WorkQueue
+// stream that is fine on its own.
+await jsm.consumers.add("FULFILLMENT", {
+  durable_name: "shippers",
+  ack_policy: AckPolicy.Explicit,
+});
+console.log("Created consumer: shippers");
+
+// A WorkQueue stream hands each task to exactly one consumer, so two unfiltered
+// consumers would both claim the same subjects. The server rejects the second
+// one with err 10099.
+try {
+  await jsm.consumers.add("FULFILLMENT", {
+    durable_name: "eu-shippers",
+    ack_policy: AckPolicy.Explicit,
+  });
+} catch (err) {
+  if (err instanceof JetStreamApiError) {
+    console.log(`Rejected (err ${err.code}): ${err.message}`);
+  } else {
+    throw err;
+  }
+}
+
+// Give each worker its own slice of the queue instead. Drop the unfiltered
+// consumer, then create one consumer per region. Their filters do not overlap,
+// so both are allowed.
+await jsm.consumers.delete("FULFILLMENT", "shippers");
+
+await jsm.consumers.add("FULFILLMENT", {
+  durable_name: "us-shippers",
+  ack_policy: AckPolicy.Explicit,
+  filter_subject: "fulfill.us",
+});
+await jsm.consumers.add("FULFILLMENT", {
+  durable_name: "eu-shippers",
+  ack_policy: AckPolicy.Explicit,
+  filter_subject: "fulfill.eu",
+});
+console.log("Created filtered consumers: us-shippers, eu-shippers");
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-shaping-the-stream-discardNew.ts
+++ b/docs-io-nats-examples/learn-jetstream-shaping-the-stream-discardNew.ts
@@ -1,0 +1,28 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { DiscardPolicy, jetstream, jetstreamManager } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Switch ORDERS to Discard New. Discard New never drops stored messages, so
+// capping it at one message leaves the existing orders in place and puts the
+// stream instantly over its limit; the next publish is rejected.
+const jsm = await jetstreamManager(nc);
+await jsm.streams.update("ORDERS", { discard: DiscardPolicy.New, max_msgs: 1 });
+
+// This publish hits the full stream and rejects with "maximum messages
+// exceeded" instead of succeeding silently. Handle it in the publisher.
+const js = jetstream(nc);
+try {
+  await js.publish("orders.created", JSON.stringify({ order_id: "ord_8w2k" }));
+} catch (err) {
+  console.log(`publish rejected: ${(err as Error).message}`);
+}
+
+// Put ORDERS back: Discard Old, no message cap (age and byte limits stay).
+await jsm.streams.update("ORDERS", { discard: DiscardPolicy.Old, max_msgs: -1 });
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-shaping-the-stream-perSubjectLimit.ts
+++ b/docs-io-nats-examples/learn-jetstream-shaping-the-stream-perSubjectLimit.ts
@@ -1,0 +1,17 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Add a per-subject ceiling so one noisy subject can't evict another's
+// messages. max_msgs_per_subject keeps the most recent N messages for every
+// subject independently, alongside the whole-stream limits.
+const jsm = await jetstreamManager(nc);
+await jsm.streams.update("ORDERS", { max_msgs_per_subject: 100000 });
+console.log("ORDERS now keeps 100000 messages per subject");
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-shaping-the-stream-setLimits.ts
+++ b/docs-io-nats-examples/learn-jetstream-shaping-the-stream-setLimits.ts
@@ -1,0 +1,20 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Cap ORDERS with a seven-day age limit and a 1 GiB byte ceiling. streams.update
+// takes just the fields you're changing and leaves the rest, and the stored
+// messages, in place. max_age is in nanoseconds.
+const jsm = await jetstreamManager(nc);
+await jsm.streams.update("ORDERS", {
+  max_age: 7 * 24 * 60 * 60 * 1_000_000_000, // 7 days
+  max_bytes: 1024 * 1024 * 1024, // 1 GiB
+});
+console.log("ORDERS capped at 7d age and 1 GiB");
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-subject-mapping-republish.ts
+++ b/docs-io-nats-examples/learn-jetstream-subject-mapping-republish.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager and the current ORDERS configuration
+const jsm = await jetstreamManager(nc);
+const info = await jsm.streams.info("ORDERS");
+
+// NATS-DOC-START
+// Add a republish rule so every message stored under `orders.>` is also
+// published live to a matching `dash.orders.>` subject that dashboards can
+// subscribe to, then apply the update.
+const config = info.config;
+config.republish = {
+  src: "orders.>",
+  dest: "dash.orders.>",
+  // headers_only: true, // republish only the headers, not the message body
+};
+const updated = await jsm.streams.update("ORDERS", config);
+console.log(`republish dest: ${updated.config.republish?.dest}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-subject-mapping-transform.ts
+++ b/docs-io-nats-examples/learn-jetstream-subject-mapping-transform.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// get a JetStream manager
+const jsm = await jetstreamManager(nc);
+
+// NATS-DOC-START
+// Create ORDERS-SHARDED with a subject transform. Every message on `ingest.*`
+// is rewritten before it is stored: `partition(3,1)` shards each customer
+// (the first wildcard token) into one of three buckets, and `wildcard(1)`
+// keeps the customer id, so `ingest.acme` becomes `orders.<0-2>.acme`.
+const info = await jsm.streams.add({
+  name: "ORDERS-SHARDED",
+  subjects: ["ingest.*"],
+  subject_transform: {
+    src: "ingest.*",
+    dest: "orders.{{partition(3,1)}}.{{wildcard(1)}}",
+  },
+});
+console.log(`Created stream: ${info.config.name}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-worker-pool-max-pending.ts
+++ b/docs-io-nats-examples/learn-jetstream-worker-pool-max-pending.ts
@@ -1,0 +1,17 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Raise max_ack_pending so a larger pool can hold more orders in progress at
+// once. The cap is shared across the whole "shipping" consumer, not per worker,
+// so size it to at least your worker count.
+const jsm = await jetstreamManager(nc);
+await jsm.consumers.update("ORDERS", "shipping", { max_ack_pending: 5000 });
+console.log("shipping max_ack_pending set to 5000");
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-worker-pool-redelivery-count.ts
+++ b/docs-io-nats-examples/learn-jetstream-worker-pool-redelivery-count.ts
@@ -1,0 +1,28 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the durable "shipping" consumer.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+// Each message reports how many times it has been delivered. A count above one
+// means a redelivery: the server handed this order out before, but a worker
+// crashed or ran past AckWait before acking. Key your side effects by order_id
+// so handling the same order twice is harmless.
+const msgs = await c.fetch({ max_messages: 10, expires: 5000 });
+for await (const m of msgs) {
+  if (m.info.deliveryCount > 1) {
+    console.log(`redelivery #${m.info.deliveryCount} of ${m.string()}`);
+  } else {
+    console.log(`first delivery of ${m.string()}`);
+  }
+  m.ack();
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-worker-pool-worker.ts
+++ b/docs-io-nats-examples/learn-jetstream-worker-pool-worker.ts
@@ -1,0 +1,23 @@
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to the NATS server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the durable "shipping" consumer created earlier.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+// consume() yields the orders the server hands this worker. Run this same
+// program in several processes: they all share the one "shipping" consumer, and
+// the server splits the stored orders across them, one order to one worker.
+const messages = await c.consume();
+for await (const m of messages) {
+  console.log(`shipping ${m.string()}`);
+  m.ack();
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-your-first-consumer-create.ts
+++ b/docs-io-nats-examples/learn-jetstream-your-first-consumer-create.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  jetstreamManager,
+} from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Create a durable pull consumer on the ORDERS stream. The durable keeps its
+// position under a fixed name, so a reader can come back later and pick up where
+// it left off. ack_policy Explicit means the server only advances that position
+// once a reader acks each message. deliver_policy All starts from the first
+// stored message. add() is idempotent: calling it again with the same config is
+// a no-op.
+const jsm = await jetstreamManager(nc);
+await jsm.consumers.add("ORDERS", {
+  durable_name: "shipping",
+  ack_policy: AckPolicy.Explicit,
+  deliver_policy: DeliverPolicy.All,
+});
+console.log("Created durable consumer: shipping");
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-your-first-consumer-doubleAck.ts
+++ b/docs-io-nats-examples/learn-jetstream-your-first-consumer-doubleAck.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the existing durable and pull one message with next(). ackAck() sends
+// the ack and waits for the server to confirm it landed, so you know the
+// consumer position advanced before moving on. Plain ack() is fire-and-forget.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+const m = await c.next();
+if (m) {
+  console.log(`${m.subject}: ${m.string()}`);
+  await m.ackAck();
+} else {
+  console.log("nothing to read");
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-your-first-consumer-next.ts
+++ b/docs-io-nats-examples/learn-jetstream-your-first-consumer-next.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the existing durable and pull one message with next(). Here we handle
+// it but never ack. The message stays in flight: once Ack Wait passes with no
+// ack, the server redelivers it to a reader of this consumer.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+const m = await c.next();
+if (m) {
+  console.log(`${m.subject}: ${m.string()}`);
+  // no ack here — the message stays in flight and is redelivered after Ack Wait
+} else {
+  console.log("nothing to read");
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-your-first-consumer-pullAndAck.ts
+++ b/docs-io-nats-examples/learn-jetstream-your-first-consumer-pullAndAck.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstream } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Bind to the existing durable and pull one message with next(). Handle it, then
+// ack() so the server advances the consumer past it and won't redeliver it.
+const js = jetstream(nc);
+const c = await js.consumers.get("ORDERS", "shipping");
+
+const m = await c.next();
+if (m) {
+  console.log(`${m.subject}: ${m.string()}`);
+  m.ack();
+} else {
+  console.log("nothing to read");
+}
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-your-first-stream-create.ts
+++ b/docs-io-nats-examples/learn-jetstream-your-first-stream-create.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Get a JetStream manager and create the ORDERS stream, which captures
+// every Acme order subject under `orders.`
+const jsm = await jetstreamManager(nc);
+const info = await jsm.streams.add({
+  name: "ORDERS",
+  subjects: ["orders.>"],
+});
+console.log(`Created stream: ${info.config.name}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/learn-jetstream-your-first-stream-info.ts
+++ b/docs-io-nats-examples/learn-jetstream-your-first-stream-info.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import { jetstreamManager } from "@nats-io/jetstream";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "nats://localhost:4222" });
+
+// NATS-DOC-START
+// Get a JetStream manager and look up the ORDERS stream, then print the
+// key fields from its configuration and current state
+const jsm = await jetstreamManager(nc);
+const info = await jsm.streams.info("ORDERS");
+console.log(`Stream:   ${info.config.name}`);
+console.log(`Subjects: ${info.config.subjects?.join(", ")}`);
+console.log(`Messages: ${info.state.messages}`);
+// NATS-DOC-END
+
+// drain the connection (flushes and closes)
+await nc.drain();

--- a/docs-io-nats-examples/queue-groups-basic.ts
+++ b/docs-io-nats-examples/queue-groups-basic.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Create three workers in the same queue group
+async function process(label: string) {
+  const sub = nc.subscribe("orders.new", { queue: "workers" });
+  for await (const msg of sub) {
+    console.log(`Worker ${label} processed: ${msg.string()}`);
+  }
+}
+
+process("A").catch(console.error);
+process("B").catch(console.error);
+process("C").catch(console.error);
+
+// Publish messages - automatically load balanced
+for (let i = 1; i <= 10; i++) {
+  nc.publish("orders.new", `Order ${i}`);
+}
+// NATS-DOC-END
+
+await nc.flush();
+await nc.drain();

--- a/docs-io-nats-examples/queue-groups-dynamic-scaling.ts
+++ b/docs-io-nats-examples/queue-groups-dynamic-scaling.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, type Subscription, delay } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Worker that can be dynamically added/removed
+function process(id: string): Promise<{id: string, sub: Subscription}> {
+  const sub = nc.subscribe("tasks", { queue: "workers" });
+  (async () => {
+    for await (const msg of sub) {
+      console.log(`Worker ${id} processing: ${msg.string()}`);
+      // Simulate work
+      await delay(100);
+    }
+  })().catch(console.error);
+  return Promise.resolve({ id, sub });
+}
+
+setInterval(() => {
+  nc.publish("tasks", new Date().toISOString());
+}, 50)
+
+// Dynamic scaling
+const workers: { id: string, sub: Subscription }[] = [];
+
+// Scale up
+for (let i = 1; i <= 5; i++) {
+  workers.push(await process(`${i}`));
+}
+
+// Scale down
+await delay(1000);
+const removed = workers.pop();
+if (removed) {
+  removed.sub.unsubscribe();
+}
+// NATS-DOC-END
+
+await delay(1000);
+
+await nc.drain();

--- a/docs-io-nats-examples/queue-groups-mixed-subscribers.ts
+++ b/docs-io-nats-examples/queue-groups-mixed-subscribers.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+
+// add a function that creates a subscription and optionally processes messages
+// in a queue group
+function addWorker(label: string, queue = "") {
+  const sub = nc.subscribe("orders.new", { queue });
+  (async () => {
+    for await (const msg of sub) {
+      console.log(`[WORKER ${label}] Processing: ${msg.string()}`);
+    }
+  })().catch(console.error);
+}
+
+// Audit logger - receives all messages
+addWorker("AUDIT");
+// Metrics collector - receives all messages
+addWorker("METRICS");
+
+// Workers in queue group - load balanced
+addWorker("A", "q");
+addWorker("B", "q");
+
+// Publish order
+nc.publish("orders.new", "Order 123");
+nc.publish("orders.new", "Order 124");
+nc.publish("orders.new", "Order 125");
+// NATS-DOC-END
+
+await nc.flush();
+await nc.drain();

--- a/docs-io-nats-examples/queue-groups-request-reply.ts
+++ b/docs-io-nats-examples/queue-groups-request-reply.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Service instance with queue group for load balancing
+function createServiceInstance(instanceId: string) {
+  const sub = nc.subscribe("api.calculate", { queue: "api-workers" });
+  (async () => {
+    for await (const msg of sub) {
+      const data = msg.string().split(",");
+      const result = parseInt(data[0], 10) + parseInt(data[1], 10);
+      const response =
+        `Result: ${result}, processed by: instance-${instanceId}`;
+      msg.respond(response);
+      console.log(`Instance ${instanceId} processed request`);
+    }
+  })().catch(console.error);
+}
+
+// Start multiple service instances
+for (let i = 1; i <= 3; i++) {
+  createServiceInstance(`instance-${i}`);
+}
+
+// Make requests - automatically load balanced
+for (let i = 0; i < 10; i++) {
+  try {
+    const response = await nc.request("api.calculate", `${i},${i * 2}`, {
+      timeout: 1000,
+    });
+    console.log(`Response: ${response.string()}`);
+  } catch (e) {
+    console.error(`Request failed: ${(e as Error).message}`);
+  }
+}
+// NATS-DOC-END
+
+await new Promise((resolve) => setTimeout(resolve, 100));
+
+await nc.drain();

--- a/docs-io-nats-examples/request-reply-basic.ts
+++ b/docs-io-nats-examples/request-reply-basic.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Set up a service
+nc.subscribe("time", {
+  callback: (_err, msg) => {
+    const time = new Date().toISOString();
+    msg.respond(time);
+  },
+});
+
+// Make a request
+
+await nc.request("time", "")
+  .then((m) => {
+    console.log(`Response: ${m.string()}`);
+  })
+  .catch((err) => {
+    console.log(`Request failed: ${err.message}`);
+  });
+// NATS-DOC-END
+
+
+await nc.drain();

--- a/docs-io-nats-examples/request-reply-calculator.ts
+++ b/docs-io-nats-examples/request-reply-calculator.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import type { Subscription } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Calculator service
+const sub = nc.subscribe("calc.add");
+(async (sub: Subscription) => {
+  for await (const m of sub) {
+    try {
+      const {a, b} = m.json<{ a: number, b: number }>();
+      if (typeof a !== "number" || typeof b !== "number") {
+        throw new Error("invalid input");
+      }
+      m.respond(JSON.stringify({result: a+b}))
+    } catch(err) {
+      m.respond("error: invalid input");
+    }
+  }
+})(sub).catch(console.error);
+
+// Make calculations
+let resp = await nc.request("calc.add", JSON.stringify({a: 5, b: 3}));
+console.log(`5 + 3 = ${resp.string()}`);
+
+resp = await nc.request("calc.add", JSON.stringify({a: 10, b: 7}));
+console.log(`10 + 7 = ${resp.string()}`);
+
+resp = await nc.request("calc.add", JSON.stringify({a: 10, b: "x"}));
+console.log(`10 + x = ${resp.string()}`);
+// NATS-DOC-END
+
+await nc.flush();
+await nc.drain();

--- a/docs-io-nats-examples/request-reply-headers.ts
+++ b/docs-io-nats-examples/request-reply-headers.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect, headers } from "@nats-io/transport-deno";
+import type { Subscription } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Header Aware service
+const sub = nc.subscribe("service");
+(async (sub: Subscription) => {
+  for await (const m of sub) {
+    const h = headers();
+    const id = m.headers?.get("X-Request-ID");
+    if (id) {
+      h.append("X-Response-ID", id);
+      h.append("X-Request-ID", id);
+    }
+    const pri = m.headers?.get("X-Priority");
+    if (pri) {
+      h.append("X-Priority", pri);
+    }
+    m.respond(m.data, {
+      headers: h,
+    });
+  }
+})(sub).catch(console.error);
+
+// Create message with headers
+const h = headers();
+h.append("X-Request-ID", "123");
+h.append("X-Priority", "high");
+
+const response = await nc.request("service", "data", {
+  headers: h,
+  timeout: 1000,
+});
+console.log(`Response: ${response.string()}`);
+const responseId = response.headers?.get("X-Response-ID");
+if (responseId) {
+  console.log(`Response ID: ${responseId}`);
+}
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/request-reply-multiple-responders.ts
+++ b/docs-io-nats-examples/request-reply-multiple-responders.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+import type { Subscription } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Multiple responders - only first response is returned
+const subA = nc.subscribe("calc.add");
+(async (sub: Subscription) => {
+  for await (const m of sub) {
+    m.respond("calculated result from A");
+  }
+})(subA).catch(console.error);
+
+const subB = nc.subscribe("calc.add");
+(async (sub: Subscription) => {
+  for await (const m of sub) {
+    m.respond("calculated result from B");
+  }
+})(subB).catch(console.error);
+
+// Gets one response
+try {
+  const response = await nc.request("calc.add", "data");
+  console.log(`Got response: ${response.string()}`);
+} catch (e) {
+  console.error(`Request failed: ${(e as Error).message}`);
+}
+// NATS-DOC-END
+
+await new Promise((resolve) => setTimeout(resolve, 100));
+
+await nc.drain();

--- a/docs-io-nats-examples/request-reply-no-responders.ts
+++ b/docs-io-nats-examples/request-reply-no-responders.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+await nc.request("no.such.service", "test")
+  .then((m) => {
+    console.log(`Response: ${m.string()}`);
+  })
+  .catch((err) => {
+    console.log(`Request failed: ${err.message}`);
+  });
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/request-reply-timeout.ts
+++ b/docs-io-nats-examples/request-reply-timeout.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS demo server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Request with custom timeout
+await nc.request("service", "data", { timeout: 2000 })
+  .then((m) => {
+    console.log(`Response: ${m.string()}`);
+  })
+  .catch((err) => {
+    console.log(`Request failed: ${err.message}`);
+  });
+// NATS-DOC-END
+
+await nc.drain();

--- a/docs-io-nats-examples/subjects-monitoring.ts
+++ b/docs-io-nats-examples/subjects-monitoring.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+// Create a wire tap for monitoring
+const sub = nc.subscribe(">");
+(async () => {
+  for await (const msg of sub) {
+    console.log(`[MONITOR] ${msg.subject}: ${msg.string()}`);
+  }
+})().catch(console.error);
+// NATS-DOC-END
+
+nc.publish("hello", "Hello NATS!");
+nc.publish("event.new", "click");
+nc.publish("weather.north.fr", "Temperature: 11°C");
+
+await new Promise((resolve) => setTimeout(resolve, 100));
+
+await nc.drain();

--- a/docs-io-nats-examples/subjects-multi-wildcard.ts
+++ b/docs-io-nats-examples/subjects-multi-wildcard.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+async function process(subject: string) {
+  const sub = nc.subscribe(subject);
+  const label = `[${subject}]`.padEnd(23);
+  for await (const msg of sub) {
+    console.log(`${label}${msg.string().padEnd(15)} (${msg.subject})`);
+  }
+}
+
+// Subscribe to all alarms
+process("sensor.alarm.*").catch(console.error);
+
+// Subscribe to all critical
+process("sensor.*.*.critical").catch(console.error);
+
+// Subscribe to everything
+process("sensor.>").catch(console.error);
+
+// Publish to specific subjects
+nc.publish("sensor.alarm.smoke", "kitchen,14:22");
+nc.publish("sensor.alarm.smoke.critical", "kitchen,14:23");
+nc.publish("sensor.alarm.water", "basement,16:42");
+nc.publish("sensor.alarm.water.critical", "basement,16:43");
+// NATS-DOC-END
+
+await nc.flush();
+await nc.drain();

--- a/docs-io-nats-examples/subjects-single-wildcard.ts
+++ b/docs-io-nats-examples/subjects-single-wildcard.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// import the connect function from a transport
+import { connect } from "@nats-io/transport-deno";
+
+// connect to NATS server
+const nc = await connect({ servers: "localhost:4222" });
+
+// NATS-DOC-START
+async function process(subject: string) {
+  const sub = nc.subscribe(subject);
+  const label = `[${subject}]`.padEnd(20);
+  for await (const msg of sub) {
+    console.log(`${label}${msg.string()}  (${msg.subject})`);
+  }
+}
+
+process("orders.*.shipped").catch(console.error);
+process("orders.*.placed").catch(console.error);
+process("orders.retail.*").catch(console.error);
+
+// Publish to specific subjects
+nc.publish("orders.wholesale.placed", "Order W73737");
+nc.publish("orders.retail.placed", "Order R65432");
+nc.publish("orders.wholesale.shipped", "Order W73001");
+nc.publish("orders.retail.shipped", "Order R65321");
+// NATS-DOC-END
+
+await nc.flush();
+
+await nc.drain();


### PR DESCRIPTION
Moves the documentation examples from the `docs-io-nats-examples`, `core-docs` and `jetstream-docs` branches into `docs-io-nats-examples/` on main (72 standalone TS scripts, additive union).

Unlike the other clients, merging alone gives these no CI coverage — the dir is outside every module matrix, not a workspace member, and deno only typechecks entrypoints it's told about. So this PR also adds a small `docs-examples` job to `test.yml`: `deno check docs-io-nats-examples/*.ts` (root `deno.json` scopes resolve the `@nats-io/*` imports to the local modules).

Verified locally with deno 2.7.1: all 72 files typecheck clean.

Why: the new docs.nats.io build fetches these snippets at build time; on main with a check job they can't rot silently or vanish with a pruned branch. Please keep the docs branches until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)