### PR TITLE
Add AsyncAuthenticator support for credential schemes that can't compute synchronously

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -869,6 +869,20 @@ export interface Authenticator {
   (nonce?: string): Auth;
 }
 
+/**
+ * AsyncAuthenticator is like {@link Authenticator}, but for credential
+ * schemes that cannot compute their result synchronously — for example,
+ * signing the connection nonce with a non-extractable WebCrypto key, which
+ * is asynchronous on every browser by specification. Mutually exclusive
+ * with {@link Authenticator} in practice: if set, it takes precedence for
+ * the initial CONNECT, and the existing synchronous {@link Authenticator}
+ * path is otherwise unaffected by its presence.
+ * @type function(nonce?: string) => Promise<Auth>
+ */
+export interface AsyncAuthenticator {
+  (nonce?: string): Promise<Auth>;
+}
+
 export interface ConnectionOptions {
   /**
    * When the server requires authentication, set an {@link Authenticator}.
@@ -877,6 +891,16 @@ export interface ConnectionOptions {
    * if {@link user} and {@link pass} or the {@link token} options are set.
    */
   authenticator?: Authenticator | Authenticator[];
+  /**
+   * Like {@link authenticator}, but for a credential scheme that can only
+   * compute its result asynchronously (e.g. signing with a non-extractable
+   * WebCrypto key). When set, this is used instead of {@link authenticator}
+   * for the initial CONNECT; while it is resolving, any protocol messages
+   * the server sends are deliberately ignored, since this connection has
+   * not yet sent its own CONNECT and nothing arriving in that window should
+   * be acted on.
+   */
+  asyncAuthenticator?: AsyncAuthenticator;
   /**
    * When set to `true` the client will print protocol messages that it receives
    * or sends to the server.

--- a/core/src/internal_mod.ts
+++ b/core/src/internal_mod.ts
@@ -84,6 +84,7 @@ export { Empty } from "./types.ts";
 export { extractProtocolMessage, protoLen } from "./transport.ts";
 
 export type {
+  AsyncAuthenticator,
   Auth,
   Authenticator,
   CallbackFn,

--- a/core/src/mod.ts
+++ b/core/src/mod.ts
@@ -57,6 +57,7 @@ export {
 } from "./internal_mod.ts";
 
 export type {
+  AsyncAuthenticator,
   Auth,
   Authenticator,
   Backoff,

--- a/core/src/protocol.ts
+++ b/core/src/protocol.ts
@@ -30,6 +30,7 @@ import { Kind, Parser } from "./parser.ts";
 import { MsgImpl } from "./msg.ts";
 import { Features, parseSemVer } from "./semver.ts";
 import type {
+  Auth,
   ConnectionOptions,
   Dispatcher,
   Msg,
@@ -393,6 +394,18 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   connected: boolean;
   connectedOnce: boolean;
   infoReceived: boolean;
+  // True only between kicking off options.asyncAuthenticator and this
+  // connection's own CONNECT actually being sent. While true, push() drops
+  // every event except the INFO that set it — this connection hasn't
+  // authenticated yet, so nothing the server sends in that window should
+  // be acted on. See ASYNC-AUTHENTICATOR-SCOPE.md.
+  awaitingAsyncConnect: boolean;
+  // Bumped every time resetOutbound() runs (a fresh dial/reconnect attempt).
+  // An in-flight asyncAuthenticator resolution captures the generation it
+  // started in and checks it before acting, so a disconnect/reconnect that
+  // happens while it's still pending doesn't send a CONNECT (or close the
+  // connection) on behalf of an attempt that's no longer current.
+  connectGeneration: number;
   info?: ServerInfo;
   muxSubscriptions: MuxSubscription;
   options: ConnectionOptions;
@@ -429,6 +442,8 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.connected = false;
     this.connectedOnce = false;
     this.infoReceived = false;
+    this.awaitingAsyncConnect = false;
+    this.connectGeneration = 0;
     this.noMorePublishing = false;
     this.abortReconnect = false;
     this.listeners = [];
@@ -481,6 +496,8 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     });
     this.parser = new Parser(this);
     this.infoReceived = false;
+    this.awaitingAsyncConnect = false;
+    this.connectGeneration++;
   }
 
   dispatchStatus(status: Status): void {
@@ -850,6 +867,36 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
   }
 
+  // Builds and sends the CONNECT frame. Shared by both the synchronous
+  // options.authenticator path and the asyncAuthenticator path below — the
+  // Connect class itself is unmodified; a pre-resolved creds object (when
+  // supplied) is merged onto the already-constructed instance rather than
+  // computed inside the constructor, since constructors can't be async.
+  private sendConnect(
+    nonce: string | undefined,
+    headersEnabled: boolean,
+    creds?: Auth,
+  ): void {
+    const { version, lang } = this.transport;
+    const c = new Connect(
+      { version, lang },
+      this.options,
+      nonce,
+    );
+    if (creds) {
+      extend(c, creds);
+    }
+    if (headersEnabled) {
+      c.headers = true;
+      c.no_responders = true;
+    }
+    const cs = JSON.stringify(c);
+    this.transport.send(
+      encode(`CONNECT ${cs}${CR_LF}`),
+    );
+    this.transport.send(PING_CMD);
+  }
+
   processInfo(m: Uint8Array) {
     const info = JSON.parse(decode(m));
     this.info = info;
@@ -863,26 +910,37 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
         this.servers.updateTLSName();
       }
       // send connect
-      const { version, lang } = this.transport;
-      try {
-        const c = new Connect(
-          { version, lang },
-          this.options,
-          info.nonce,
-        );
-
-        if (info.headers) {
-          c.headers = true;
-          c.no_responders = true;
+      if (this.options.asyncAuthenticator) {
+        // Fire-and-forget: processInfo stays synchronous (it's called
+        // from Parser.parse(), which is not awaited by its caller), so
+        // there's no way to await the authenticator here. The resolution
+        // itself, and sending CONNECT, happens in the .then() below,
+        // decoupled from this call stack. awaitingAsyncConnect gates
+        // push() (see below) so nothing arriving before CONNECT is
+        // actually sent gets acted on. generation guards against a
+        // disconnect/reconnect racing this resolution — see
+        // resetOutbound().
+        this.awaitingAsyncConnect = true;
+        const generation = this.connectGeneration;
+        Promise.resolve()
+          .then(() => this.options.asyncAuthenticator!(info.nonce))
+          .then((creds) => {
+            if (generation !== this.connectGeneration) return;
+            this.awaitingAsyncConnect = false;
+            this.sendConnect(info.nonce, !!info.headers, creds);
+          })
+          .catch((err) => {
+            if (generation !== this.connectGeneration) return;
+            this.awaitingAsyncConnect = false;
+            this.close(err as Error).catch();
+          });
+      } else {
+        try {
+          this.sendConnect(info.nonce, !!info.headers);
+        } catch (err) {
+          // if we are dying here, this is likely some an authenticator blowing up
+          this.close(err as Error).catch();
         }
-        const cs = JSON.stringify(c);
-        this.transport.send(
-          encode(`CONNECT ${cs}${CR_LF}`),
-        );
-        this.transport.send(PING_CMD);
-      } catch (err) {
-        // if we are dying here, this is likely some an authenticator blowing up
-        this.close(err as Error).catch();
       }
     }
     if (updates) {
@@ -902,6 +960,15 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   }
 
   push(e: ParserEvent): void {
+    // We haven't sent our own CONNECT yet — an asyncAuthenticator is still
+    // resolving. Nothing the server sends in this window should be acted
+    // on; the INFO that set this flag is the one exception, since that's
+    // what's already driving processInfo/resolution in the first place.
+    // Bytes are still parsed upstream in Parser.parse() regardless (parser
+    // framing state stays correct) — this only drops the resulting event.
+    if (this.awaitingAsyncConnect && e.kind !== Kind.INFO) {
+      return;
+    }
     switch (e.kind) {
       case Kind.MSG: {
         const { msg, data } = e;

--- a/core/tests/authenticator_test.ts
+++ b/core/tests/authenticator_test.ts
@@ -33,7 +33,7 @@ import type {
   NatsConnectionImpl,
 } from "../src/internal_mod.ts";
 
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import {
   encodeAccount,
   encodeOperator,
@@ -263,4 +263,91 @@ Deno.test("authenticator - bad creds", () => {
     Error,
     "unable to parse credentials",
   );
+});
+
+// Mirrors nkeyAuthenticator's own signing logic (authenticator.ts) rather
+// than reusing it directly, wrapped with a real delay — proves this is a
+// genuinely asynchronous authenticator settling later, not a Promise that
+// happens to resolve synchronously on the same microtask.
+function delayedNkeyAsyncAuthenticator(
+  seed: Uint8Array,
+  delayMs: number,
+): (nonce?: string) => Promise<Auth> {
+  return async (nonce?: string): Promise<Auth> => {
+    await delay(delayMs);
+    const kp = nkeys.fromSeed(seed);
+    const nkey = kp.getPublicKey();
+    const challenge = new TextEncoder().encode(nonce || "");
+    const sig = nkeys.encode(kp.sign(challenge));
+    return { nkey, sig };
+  };
+}
+
+Deno.test("authenticator - async fn", async () => {
+  const user = nkeys.createUser();
+  const seed = user.getSeed();
+  const nkey = user.getPublicKey();
+
+  const { ns, nc } = await setup({
+    authorization: {
+      users: [{ nkey }],
+    },
+  }, {
+    asyncAuthenticator: delayedNkeyAsyncAuthenticator(seed, 250),
+  });
+
+  await nc.flush();
+  assertEquals(nc.isClosed(), false);
+  await cleanup(ns, nc);
+});
+
+Deno.test("authenticator - async fn rejects", async () => {
+  const asyncAuthenticator = (_nonce?: string): Promise<Auth> => {
+    return Promise.reject(new Error("async authenticator blew up"));
+  };
+
+  await assertRejects(
+    async () => {
+      await setup({}, { asyncAuthenticator, reconnect: false });
+    },
+    Error,
+  );
+});
+
+// This is the test that actually proves the awaitingAsyncConnect gate in
+// ProtocolHandler.push() works, not just that the code compiles. It uses a
+// very short server-side ping_interval against an authenticator delay long
+// enough that the real nats-server (confirmed via its own source,
+// server.go: "Set the Ping timer. Will be reset once connect was received")
+// will send at least one unsolicited PING before this client's CONNECT is
+// sent. If the gate didn't work — if that early PING were dispatched to
+// processPing() and a PONG were written to a transport that hasn't sent
+// CONNECT yet — this would either fail outright or leave the connection in
+// a bad state. Success here means the race was hit and handled correctly,
+// not that the race never happened.
+Deno.test("authenticator - async fn ignores data before connect", async () => {
+  const user = nkeys.createUser();
+  const seed = user.getSeed();
+  const nkey = user.getPublicKey();
+
+  const { ns, nc } = await setup({
+    authorization: {
+      users: [{ nkey }],
+    },
+    // Aggressive on purpose — short enough that the server's ping timer
+    // (armed immediately after INFO, per server.go) fires well within the
+    // authenticator's artificial delay below. ping_max raised generously so
+    // the several unanswered pings this produces (we're not able to PONG
+    // until the gate opens) don't also trip the server's own unrelated
+    // stale-connection detection — that's a real, separate server defense,
+    // not what this test is isolating.
+    ping_interval: "50ms",
+    ping_max: 50,
+  }, {
+    asyncAuthenticator: delayedNkeyAsyncAuthenticator(seed, 500),
+  });
+
+  await nc.flush();
+  assertEquals(nc.isClosed(), false);
+  await cleanup(ns, nc);
 });


### PR DESCRIPTION
WebCrypto, a browser standard since 2017, overlaps with the nats client's own signing process.
The nats client's Authenticators perform synchronous signing, whereas WebCrypto's crypto.subtle.sign() always returns a Promise. To bridge that gap, a new AsyncAuthenticator was added that resolves asynchronously, alongside the existing synchronous Authenticator — unchanged for every existing use.

Side effect: Since processInfo can't await inside a constructor, the async authenticator resolves via a fire-and-forget path instead, and push() ignores every event but the triggering INFO until this connection's own CONNECT is actually sent — so a real server PING (or anything else) arriving before authentication completes isn't acted on. This keeps push()/Parser.parse()/Dispatcher<T> synchronous for every existing (non-async) authenticator, rather than making the whole event pipeline async to support this one case.

Operational note: the async authenticator's full round trip must complete within nats-server's auth_timeout (2s by default, armed immediately after INFO) or the server will close the connection — worth flagging in deployment docs for anyone using a signing service with meaningful latency.

closes #432 

This contribution is my original work and that I license to the project under the Apache-2.0 license
(https://github.com/nats-io/nats.js/blob/main/LICENSE).

Signed-off-by: Charlie Federspiel